### PR TITLE
BODA-20: biblioteca de componentes del sistema de marca

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -13,16 +13,99 @@
     "no": "No"
   },
   "errores": {
-    "generico": "Algo no ha ido bien. Inténtalo de nuevo en un momento.",
+    "generico": "Algo no ha ido bien. Intentadlo de nuevo en un momento.",
     "noEncontrado": "No hemos encontrado esta página.",
-    "sinPermiso": "No tienes acceso a esta sección.",
+    "sinPermiso": "No tenéis acceso a esta sección.",
     "campoObligatorio": "Este campo es obligatorio.",
-    "emailInvalido": "Revisa el correo electrónico.",
+    "emailInvalido": "Revisad el correo, parece incompleto.",
     "sinConexion": "Parece que no hay conexión."
   },
   "meta": {
-    "titulo": "Nuestra boda",
-    "descripcion": "Toda la información de nuestro gran día."
+    "titulo": "Paloma y David",
+    "descripcion": "Nos casamos. Aquí tenéis todo lo que necesitáis saber."
+  },
+  "navegacion": {
+    "inicio": "Inicio",
+    "programa": "Programa",
+    "alojamiento": "Alojamiento",
+    "comoLlegar": "Cómo llegar",
+    "playlist": "Playlist",
+    "confirmar": "Confirmar",
+    "irAlContenido": "Ir al contenido"
+  },
+  "portada": {
+    "etiquetaFecha": "La fecha",
+    "etiquetaLugar": "El lugar",
+    "confirmarAsistencia": "Confirmar asistencia",
+    "verElDia": "Ver el día",
+    "altHero": "Paloma y David"
+  },
+  "cuentaAtras": {
+    "titulo": "Nos vemos en",
+    "dias": "días",
+    "horas": "horas",
+    "minutos": "minutos",
+    "segundos": "segundos",
+    "yaEsHoy": "Hoy es el día"
+  },
+  "programa": {
+    "etiqueta": "El día, hora a hora",
+    "titulo": "El día, hora a hora"
+  },
+  "alojamiento": {
+    "etiqueta": "Dónde dormir",
+    "titulo": "Alojamiento",
+    "reservar": "Reservar"
+  },
+  "comoLlegar": {
+    "etiqueta": "El lugar",
+    "titulo": "Cómo llegar",
+    "abrirMapa": "Abrir en el mapa"
+  },
+  "playlist": {
+    "etiqueta": "La pista de baile es cosa de todos",
+    "titulo": "Playlist colaborativa",
+    "descripcion": "Dejadnos la canción que no puede faltar. La añadiremos a la lista que sonará esa noche.",
+    "campoCancion": "Canción y artista",
+    "anadir": "Añadir",
+    "anadida": "Apuntada. Gracias.",
+    "vacia": "Todavía no hay canciones. Estrenad la lista."
+  },
+  "rsvp": {
+    "titulo": "Confirmad asistencia",
+    "nombre": "Nombre y apellidos",
+    "contacto": "Email o teléfono",
+    "contactoAyuda": "para avisaros de cambios",
+    "pregunta": "¿Vendréis?",
+    "sinAsistencia": "No podré ir",
+    "conAsistencia": "Sí, allí estaremos",
+    "personas": "Nº de personas",
+    "autobus": "Autobús",
+    "menu": "Alergias o menú especial",
+    "menuAyuda": "Celíaco, vegetariano, sin lactosa…",
+    "mensaje": "Un mensaje para nosotros",
+    "mensajeAyuda": "Opcional",
+    "enviar": "Enviar confirmación",
+    "enviando": "Enviando…",
+    "indicadAsistencia": "Indicadnos si podréis venir.",
+    "graciasSi": "Qué alegría",
+    "graciasSiTexto": "Queda apuntado. Os escribiremos unas semanas antes con los últimos detalles.",
+    "graciasNo": "Os echaremos de menos",
+    "graciasNoTexto": "Gracias por decírnoslo. Brindaremos por vosotros y os guardaremos un trozo de tarta.",
+    "editarRespuesta": "Cambiar la respuesta",
+    "tokenInvalido": "Este enlace no es válido. Escribidnos y os mandamos uno nuevo.",
+    "plazoCerrado": "El plazo para confirmar ya se ha cerrado. Escribidnos y lo miramos."
+  },
+  "saveTheDate": {
+    "etiqueta": "Reservad la fecha",
+    "abrir": "Abrir la invitación",
+    "pista": "Tocad el sello para abrir",
+    "nota": "La invitación con todos los detalles llegará más adelante.",
+    "anadirCalendario": "Añadir al calendario",
+    "verLaWeb": "Ver la web"
+  },
+  "pie": {
+    "escribidnos": "Escribidnos"
   },
   "cocina": {
     "titulo": "Sistema de diseño",
@@ -32,6 +115,7 @@
     "seccionEspaciado": "Espaciado",
     "seccionForma": "Forma y sombra",
     "seccionMovimiento": "Movimiento",
+    "seccionComponentes": "Componentes",
     "grupoSuperficies": "Superficies",
     "grupoTinta": "Texto",
     "grupoMarca": "Marca y acento",
@@ -42,7 +126,12 @@
     "temaSistema": "Sistema",
     "cambiarTema": "Cambiar tema",
     "pruebaMovimiento": "Reproducir animación",
+    "avisoMovimiento": "Con «movimiento reducido» activado en el sistema, estas animaciones se reducen a una aparición corta.",
     "muestraTipografica": "Nos casamos",
-    "avisoMovimiento": "Con «movimiento reducido» activado en el sistema, estas animaciones se reducen a una aparición corta."
+    "botonPrimario": "Primario",
+    "botonSecundario": "Secundario",
+    "botonTerciario": "Terciario",
+    "botonDesactivado": "Desactivado",
+    "seccionInversa": "Bloque inverso: los mismos componentes, sin cambiar una clase"
   }
 }

--- a/src/app/cocina/page.tsx
+++ b/src/app/cocina/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 
+import { Boton } from "@/components/ui/boton";
+import { CampoTexto } from "@/components/ui/campo";
 import { SelectorTema } from "@/components/ui/selector-tema";
+import { Cita, Etiqueta } from "@/components/ui/tipografia";
 import {
   ANIMACIONES,
   GRUPOS_COLOR,
@@ -135,6 +138,48 @@ export default function PaginaCocina() {
             </li>
           ))}
         </ul>
+      </Seccion>
+
+      <Seccion titulo={t("cocina.seccionComponentes")}>
+        <div className="grid gap-elemento sm:grid-cols-2">
+          <div className="grid content-start gap-pila">
+            <Etiqueta>{t("cocina.botonPrimario")}</Etiqueta>
+            <div className="flex flex-wrap items-center gap-interno">
+              <Boton>{t("cocina.botonPrimario")}</Boton>
+              <Boton jerarquia="secundario">{t("cocina.botonSecundario")}</Boton>
+              <Boton jerarquia="terciario">{t("cocina.botonTerciario")}</Boton>
+              <Boton disabled>{t("cocina.botonDesactivado")}</Boton>
+            </div>
+          </div>
+
+          <div className="grid content-start gap-pila">
+            <CampoTexto etiqueta={t("rsvp.nombre")} placeholder="Paloma Fernández" />
+            <CampoTexto
+              etiqueta={t("rsvp.contacto")}
+              ayuda={t("rsvp.contactoAyuda")}
+              error={t("errores.emailInvalido")}
+              defaultValue="correo@"
+            />
+          </div>
+        </div>
+
+        {/*
+          La prueba de fuego del sistema: exactamente los mismos componentes,
+          sin una sola clase distinta, dentro de un bloque inverso.
+        */}
+        <div
+          data-seccion="inversa"
+          className="mt-elemento rounded-tarjeta p-elemento"
+          data-prueba="bloque-inverso"
+        >
+          <Etiqueta>{t("cocina.seccionInversa")}</Etiqueta>
+          <div className="mt-pila flex flex-wrap items-center gap-interno">
+            <Boton>{t("cocina.botonPrimario")}</Boton>
+            <Boton jerarquia="secundario">{t("cocina.botonSecundario")}</Boton>
+            <Boton jerarquia="terciario">{t("cocina.botonTerciario")}</Boton>
+          </div>
+          <Cita className="mt-pila">{t("cocina.muestraTipografica")}</Cita>
+        </div>
       </Seccion>
     </main>
   );

--- a/src/components/ui/boton.tsx
+++ b/src/components/ui/boton.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+/**
+ * BOTÓN
+ *
+ * Tres jerarquías, como manda el sistema de marca: primario (relleno oliva),
+ * secundario (contorno) y terciario (texto subrayado). Nada más — un cuarto
+ * estilo sería ruido.
+ *
+ * Solo usa tokens semánticos: en un bloque `[data-seccion="inversa"]` los
+ * mismos colores se reasignan y el botón se adapta sin tocar una clase.
+ *
+ * Altura mínima de 52 px: el objetivo táctil cómodo en móvil, que es donde la
+ * mayoría de invitados va a abrir esto desde WhatsApp.
+ */
+
+export type JerarquiaBoton = "primario" | "secundario" | "terciario";
+
+const BASE =
+  "inline-flex items-center justify-center gap-interno-compacto text-etiqueta uppercase tracking-boton transicion-color disabled:pointer-events-none disabled:opacity-50";
+
+const JERARQUIAS: Record<JerarquiaBoton, string> = {
+  primario:
+    "min-h-control rounded-boton bg-acento px-elemento text-tinta-sobre-acento hover:bg-acento-hover",
+  secundario:
+    "min-h-control rounded-boton border border-borde-fuerte px-elemento text-tinta-marca hover:border-borde-marca hover:bg-superficie-hundida",
+  terciario:
+    "min-h-control-compacto border-b border-borde-fuerte px-interno-compacto text-marca hover:border-borde-marca hover:text-tinta",
+};
+
+interface PropiedadesComunes {
+  jerarquia?: JerarquiaBoton;
+  children: ReactNode;
+  className?: string;
+}
+
+type PropiedadesBoton = PropiedadesComunes &
+  Omit<ComponentPropsWithoutRef<"button">, "className" | "children">;
+
+type PropiedadesEnlace = PropiedadesComunes &
+  Omit<ComponentPropsWithoutRef<typeof Link>, "className" | "children">;
+
+export function Boton({
+  jerarquia = "primario",
+  className = "",
+  children,
+  type = "button",
+  ...resto
+}: PropiedadesBoton) {
+  return (
+    <button type={type} className={`${BASE} ${JERARQUIAS[jerarquia]} ${className}`} {...resto}>
+      {children}
+    </button>
+  );
+}
+
+/** Mismo aspecto que `Boton`, pero navega. Un enlace nunca debe ser un botón. */
+export function BotonEnlace({
+  jerarquia = "primario",
+  className = "",
+  children,
+  ...resto
+}: PropiedadesEnlace) {
+  return (
+    <Link className={`${BASE} ${JERARQUIAS[jerarquia]} ${className}`} {...resto}>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/ui/campo.tsx
+++ b/src/components/ui/campo.tsx
@@ -1,0 +1,134 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { useId } from "react";
+
+/**
+ * CAMPOS DE FORMULARIO
+ *
+ * El RSVP es el formulario más importante del proyecto: lo rellenan invitados
+ * desde el móvil, a menudo mayores, a veces con prisa. Las decisiones que hay
+ * aquí no son estéticas:
+ *
+ * - La etiqueta es un `<label>` de verdad, asociado por id. Un placeholder no
+ *   es una etiqueta: desaparece al escribir y los lectores de pantalla no
+ *   siempre lo anuncian.
+ * - El texto del campo mide 16 px como mínimo. Por debajo, Safari en iOS hace
+ *   zoom automático al enfocar y descoloca la página entera.
+ * - El error se asocia con `aria-describedby` y se marca con `aria-invalid`,
+ *   para que se anuncie al enfocar y no solo se vea en rojo.
+ * - El color nunca es el único indicador: el error lleva texto.
+ */
+
+interface Envoltura {
+  etiqueta: string;
+  ayuda?: string;
+  error?: string;
+  children: (propiedades: {
+    id: string;
+    "aria-invalid": boolean;
+    "aria-describedby": string | undefined;
+  }) => ReactNode;
+}
+
+const CLASES_CONTROL =
+  "min-h-campo w-full rounded-campo border bg-superficie px-interno text-cuerpo text-tinta transicion-color placeholder:text-tinta-tenue focus:outline-none focus-visible:border-borde-marca";
+
+function EnvolturaCampo({ etiqueta, ayuda, error, children }: Envoltura) {
+  const id = useId();
+  const idError = `${id}-error`;
+  const idAyuda = `${id}-ayuda`;
+  const descripcion = [error ? idError : null, ayuda ? idAyuda : null]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className="grid gap-interno-compacto">
+      <label
+        htmlFor={id}
+        className={`text-etiqueta uppercase tracking-etiqueta ${
+          error ? "text-error" : "text-tinta-suave"
+        }`}
+      >
+        {etiqueta}
+      </label>
+
+      {children({
+        id,
+        "aria-invalid": Boolean(error),
+        "aria-describedby": descripcion || undefined,
+      })}
+
+      {ayuda ? (
+        <span id={idAyuda} className="text-pequeno text-tinta-tenue">
+          {ayuda}
+        </span>
+      ) : null}
+
+      {error ? (
+        <span id={idError} role="alert" className="text-pequeno text-error">
+          {error}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+type PropiedadesTexto = Omit<ComponentPropsWithoutRef<"input">, "id" | "className"> &
+  Pick<Envoltura, "etiqueta" | "ayuda" | "error">;
+
+export function CampoTexto({ etiqueta, ayuda, error, ...resto }: PropiedadesTexto) {
+  return (
+    <EnvolturaCampo etiqueta={etiqueta} ayuda={ayuda} error={error}>
+      {(propiedades) => (
+        <input
+          {...propiedades}
+          {...resto}
+          className={`${CLASES_CONTROL} ${error ? "border-error" : "border-borde"}`}
+        />
+      )}
+    </EnvolturaCampo>
+  );
+}
+
+type PropiedadesArea = Omit<ComponentPropsWithoutRef<"textarea">, "id" | "className"> &
+  Pick<Envoltura, "etiqueta" | "ayuda" | "error">;
+
+export function CampoTextoLargo({ etiqueta, ayuda, error, ...resto }: PropiedadesArea) {
+  return (
+    <EnvolturaCampo etiqueta={etiqueta} ayuda={ayuda} error={error}>
+      {(propiedades) => (
+        <textarea
+          {...propiedades}
+          {...resto}
+          className={`${CLASES_CONTROL} resize-y py-interno leading-cuerpo ${
+            error ? "border-error" : "border-borde"
+          }`}
+        />
+      )}
+    </EnvolturaCampo>
+  );
+}
+
+type PropiedadesSeleccion = Omit<ComponentPropsWithoutRef<"select">, "id" | "className"> &
+  Pick<Envoltura, "etiqueta" | "ayuda" | "error">;
+
+export function CampoSeleccion({
+  etiqueta,
+  ayuda,
+  error,
+  children,
+  ...resto
+}: PropiedadesSeleccion) {
+  return (
+    <EnvolturaCampo etiqueta={etiqueta} ayuda={ayuda} error={error}>
+      {(propiedades) => (
+        <select
+          {...propiedades}
+          {...resto}
+          className={`${CLASES_CONTROL} ${error ? "border-error" : "border-borde"}`}
+        >
+          {children}
+        </select>
+      )}
+    </EnvolturaCampo>
+  );
+}

--- a/src/components/ui/tipografia.tsx
+++ b/src/components/ui/tipografia.tsx
@@ -1,0 +1,121 @@
+import type { ElementType, ReactNode } from "react";
+
+/**
+ * TIPOGRAFÍA
+ *
+ * En un diseño editorial la tipografía ES el diseño, así que la escala se
+ * encapsula aquí en lugar de repartir clases por todas las secciones.
+ *
+ * La etiqueta HTML y el tamaño van por separado a propósito: el orden de los
+ * encabezados debe seguir la jerarquía del documento (un `h2` después de un
+ * `h1`, sin saltarse niveles) aunque visualmente convenga otro tamaño. Mezclar
+ * ambas cosas es la causa más común de webs que se navegan fatal con lector de
+ * pantalla.
+ */
+
+interface PropiedadesTitulo {
+  children: ReactNode;
+  /** Etiqueta HTML. Define la jerarquía del documento, no el tamaño. */
+  como?: ElementType;
+  className?: string;
+}
+
+export function Display({
+  children,
+  como: Etiqueta = "h1",
+  className = "",
+}: PropiedadesTitulo) {
+  return (
+    <Etiqueta
+      className={`font-titulo text-display leading-display tracking-display ${className}`}
+    >
+      {children}
+    </Etiqueta>
+  );
+}
+
+export function Titulo1({
+  children,
+  como: Etiqueta = "h1",
+  className = "",
+}: PropiedadesTitulo) {
+  return (
+    <Etiqueta className={`font-titulo text-titulo-1 leading-titulo ${className}`}>
+      {children}
+    </Etiqueta>
+  );
+}
+
+export function Titulo2({
+  children,
+  como: Etiqueta = "h2",
+  className = "",
+}: PropiedadesTitulo) {
+  return (
+    <Etiqueta className={`font-titulo text-titulo-2 leading-titulo-corto ${className}`}>
+      {children}
+    </Etiqueta>
+  );
+}
+
+export function Titulo3({
+  children,
+  como: Etiqueta = "h3",
+  className = "",
+}: PropiedadesTitulo) {
+  return (
+    <Etiqueta className={`font-titulo text-titulo-3 leading-titulo-corto ${className}`}>
+      {children}
+    </Etiqueta>
+  );
+}
+
+/** Versalita espaciada: el rótulo que precede a cada sección. */
+export function Etiqueta({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={`block text-etiqueta uppercase tracking-etiqueta text-tinta-tenue ${className}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Cursiva serif: las frases que respiran, nunca para información esencial. */
+export function Cita({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={`font-titulo text-cita italic leading-cita text-tinta-suave ${className}`}>
+      {children}
+    </p>
+  );
+}
+
+export function Cuerpo({
+  children,
+  grande = false,
+  className = "",
+}: {
+  children: ReactNode;
+  grande?: boolean;
+  className?: string;
+}) {
+  return (
+    <p
+      className={`${grande ? "text-cuerpo-grande" : "text-cuerpo"} leading-cuerpo text-tinta-suave ${className}`}
+    >
+      {children}
+    </p>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -23,8 +23,10 @@
  * valores: por eso el tema oscuro y los bloques `[data-seccion]` funcionan
  * reasignando semánticos en runtime.
  *
- * Resultado: `bg-superficie` y `var(--superficie)` son EL MISMO token. Una
- * sola fuente de verdad, dos sintaxis.
+ * Resultado: la utilidad `bg-superficie` compila literalmente a
+ * `var(--superficie)`. No hay copia del valor, hay referencia — por eso los
+ * componentes pueden usar indistintamente la utilidad o el token, y ambos
+ * siguen al tema activo.
  *
  * Los `*: initial` borran antes las escalas por defecto de Tailwind: nadie
  * puede escribir `bg-red-500`, `text-2xl` ni `p-4` en este proyecto. Solo
@@ -129,6 +131,9 @@
   --spacing-bloque: var(--espacio-bloque);
   --spacing-seccion-compacta: var(--espacio-seccion-compacta);
   --spacing-seccion: var(--espacio-seccion);
+  --spacing-control: var(--alto-control);
+  --spacing-control-compacto: var(--alto-control-compacto);
+  --spacing-campo: var(--alto-campo);
 
   /* Forma */
   --radius-boton: var(--radio-boton);

--- a/src/styles/tokens/motion.css
+++ b/src/styles/tokens/motion.css
@@ -106,6 +106,33 @@
 }
 
 /* --------------------------------------------------------------------------
+ * Transiciones
+ *
+ * Tailwind genera `duration-*` a partir de números sueltos, lo que obligaría a
+ * escribir `duration-[250ms]` en cada componente: un valor arbitrario, justo lo
+ * que la regla 1 prohíbe. Estas utilidades encapsulan la transición completa
+ * en un token con nombre.
+ * ----------------------------------------------------------------------- */
+
+@utility transicion-color {
+  transition:
+    color var(--transicion-color),
+    background-color var(--transicion-color),
+    border-color var(--transicion-color),
+    box-shadow var(--transicion-color);
+}
+
+@utility transicion-transformacion {
+  transition:
+    transform var(--transicion-transformacion),
+    opacity var(--transicion-transformacion);
+}
+
+@utility transicion-suave {
+  transition: all var(--transicion-aparicion);
+}
+
+/* --------------------------------------------------------------------------
  * Utilidades de entrada
  *
  * `-al-ver` reproduce la animación cuando el elemento entra en el viewport;

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -135,6 +135,11 @@
   --space-seccion-compacta: 5rem;
   --space-seccion: 8.25rem;
 
+  /* Altura de los controles: el objetivo táctil cómodo en móvil. */
+  --size-control: 3.25rem;
+  --size-control-compacto: 2.75rem;
+  --size-campo: 3.125rem;
+
   /* ---------------------------------------------------------------------
    * Forma
    * ------------------------------------------------------------------- */

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -108,6 +108,9 @@
   --espacio-bloque: var(--space-bloque);
   --espacio-seccion-compacta: var(--space-seccion-compacta);
   --espacio-seccion: var(--space-seccion);
+  --alto-control: var(--size-control);
+  --alto-control-compacto: var(--size-control-compacto);
+  --alto-campo: var(--size-campo);
 
   /* --- Forma --------------------------------------------------------- */
   --radio-boton: var(--radius-redondo);

--- a/tests/e2e/tokens.spec.ts
+++ b/tests/e2e/tokens.spec.ts
@@ -160,3 +160,62 @@ test.describe("Movimiento reducido", () => {
     expect(duracion).toBe("0.1s");
   });
 });
+
+/**
+ * La prueba de fuego del sistema de tokens: los MISMOS componentes, sin una
+ * sola clase distinta, dentro de un bloque inverso. Si esto funciona, cambiar
+ * el aspecto de una sección entera no obliga a tocar ningún componente.
+ */
+test.describe("Bloques inversos", () => {
+  test("los mismos componentes se adaptan sin cambiar de clase", async ({ page }) => {
+    await page.goto("/cocina");
+
+    const bloque = page.locator('[data-prueba="bloque-inverso"]');
+    await expect(bloque).toBeVisible();
+
+    const { normal, inverso } = await page.evaluate(() => {
+      const dentro = document.querySelector('[data-prueba="bloque-inverso"]')!;
+      const raiz = getComputedStyle(document.documentElement);
+      return {
+        normal: raiz.getPropertyValue("--fondo").trim(),
+        inverso: getComputedStyle(dentro).getPropertyValue("--fondo").trim(),
+      };
+    });
+
+    expect(inverso).not.toBe("");
+    expect(inverso).not.toBe(normal);
+  });
+
+  test("el texto del bloque inverso mantiene contraste suficiente", async ({ page }) => {
+    await page.goto("/cocina");
+
+    // Comprobación real de contraste: el color de texto computado dentro del
+    // bloque tiene que separarse del fondo del propio bloque, no del de la
+    // página. Un bloque inverso mal resuelto da texto oscuro sobre oscuro.
+    const ratio = await page.evaluate(() => {
+      const bloque = document.querySelector('[data-prueba="bloque-inverso"]') as HTMLElement;
+      const estilo = getComputedStyle(bloque);
+
+      const luminancia = (color: string) => {
+        const [r, g, b] = color
+          .match(/\d+(\.\d+)?/g)!
+          .slice(0, 3)
+          .map(Number);
+        const canal = (v: number) => {
+          const s = v / 255;
+          return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+        };
+        return 0.2126 * canal(r) + 0.7152 * canal(g) + 0.0722 * canal(b);
+      };
+
+      const lFondo = luminancia(estilo.backgroundColor);
+      const lTexto = luminancia(estilo.color);
+      const claro = Math.max(lFondo, lTexto);
+      const oscuro = Math.min(lFondo, lTexto);
+      return (claro + 0.05) / (oscuro + 0.05);
+    });
+
+    // AA para texto normal exige 4.5:1.
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});


### PR DESCRIPTION
Los primitivos de interfaz que va a consumir toda la landing: botón en sus tres jerarquías, campos de formulario y escala tipográfica.

## Decisiones que no son estéticas

- **La etiqueta de cada campo es un `<label>` real** asociado por id. Un placeholder no es una etiqueta: desaparece al escribir y los lectores de pantalla no siempre lo anuncian.
- **El texto de los campos mide 16 px como mínimo.** Por debajo, Safari en iOS hace zoom automático al enfocar y descoloca la página entera — justo en el dispositivo desde el que la mayoría de invitados va a abrir el enlace desde WhatsApp.
- **Los errores se asocian con `aria-describedby` y `aria-invalid`**, y llevan texto. El color nunca es el único indicador.
- **En tipografía, la etiqueta HTML y el tamaño van por separado.** La jerarquía del documento no puede depender de lo que convenga visualmente; mezclarlas es la causa más común de webs que se navegan fatal con lector de pantalla.

## Dos valores arbitrarios que se habían colado

Ambos tokenizados:

- La **altura de los controles** (`min-h-[3.25rem]` → `min-h-control`).
- La **duración de las transiciones**. `duration-*` de Tailwind se genera a partir de números sueltos, lo que obligaba a escribir `duration-[250ms]` en cada componente. Ahora son utilidades propias (`transicion-color`, `transicion-transformacion`) que encapsulan el token completo.

## La prueba de fuego del sistema

Un test E2E coge **los mismos componentes, sin una sola clase distinta**, y los mete en un bloque `[data-seccion="inversa"]`. Verifica dos cosas:

1. Que los semánticos se reasignan dentro del bloque.
2. Que **el contraste resultante cumple AA (4.5:1)**, calculado sobre los colores computados reales.

Lo segundo importa: un bloque inverso mal resuelto da texto oscuro sobre oscuro, y ningún test que mire clases lo detectaría.

## Verificación

`npm run verificar` en verde · 14 tests unitarios · 13 E2E en Chromium y WebKit móvil.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_