### PR TITLE
E2: esquema completo, RLS y funciones del RSVP, verificado contra un Postgres real

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,23 @@ jobs:
       - name: Formato
         run: npm run format:check
 
+  base-de-datos:
+    name: Migraciones y seguridad de la BBDD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar PostgreSQL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql postgresql-contrib
+
+      - name: Aplicar migraciones y ejecutar la suite de seguridad
+        # Bloqueante a propósito: comprueba que anon no puede leer ninguna tabla
+        # privada, que nadie se cuela registrándose, y que un invitado no puede
+        # confirmar por otro. Si esto falla, no se mergea.
+        run: sudo ./scripts/probar-bbdd.sh
+
   e2e:
     name: Tests E2E
     runs-on: ubuntu-latest

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10,20 +10,20 @@ Board de trabajo. Cada ticket es una rama y una PR. Ver [PLAN-MAESTRO.md](./PLAN
 
 ## Resumen
 
-| Épica                 | Tickets      | Estado                       |
-| --------------------- | ------------ | ---------------------------- |
-| E1 · Cimientos        | BODA-01 → 06 | ✅ 5 hechos · 📋 1 pendiente |
-| E2 · Base de datos    | BODA-10 → 14 | 📋 5 pendientes              |
-| E3 · Landing          | BODA-20 → 28 | 📋 9 pendientes              |
-| E4 · Save the Date    | BODA-30 → 32 | 📋 3 pendientes              |
-| E5 · Auth y panel     | BODA-40 → 43 | 📋 4 pendientes              |
-| E6 · Invitados y RSVP | BODA-50 → 58 | 📋 9 pendientes              |
-| E7 · Presupuesto      | BODA-60 → 64 | 📋 5 pendientes              |
-| E8 · Proveedores      | BODA-70 → 74 | 📋 5 pendientes              |
-| E9 · Tareas y seating | BODA-80 → 84 | 📋 5 pendientes              |
-| E10 · Producción      | BODA-90 → 95 | 📋 6 pendientes              |
+| Épica                 | Tickets      | Estado                        |
+| --------------------- | ------------ | ----------------------------- |
+| E1 · Cimientos        | BODA-01 → 06 | ✅ 6 hechos                   |
+| E2 · Base de datos    | BODA-10 → 14 | ✅ 5 hechos                   |
+| E3 · Landing          | BODA-20 → 28 | ✅ 2 hechos · 📋 7 pendientes |
+| E4 · Save the Date    | BODA-30 → 32 | 📋 3 pendientes               |
+| E5 · Auth y panel     | BODA-40 → 43 | 📋 4 pendientes               |
+| E6 · Invitados y RSVP | BODA-50 → 58 | 📋 9 pendientes               |
+| E7 · Presupuesto      | BODA-60 → 64 | 📋 5 pendientes               |
+| E8 · Proveedores      | BODA-70 → 74 | 📋 5 pendientes               |
+| E9 · Tareas y seating | BODA-80 → 84 | 📋 5 pendientes               |
+| E10 · Producción      | BODA-90 → 95 | 📋 6 pendientes               |
 
-**Total: 57 tickets · 5 hechos.**
+**Total: 57 tickets · 13 hechos.**
 
 ---
 
@@ -88,7 +88,7 @@ ESLint + Prettier + Stylelint + Husky + lint-staged. **Las reglas del §2 se apl
 
 ### BODA-06 · Proyecto Supabase y conexión
 
-`📋` · `M` · ← BODA-01
+`✅` · `M` · ← BODA-01
 
 Proyectos de producción y staging. Clientes tipados (browser, servidor, middleware). Supabase CLI para local. Generación automática de tipos.
 
@@ -101,32 +101,32 @@ Proyectos de producción y staging. Clientes tipados (browser, servidor, middlew
 
 ### BODA-10 · Esquema base y convenciones
 
-`📋` · `S` · ← BODA-06
+`✅` · `S` · ← BODA-06
 
 Extensiones, `updated_at` por trigger, helpers de auditoría, tabla `profiles` ligada a `auth.users` con roles.
 
 ### BODA-11 · Configuración de la boda
 
-`📋` · `S` · ← BODA-10
+`✅` · `S` · ← BODA-10
 
 `wedding_settings` (fila única): fecha, lugar, nombres, coordenadas, flags de secciones, fecha límite de RSVP. **Fuente de verdad de todo dato de la boda.**
 **E2E:** cambiar la fecha en BBDD se refleja en la cuenta atrás de la landing.
 
 ### BODA-12 · Invitados
 
-`📋` · `M` · ← BODA-10
+`✅` · `M` · ← BODA-10
 
 `guest_groups`, `guests`, `rsvps` con sus enums. Índice único sobre `invite_token`.
 
 ### BODA-13 · Presupuesto, proveedores y organización
 
-`📋` · `M` · ← BODA-10
+`✅` · `M` · ← BODA-10
 
 `vendor_categories`, `vendors`, `vendor_documents`, `services`, `budget_categories`, `budget_items`, `payments`, `tasks`, `tables`, `media`, `activity_log`. Vistas `v_budget_summary` y `v_guest_stats`.
 
 ### BODA-14 · RLS y funciones públicas
 
-`📋` · `L` · ← BODA-11, BODA-12, BODA-13 · **🔒 crítico**
+`✅` · `L` · ← BODA-11, BODA-12, BODA-13 · **🔒 crítico**
 
 Políticas RLS de todas las tablas + `get_invitation(token)` y `submit_rsvp(token, responses)` como `SECURITY DEFINER` con rate limiting.
 

--- a/docs/MODELO-DATOS.md
+++ b/docs/MODELO-DATOS.md
@@ -1,0 +1,686 @@
+# Modelo de datos
+
+> Esquema de la base de datos de la web de boda: PostgreSQL 17 sobre Supabase.
+> Es documento vivo: **cualquier cambio de esquema se documenta en la misma PR
+> que lo introduce**, junto a su migración y su SQL de rollback.
+
+Las migraciones viven en [`supabase/migrations/`](../supabase/migrations/) y se
+aplican en orden alfabético, que es el orden cronológico de su prefijo:
+
+| Fichero                                 | Ticket            | Contenido                                                                          |
+| --------------------------------------- | ----------------- | ---------------------------------------------------------------------------------- |
+| `20260803090000_base.sql`               | BODA-10 · BODA-11 | Cierre de privilegios, extensiones, utilidades, auditoría, perfiles, configuración |
+| `20260803090100_invitados.sql`          | BODA-12           | Grupos de invitación, invitados, confirmaciones                                    |
+| `20260803090200_economia.sql`           | BODA-13           | Proveedores, servicios, presupuesto, pagos                                         |
+| `20260803090300_organizacion.sql`       | BODA-13           | Tareas, mesas, medios y cableado de la auditoría                                   |
+| `20260803090400_rls.sql`                | BODA-14           | Funciones de rol, privilegios, políticas RLS, `force`                              |
+| `20260803090500_funciones_publicas.sql` | BODA-14           | RSVP público y emisión de enlaces                                                  |
+| `20260803090600_vistas.sql`             | BODA-14           | Vistas de lectura y barrido final de permisos                                      |
+| `20260803090700_arranque.sql`           | BODA-10           | Arranque en frío del primer propietario                                            |
+
+Cada una tiene su reverso exacto en
+[`supabase/migrations/rollback/`](../supabase/migrations/rollback/), con el mismo
+nombre. Se ejecutan en orden **inverso**.
+
+En números: **24 tablas, 8 vistas, 14 enumerados, 42 funciones, 46 políticas RLS.**
+
+Todo esto no se da por bueno leyéndolo: `./scripts/probar-bbdd.sh` levanta un
+PostgreSQL desechable, aplica las migraciones desde cero y ejecuta
+[la suite de seguridad](../supabase/tests/seguridad.sql) — **31 comprobaciones**
+que atacan la base como un intruso. Corre en CI y es bloqueante.
+
+### El arranque en frío
+
+`perfiles.activo` nace en `false` y el trigger `proteger_privilegios_perfil`
+exige un propietario activo para activar a nadie. En una base recién desplegada
+no hay ninguno, así que el candado se cierra sobre sí mismo: **nadie podría
+entrar jamás**. Se detectó ejecutando el flujo completo contra un Postgres real;
+ninguna lectura del SQL lo habría visto, porque cada pieza es correcta por
+separado.
+
+Lo resuelve `designar_primer_propietario(usuario_id, nombre)`, que solo puede
+ejecutar `service_role`, se niega a actuar si ya existe un propietario activo, y
+por tanto no sirve como puerta trasera más adelante.
+
+---
+
+## 1. Convenciones
+
+Estas reglas se aplican sin excepción. Si algo del esquema no las cumple, es un
+error, no un caso especial.
+
+- **Todo en castellano.** Tablas, columnas, tipos, valores de enumerado,
+  funciones, índices y restricciones. Sólo son inglesas las palabras reservadas
+  de SQL. Se admiten como préstamos técnicos ya asentados: `id` (identificador),
+  `token`, `hashtag`, y los acrónimos `RSVP`, `IBAN`, `MIME`, `URL`, `BCP 47`,
+  `ISO 4217`. Donde había alternativa castellana natural se ha usado: la huella
+  criptográfica del token es `huella_token`, no `token_hash`; el marcador borroso
+  de una imagen es `marcador_borroso`, no `blur_hash`; el correo es
+  `correo_electronico`, no `email`.
+- **Nombres.** Restricciones `<tabla>_<detalle>`; claves foráneas
+  `<tabla>_<columna>_fk`; índices `<tabla>_<detalle>_idx`; políticas
+  `<tabla>_<quién>_<qué>`. Una sola convención en todo el esquema.
+- **Toda tabla** lleva `id uuid` (salvo las de fila única por clave natural),
+  `creado_en` y `actualizado_en`.
+- **`actualizado_en`** lo sella siempre el mismo trigger,
+  `public.fijar_actualizado_en()`, y siempre con la misma condición
+  `when (old.* is distinct from new.*)`. Significa lo mismo en las 24 tablas:
+  «cuándo cambió algo de verdad». Un UPDATE que no cambia nada no la mueve.
+- **RLS se activa en la sentencia inmediatamente posterior al `CREATE TABLE`**,
+  antes de índices, comentarios y triggers. Nunca existe una tabla, ni un
+  instante, sin RLS.
+- **Cero hardcode.** Lo que puede cambiar sin que cambie la lógica es
+  configuración y vive en una tabla: los datos de la boda, las secciones de la
+  landing, los límites del cortafuegos, los campos que la auditoría redacta.
+- **Errores con código estable.** Los triggers y funciones lanzan códigos
+  (`RSV03`, `CNF01`, `PRF01`, `MED01`…), nunca texto visible: el copy vive en
+  `content/copy.es.json`. Los identificadores internos viajan en `DETAIL`, que
+  PostgREST no devuelve al cliente, para no convertir un error en un oráculo de
+  existencia de uuids ajenos.
+
+---
+
+## 2. Diagrama de relaciones
+
+```mermaid
+erDiagram
+    auth_users ||--o| perfiles : "extiende"
+    invitaciones_panel ||..o| perfiles : "autoriza por correo"
+
+    grupos_invitacion ||--o{ invitados : "compone"
+    grupos_invitacion ||--o| notas_grupo : "notas privadas"
+    invitados ||--o| notas_invitado : "notas privadas"
+    invitados ||--o{ confirmaciones : "historial de respuestas"
+    mesas ||--o{ invitados : "sienta"
+    perfiles ||--o{ confirmaciones : "registró"
+
+    categorias_proveedor ||--o{ proveedores : "clasifica"
+    proveedores ||--o{ servicios : "contrata"
+    proveedores ||--o{ documentos_proveedor : "adjunta"
+    proveedores ||--o{ partidas_presupuesto : "genera gasto"
+    proveedores ||--o{ tareas : "motiva"
+    categorias_presupuesto ||--o{ partidas_presupuesto : "agrupa"
+    partidas_presupuesto ||--o{ pagos : "se liquida en"
+    perfiles ||--o{ pagos : "registró"
+    perfiles ||--o{ documentos_proveedor : "subió"
+    perfiles ||--o{ tareas : "es responsable"
+    perfiles ||--o{ medios : "subió"
+
+    configuracion_boda ||..|| configuracion_privada : "misma boda, visibilidad distinta"
+    secciones_landing ||..o{ medios : "misma sección"
+
+    auth_users {
+        uuid id PK
+        text email
+    }
+    perfiles {
+        uuid id PK
+        uuid usuario_id FK "único, CASCADE"
+        text correo_electronico
+        enum rol "propietario|editor|lector"
+        bool activo "por defecto FALSE"
+    }
+    invitaciones_panel {
+        text correo_electronico PK
+        enum rol
+    }
+    grupos_invitacion {
+        uuid id PK
+        text nombre
+        bytea huella_token "SHA-256, único"
+        smallint maximo_acompanantes
+        enum lado
+        array invitado_a
+    }
+    invitados {
+        uuid id PK
+        uuid grupo_id FK "CASCADE"
+        uuid mesa_id FK "SET NULL"
+        text nombre_completo "derivado"
+        bool es_nino
+        bool es_acompanante
+        enum tipo_menu
+        text alergias
+    }
+    confirmaciones {
+        uuid id PK
+        uuid invitado_id FK "CASCADE"
+        enum estado
+        enum origen
+        bool es_vigente "una sola por invitado"
+        bool necesita_autobus
+    }
+    proveedores {
+        uuid id PK
+        uuid categoria_id FK "RESTRICT"
+        enum estado
+        numeric importe_acordado
+    }
+    servicios {
+        uuid id PK
+        uuid proveedor_id FK "RESTRICT"
+        numeric precio_unitario
+        bool por_invitado
+        numeric importe_fijo "generada"
+    }
+    partidas_presupuesto {
+        uuid id PK
+        uuid categoria_id FK "RESTRICT"
+        uuid proveedor_id FK "SET NULL"
+        numeric importe_estimado
+        numeric importe_real
+    }
+    pagos {
+        uuid id PK
+        uuid partida_id FK "RESTRICT"
+        numeric importe
+        date fecha_vencimiento
+        date pagado_en
+    }
+    medios {
+        uuid id PK
+        text ruta_almacenamiento "único"
+        jsonb texto_alternativo
+        enum seccion
+        bool publicado "por defecto FALSE"
+    }
+    registro_auditoria {
+        uuid id PK
+        text tabla
+        enum operacion
+        jsonb datos_anteriores "redactado"
+        jsonb datos_nuevos "redactado"
+        text origen_cambio
+    }
+```
+
+### Qué pasa al borrar
+
+El criterio no es uniforme, y la diferencia es deliberada:
+
+| Borras…               | …y se lleva por delante                            | …y sobrevive                                                                   |
+| --------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Un grupo              | sus invitados y sus confirmaciones (`CASCADE`)     | la entrada de auditoría, con los datos para reconstruirlo                      |
+| Un invitado           | su historial de respuestas (`CASCADE`, RGPD)       | la auditoría                                                                   |
+| Una mesa              | nada: sus invitados quedan «sin mesa» (`SET NULL`) | todo el reparto                                                                |
+| Un colaborador        | nada: autorías a NULL (`SET NULL`)                 | tareas, pagos, documentos, medios y toda la traza de auditoría                 |
+| Un proveedor          | **nada**: `RESTRICT`                               | facturas, contratos y servicios — son contabilidad, hay que resolverlos a mano |
+| Una categoría         | **nada**: `RESTRICT`                               | obliga a recategorizar antes                                                   |
+| Una partida con pagos | **nada**: `RESTRICT`                               | el histórico de pagos                                                          |
+| La configuración      | **nada**: un trigger lo impide (`CFG01`)           | la boda sigue teniendo fecha                                                   |
+
+---
+
+## 3. Las entidades
+
+### 3.1 Configuración y acceso
+
+#### `configuracion_boda` — fila única, **pública entera**
+
+Fecha, nombres, lugares, coordenadas, hashtag, moneda, idioma, plazo de RSVP.
+
+Está separada de la parte privada **por diseño**: la landing necesita leerla y
+RLS filtra filas, no columnas. Como aquí sólo hay una fila, una política de
+lectura pública expone la fila completa — así que en esta tabla no puede haber
+nada que no sea publicable. La restricción de fila única es declarativa
+(`fila_unica boolean check (fila_unica) unique`) y no un trigger: una
+restricción no se esquiva. La fila la siembra la migración y **no se puede
+borrar**.
+
+#### `configuracion_privada` — fila única, **nunca sale del panel**
+
+`presupuesto_objetivo`, `aforo_maximo`, `telefono_contacto`, `iban_regalos`,
+`notas_privadas`. Lectura para editor y propietario; escritura sólo propietario.
+
+#### `secciones_landing`
+
+Qué secciones se enseñan y en qué orden (`seccion` PK, `visible`, `orden`).
+Sustituye a los antiguos nueve flags `mostrar_*`, que formaban un vocabulario
+paralelo al del enumerado de secciones y obligaban al frontend a traducir
+nombres a mano. Ahora hay **una sola lista**: el enumerado `seccion_landing`.
+
+#### `invitaciones_panel`
+
+Lista blanca de correos autorizados a entrar en el panel, con el rol que se les
+concede. **Es la pieza que hace que registrarse no conceda nada.**
+
+#### `perfiles`
+
+Extiende `auth.users`. `rol` (`propietario`/`editor`/`lector`) y `activo`
+—**por defecto `false`**—. El correo se copia desde `auth.users` por trigger,
+con índice **no único**: `auth.users` ya garantiza su unicidad, y un choque aquí
+abortaría el alta de la cuenta con un 500 opaco.
+
+#### `registro_auditoria` y `campos_auditoria_redactados`
+
+Bitácora de quién cambió qué y cuándo. Está enganchada a **las 20 tablas de
+dominio**, no a dos: los triggers de fila también se disparan en los borrados en
+cascada, así que un grupo borrado por error se puede reconstruir entero.
+
+`campos_auditoria_redactados` es una **tabla** y no una lista dentro de la
+función: declarar un campo sensible es configuración, no debe exigir migración.
+Los valores de esas columnas se sustituyen por un marcador antes de escribirlos.
+La clave se conserva, y `campos_modificados` se calcula **antes** de redactar, de
+modo que un cambio de token consta aunque su valor no se guarde.
+
+`origen_cambio` distingue `panel`, `sistema` y `rsvp:<grupo>`. Sin él, todo lo
+que entra por una función pública llamada con la clave anónima aparecería como
+cambio del sistema, porque ahí `auth.uid()` es `NULL`.
+
+### 3.2 Invitados
+
+#### `grupos_invitacion`
+
+La unidad de invitación: una familia o una pareja.
+
+- **`huella_token bytea`** — el SHA-256 del token. El texto plano **no se
+  almacena**: existe una sola vez, como valor devuelto por
+  `crear_grupo_invitacion()` o `rotar_token_invitacion()`. Si se pierde, se emite
+  otro; rotar invalida el anterior en el acto, así que también sirve para
+  revocar un enlace filtrado.
+- **`invitado_a`** — array de eventos, normalizado por trigger (sin duplicados y
+  ordenado). El CHECK no fija el número de eventos: ese dato es derivable del
+  enumerado y copiarlo obligaría a tocar la restricción al añadir uno nuevo.
+- **`invitado_a`, `maximo_acompanantes`, `lado` y `huella_token` son
+  privilegios, no datos**: definen a cuántos eventos entra el grupo y cuánta
+  gente puede añadir. Un trigger los congela frente a cualquiera que no sea
+  editor (`RSV06`).
+
+#### `notas_grupo` y `notas_invitado`
+
+Notas privadas de los novios, en tablas aparte. La ruta pública del RSVP tiene
+que leer `grupos_invitacion` e `invitados`; **lo que el invitado no debe ver,
+sencillamente no está en la tabla que se le devuelve.** Ninguna función pública
+las toca, y llevan RLS forzada.
+
+#### `invitados`
+
+- `nombre_completo` es columna real mantenida por trigger, no `GENERATED`:
+  PostgreSQL prohíbe `when (old.* is distinct from new.*)` en un trigger BEFORE
+  de una tabla con columnas generadas, y sin esa cláusula esta tabla —y sólo
+  ella— movería `actualizado_en` en UPDATEs que no cambian nada.
+- **El menú infantil es una implicación, no una equivalencia**:
+  `check (tipo_menu <> 'infantil' or es_nino)`. La equivalencia estricta hacía
+  imposible registrar a un niño celíaco, vegano o vegetariano — el único caso en
+  que la exactitud del dato importa de verdad. El recuento de niños se hace por
+  `es_nino`, que es el dato fiable.
+- El tope de acompañantes lo garantiza un _constraint trigger_ que **bloquea la
+  fila del grupo** antes de contar. Contarlo en la aplicación deja una carrera
+  ganable: en READ COMMITTED, treinta llamadas concurrentes leen todas
+  `count(*) = 0` y todas insertan.
+
+#### `confirmaciones` — histórico de sólo inserción
+
+Una fila por respuesta. La anterior deja de ser vigente; nunca se edita.
+
+- `es_vigente` con índice único parcial garantiza **como mucho** una vigente por
+  persona; un _constraint trigger_ diferido garantiza **al menos** una. Sin el
+  segundo, un invitado sin fila vigente desaparece en silencio del recuento de
+  confirmados, del reparto de menús y de la lista del autobús: ningún error,
+  sólo números que no cuadran.
+- La inmutabilidad se comprueba **por sustracción**
+  (`to_jsonb(new) - 'es_vigente' - 'actualizado_en'`), no con una lista cerrada
+  de columnas: así cubre `id`, `creado_en` y toda columna futura sin que nadie
+  tenga que acordarse de ampliarla. Reordenar `creado_en` era reordenar la
+  cronología de quién dijo qué y cuándo, que es lo único que esta tabla existe
+  para probar.
+- `origen` tiene por defecto `publico`, **el valor menos fiable**. Con `panel`
+  por defecto, un INSERT que se olvidara de fijarlo quedaría registrado como si
+  lo hubiera tecleado un novio. Un CHECK ata origen y autoría:
+  `panel` ⇔ `registrado_por is not null`.
+- `respondido_en` lo sella el servidor en el origen público, y nunca puede estar
+  en el futuro.
+
+### 3.3 Economía
+
+`categorias_proveedor` → `proveedores` → `servicios` / `documentos_proveedor`;
+`categorias_presupuesto` → `partidas_presupuesto` → `pagos`.
+
+- **Documentos y servicios usan `RESTRICT`, no `CASCADE`.** Facturas y contratos
+  son documentación contable: no pueden desaparecer porque alguien pulse
+  «Borrar» en la ficha del fotógrafo en vez de marcarlo como descartado. Además,
+  tras una cascada la aplicación ya no ve esas filas y los objetos quedarían
+  huérfanos para siempre en el bucket de Storage, sin nada que los referencie.
+- `servicios.por_invitado` marca los precios que dependen de los confirmados.
+  `importe_fijo` es una columna generada que vale `NULL` justamente en esos
+  casos, para que nadie la confunda con un total real; el total lo da
+  `v_servicios_importe`.
+- Las rutas de Storage (`documentos_proveedor`, `pagos`, `medios`) se validan
+  todas con la misma función: sin barra inicial, sin `..`, y **admitiendo
+  mayúsculas** — `galeria/DSC_0001.JPG` es una clave legal y habitual, y
+  rechazarla dejaba ficheros huérfanos en el bucket con un error que el usuario
+  no podía corregir.
+
+### 3.4 Organización
+
+- `tareas` — `completada_en` lo mantiene un trigger a partir de `estado`, con un
+  CHECK que exige la equivalencia. No hay tareas reabiertas con fecha de cierre
+  zombi.
+- `mesas` — capacidad acotada a 1..30 (red contra el dedazo, no regla de
+  producto) y posición completa o ausente: media coordenada rompería el plano.
+- `medios` — `publicado` por defecto `false`. El texto alternativo es obligatorio
+  **en el idioma por defecto de la boda**, que se lee de `configuracion_boda` en
+  un trigger en vez de fijar `'es'` en un CHECK: si los novios cambian el idioma,
+  la restricción de accesibilidad tiene que seguir protegiendo el idioma que
+  realmente se sirve.
+
+### 3.5 Seguridad del RSVP
+
+- `parametros_seguridad` — fila única con los límites del cortafuegos
+  (intentos, ventana, retención). Son configuración: se ajustan sin migración.
+- `intentos_rsvp` — intentos de resolver un token. Guarda la **huella** del token
+  intentado, nunca el token: la bitácora de seguridad no puede convertirse en un
+  almacén de credenciales.
+
+---
+
+## 4. Vistas
+
+Todas con `security_invoker = on` y **columnas enumeradas una a una**.
+
+En PostgreSQL una vista se ejecuta con los privilegios de su propietario salvo
+que se diga lo contrario; en Supabase ese propietario es `postgres`, dueño de
+todas las tablas, de modo que una vista normal **ignora toda la RLS**.
+`v_resumen_presupuesto` cruza por definición categorías, partidas, pagos y
+proveedores: es exactamente el agregado que un atacante quiere. Con
+`security_invoker`, quien consulta pasa por sus propias políticas y un atacante
+recibe cero filas.
+
+El `select *` está prohibido por el mismo motivo que en las funciones públicas:
+con el asterisco, cualquier `add column` futuro se publica solo y en silencio.
+Las vistas **materializadas** están prohibidas sobre estas tablas: no admiten
+`security_invoker` en absoluto.
+
+| Vista                      | Quién la ve   | Para qué                                             |
+| -------------------------- | ------------- | ---------------------------------------------------- |
+| `v_configuracion_publica`  | `anon`        | Datos de la boda para la landing                     |
+| `v_secciones_publicas`     | `anon`        | Secciones visibles, en orden                         |
+| `v_medios_publicados`      | `anon`        | Fotos publicadas por sección                         |
+| `v_estadisticas_invitados` | colaboradores | Confirmados, adultos, niños, autobús, alojamiento    |
+| `v_menus_confirmados`      | colaboradores | Recuento de menús para el catering                   |
+| `v_servicios_importe`      | colaboradores | Importe real, resolviendo el precio por invitado     |
+| `v_resumen_presupuesto`    | colaboradores | Previsto vs estimado vs real vs pagado, y desviación |
+| `v_proximos_pagos`         | colaboradores | Qué hay que pagar y cuándo                           |
+
+`v_servicios_importe` existe para que la fórmula del coste por invitado viva en
+la base de datos y no replicada en TypeScript: si mañana se decide contar a los
+niños a media tarifa, se cambia aquí y el panel entero se entera.
+
+---
+
+## 5. Modelo de seguridad
+
+> La seguridad vive en la base de datos. Ni una sola de las garantías de esta
+> sección depende de una casilla de un dashboard, de un `if` del frontend ni de
+> que una función de aplicación se acuerde de comprobar algo.
+
+### 5.1 Los privilegios parten de cero
+
+Supabase deja puesto `alter default privileges ... grant all on tables to anon,
+authenticated`: en el instante del `CREATE TABLE`, `anon` ya tiene SELECT,
+INSERT, UPDATE, DELETE y **TRUNCATE** sobre la tabla, y lo único que lo tapa es
+RLS — que **no se aplica a TRUNCATE**.
+
+La primera migración revoca esos privilegios por defecto **antes de crear la
+primera tabla**, de modo que ninguna tabla del proyecto nace concedida. Después
+se conceden uno a uno, enumerando siempre las operaciones (nunca `all`, para que
+TRUNCATE no entre por la puerta de atrás).
+
+### 5.2 Qué ve cada quién
+
+| Rol                     | Lectura                                                                                             | Escritura                                                        |
+| ----------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **`anon`** (la landing) | `configuracion_boda`, `secciones_landing` visibles, `medios` publicados, y las tres vistas públicas | **nada**                                                         |
+| **`anon`** (con token)  | Su invitación, vía `obtener_invitacion()`                                                           | Su RSVP, vía `registrar_confirmacion()` y `anadir_acompanante()` |
+| **`lector`**            | Todo el dominio: invitados, confirmaciones, economía, tareas, mesas, medios                         | nada                                                             |
+| **`editor`**            | Lo anterior + notas privadas + `configuracion_privada`                                              | Todo el dominio; en `confirmaciones` sólo INSERT                 |
+| **`propietario`**       | Todo, incluida la bitácora de auditoría y la lista blanca                                           | Todo, incluidos usuarios y configuración privada                 |
+
+Nadie —ningún rol, en ninguna circunstancia— tiene UPDATE ni DELETE sobre
+`confirmaciones` ni sobre `registro_auditoria`. Un histórico que se puede editar
+no es un histórico.
+
+### 5.3 Registrarse no concede nada
+
+Un alta en `auth.users` dispara un trigger que crea el perfil **inactivo y con
+rol `lector`**, salvo que el correo figure en `invitaciones_panel`. Todas las
+funciones de rol (`puede_leer`, `puede_editar`, `es_propietario`) exigen
+`activo`.
+
+Consecuencia práctica: **el registro público de Supabase puede quedarse
+activado sin riesgo.** Quien se fabrique una cuenta con la clave anónima obtiene
+una sesión válida que no puede leer absolutamente nada. La defensa es una tabla
+versionada y testeada, no una casilla de un panel que nadie versiona y cualquiera
+puede volver a activar.
+
+El trigger además captura sus propios errores: un fallo sincronizando el perfil
+no puede abortar la transacción de Supabase Auth y dejar al usuario con un 500.
+
+### 5.4 El primer propietario (arranque en frío)
+
+Una base recién desplegada **no tiene ningún colaborador activo**, y
+`invitaciones_panel` sólo la puede gestionar un `propietario`. La primera fila,
+por tanto, no puede entrar por la API: es un acto deliberado, fuera de banda, y
+está bien que lo sea.
+
+Se hace una sola vez, desde el editor SQL de Supabase o con la clave
+`service_role` (ambos con `bypassrls`), **antes** de que los novios se
+registren:
+
+```sql
+insert into public.invitaciones_panel (correo_electronico, rol)
+values ('novia@sudominio.es', 'propietario'),
+       ('novio@sudominio.es', 'propietario');
+```
+
+A partir de ahí el flujo es automático: al registrarse con ese correo, el
+trigger `auth_users_sincronizar_perfil` crea el perfil ya **activo y con rol
+`propietario`**, porque el rol y el alta se resuelven en el propio INSERT del
+perfil. No hace falta ningún UPDATE, y por eso el trigger
+`proteger_privilegios_perfil` —que sólo vigila UPDATE— no se interpone ni crea
+un candado sobre sí mismo.
+
+Deliberadamente **no se siembra ningún propietario en las migraciones**: un
+correo de los novios incrustado en un fichero versionado sería un dato real de
+la boda dentro del código, justo lo que prohíbe la regla 1.
+
+### 5.5 Nadie se asciende a sí mismo
+
+`rol` y `activo` viven en la misma fila que el usuario edita para cambiarse el
+nombre. Sin protección, «editar mi perfil» y «hacerme propietario» son la misma
+operación. Hay dos defensas independientes:
+
+1. Un trigger (`PRF01`) que rechaza cualquier cambio de `rol`, `activo` o
+   `usuario_id` que no venga de un propietario activo.
+2. El `with check` de la política de autoedición, que congela ambas columnas.
+
+Las funciones que la política consulta son `SECURITY DEFINER` a propósito: una
+política sobre `perfiles` que leyera `perfiles` provocaría recursión infinita.
+
+### 5.6 `force row level security`
+
+`enable row level security` **no se aplica al propietario de la tabla**, que en
+Supabase es también el propietario de las funciones `SECURITY DEFINER`. Sin
+`force`, dentro de cualquier función definer —presente o futura— la RLS está
+sencillamente desactivada.
+
+Se fuerza en **14 de 24 tablas**. Las 10 excepciones no son olvidos; cada una
+existe porque la maquinaria interna necesita tocarla como propietario:
+
+| Tabla                                               | Por qué no se fuerza                                                                    |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `perfiles`, `invitaciones_panel`                    | Las leen las funciones de rol y el trigger de alta, que corren antes de que haya sesión |
+| `registro_auditoria`, `campos_auditoria_redactados` | Las usa el trigger de auditoría                                                         |
+| `configuracion_boda`                                | Es pública entera; la leen los triggers de plazo y accesibilidad                        |
+| `parametros_seguridad`, `intentos_rsvp`             | Las usa el cortafuegos del RSVP                                                         |
+| `grupos_invitacion`, `invitados`, `confirmaciones`  | Las recorren las funciones públicas del RSVP                                            |
+
+**La compensación por esas tres últimas está en cómo está escrito el SQL de las
+funciones públicas**, y es una regla de revisión, no una recomendación:
+
+- Ninguna función declara `returns setof <tabla>` ni usa `select *`. El tipo de
+  retorno se enumera columna a columna, de modo que añadir mañana una columna
+  sensible a `invitados` no la publica sola.
+- **`invitado_id` nunca se acepta como dato de entrada suelto**: se deriva del
+  token _dentro de la misma sentencia_ que lee o escribe. Un identificador ajeno
+  no produce un error, produce cero filas — no hay ventana entre comprobar y
+  escribir.
+- Prohibido `jsonb_populate_record` contra el tipo de una tabla completa: se
+  enumeran los campos que el invitado puede escribir, y `origen`,
+  `registrado_por`, `respondido_en` y `es_vigente` los fija el servidor.
+- El plazo se comprueba siempre contra `now()`, jamás contra una fecha recibida.
+
+### 5.7 Cómo funciona el RSVP por token
+
+```
+El invitado recibe   https://…/rsvp/<token de 32 caracteres>
+                     └─ 192 bits de entropía, base64 url-safe
+
+  1. obtener_invitacion(token)
+       ├─ cortafuegos: ¿demasiados intentos fallidos desde este origen? → RSV02
+       ├─ busca por SHA-256 del token (la tabla no guarda el token en claro)
+       ├─ anota el intento en intentos_rsvp
+       └─ devuelve SOLO su grupo y sus personas, con columnas enumeradas:
+          nada de notas privadas, nada de la dirección de otros, nada del token
+
+  2. registrar_confirmacion(token, respuestas)
+       ├─ mismo cortafuegos y misma resolución por huella
+       ├─ INSERT ... FROM jsonb_array_elements JOIN invitados JOIN grupo del token
+       │    → un invitado_id de otro grupo no casa: 0 filas
+       ├─ si insertadas ≠ recibidas → RSV04 y se deshace TODO
+       └─ triggers: plazo (RSV03), sellado de fecha (RSV07), vigencia
+
+  3. anadir_acompanante(token, …)
+       └─ constraint trigger con bloqueo del grupo → RSV05 si se agota el cupo
+```
+
+**Un enlace no válido no lanza excepción: devuelve vacío.** No es un capricho de
+estilo. El cortafuegos cuenta los intentos fallidos guardándolos en
+`intentos_rsvp`; si al detectar un token inválido la función lanzara una
+excepción, PostgREST abortaría la transacción y ese INSERT se iría con ella. La
+bitácora sólo acabaría conteniendo intentos con **éxito** y el límite no saltaría
+jamás. Se comprobó sobre la base real: quince intentos fallidos seguidos dejaban
+cero filas registradas. PostgreSQL no tiene transacciones autónomas, así que la
+única forma de que el registro sobreviva es no abortar.
+
+Contrato resultante, que el frontend debe respetar:
+
+| Función                  | Enlace no válido |
+| ------------------------ | ---------------- |
+| `obtener_invitacion`     | cero filas       |
+| `registrar_confirmacion` | devuelve `0`     |
+| `anadir_acompanante`     | devuelve `NULL`  |
+
+### 5.8 Sólo tres funciones son públicas
+
+`obtener_invitacion`, `registrar_confirmacion` y `anadir_acompanante`. Ninguna
+más.
+
+Conseguirlo exige un cuidado que no es evidente: **`revoke execute ... from
+public` no basta, pero revocar las default privileges tampoco.** Se comprobó
+sobre una base limpia que toda función nueva sigue naciendo con EXECUTE para el
+pseudo-rol PUBLIC, del que `anon` hereda — de modo que una función creada sin su
+`revoke` explícito queda publicada como RPC aunque su autor crea lo contrario, y
+sin ningún error que lo delate.
+
+Por eso hay dos capas: un `revoke` explícito junto a cada función, y un **barrido
+final** en la última migración que revoca EXECUTE a PUBLIC y a `anon` sobre todas
+las funciones de `public` y devuelve el permiso sólo a las tres puertas del RSVP.
+La segunda capa existe porque la primera es justo lo que alguien olvidará el día
+que añada la función número treinta.
+
+### 5.9 Códigos de error
+
+| Código  | Significa                                            | Lo lanza                    |
+| ------- | ---------------------------------------------------- | --------------------------- |
+| `RSV01` | Enlace no válido — **resultado vacío**, no excepción | Las tres funciones públicas |
+| `RSV02` | Demasiados intentos                                  | `exigir_cupo_rsvp()`        |
+| `RSV03` | Plazo de confirmación cerrado                        | Trigger de plazo            |
+| `RSV04` | El invitado no pertenece a esta invitación           | `registrar_confirmacion()`  |
+| `RSV05` | El grupo ha agotado sus acompañantes                 | Constraint trigger de aforo |
+| `RSV06` | Intento de cambiar privilegios de la invitación      | Trigger de congelación      |
+| `RSV07` | Respuesta fechada en el futuro                       | Trigger de sellado          |
+| `CNF01` | Las confirmaciones son inmutables                    | Trigger de inmutabilidad    |
+| `CNF02` | No se puede reactivar una respuesta caducada         | Trigger de inmutabilidad    |
+| `CNF03` | Un invitado se quedaría sin respuesta vigente        | Constraint trigger diferido |
+| `PRF01` | Sólo un propietario cambia rol o alta                | Trigger de privilegios      |
+| `CFG01` | La configuración no se borra                         | Trigger de borrado          |
+| `MED01` | Falta texto alternativo en el idioma de la boda      | Trigger de accesibilidad    |
+
+Cada uno necesita su entrada en `content/copy.es.json` bajo `errores`.
+
+---
+
+## 6. Guardias para el CI
+
+Las tres consultas siguientes **deben devolver cero filas** y son bloqueantes
+(regla 4 del proyecto). Detectan por sí solas las regresiones más peligrosas.
+
+```sql
+-- a) Ninguna tabla del esquema público sin RLS
+select c.relname
+  from pg_class c join pg_namespace n on n.oid = c.relnamespace
+ where n.nspname = 'public' and c.relkind = 'r' and not c.relrowsecurity;
+
+-- b) Ninguna vista sin security_invoker; ninguna vista materializada
+--    Ojo: PostgreSQL guarda la opción tal cual se escribió, así que hay que
+--    aceptar 'on' y 'true'. Comparar sólo contra 'true' marca como inseguras
+--    las ocho vistas del proyecto, y un guardia con falsos positivos acaba
+--    desactivado — que es peor que no tenerlo.
+select c.relname, c.relkind
+  from pg_class c join pg_namespace n on n.oid = c.relnamespace
+ where n.nspname = 'public'
+   and (c.relkind = 'm'
+        or (c.relkind = 'v' and coalesce((select lower(option_value)
+              from pg_options_to_table(c.reloptions)
+             where option_name = 'security_invoker'), 'false') not in ('true','on')));
+
+-- c) Ninguna función ejecutable por anon salvo las tres RPC del RSVP
+select p.proname
+  from pg_proc p
+ where p.pronamespace = 'public'::regnamespace
+   and has_function_privilege('anon', p.oid, 'execute')
+   and p.proname not in ('obtener_invitacion','registrar_confirmacion','anadir_acompanante');
+```
+
+Además, la suite E2E con la clave anónima debe comprobar, como mínimo:
+
+- `anon` no obtiene datos de ninguna tabla privada (invitados, grupos,
+  confirmaciones, notas, proveedores, pagos, partidas, servicios, documentos,
+  tareas, mesas, perfiles, auditoría, configuración privada, lista blanca,
+  parámetros e intentos), ni de `v_resumen_presupuesto`;
+- `anon` sí lee `v_configuracion_publica`, `v_secciones_publicas` y sólo los
+  medios publicados;
+- una cuenta creada con la clave anónima no lee nada y no puede ascenderse;
+- `obtener_invitacion` con un token devuelve **sólo** ese grupo;
+- `registrar_confirmacion` con un `invitado_id` de otro grupo devuelve `RSV04`
+  y **no deja escrito nada**, y la confirmación de la víctima sigue vigente;
+- fuera de plazo devuelve `RSV03`; superado el cupo de intentos, `RSV02`;
+- un `lector` autenticado no escribe en ninguna tabla.
+
+---
+
+## 7. Datos de desarrollo
+
+[`supabase/seed.sql`](../supabase/seed.sql) carga un juego mínimo, marcado con el
+prefijo `(DES)` y con correos en el dominio reservado `.test`. Si en una pantalla
+aparece «(DES)», está leyendo del seed.
+
+Incluye dos grupos con **token conocido** para que la suite E2E pueda visitar
+`/rsvp/<token>` sin capturar nada:
+
+```
+Familia Uno  ->  desarrollo-familia-uno-000000
+Familia Dos  ->  desarrollo-familia-dos-000000
+```
+
+Que estén versionados es seguro precisamente porque este fichero nunca se
+ejecuta contra producción: allí el token en claro sólo existe en el momento de
+emitirlo.
+
+El seed levanta temporalmente `force row level security` durante la carga —
+`force` también le aplica al propietario, que es el rol con el que corre— y la
+vuelve a poner al final, comprobando antes de terminar que ninguna tabla se ha
+quedado sin RLS. La alternativa habría sido escribir una política para
+`postgres`, es decir, abrir en producción un agujero por comodidad del entorno
+local.

--- a/scripts/probar-bbdd.sh
+++ b/scripts/probar-bbdd.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# BODA-14 · Prueba las migraciones y la seguridad contra un Postgres REAL.
+#
+# No hay mocks: un mock de RLS no demuestra absolutamente nada. Este script
+# levanta una base de datos desechable, simula lo que Supabase aporta
+# (esquema auth, roles anon/authenticated/service_role, pgcrypto en el esquema
+# extensions), aplica todas las migraciones en orden y ejecuta la suite de
+# seguridad.
+#
+# Sale con error si alguna migración falla o si alguna comprobación imprime
+# FALLA, así que sirve tal cual como paso de CI.
+#
+# Uso:  ./scripts/probar-bbdd.sh
+
+set -euo pipefail
+
+PUERTO="${PGPUERTO_PRUEBA:-5433}"
+DATOS="${PGDATOS_PRUEBA:-/var/lib/postgresql/pruebaboda}"
+BASE=boda_prueba
+RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | sort -V | tail -1 || true)"
+[ -n "$BIN" ] && export PATH="$BIN:$PATH"
+
+command -v initdb >/dev/null || {
+  echo "No hay PostgreSQL instalado. Instala postgresql-16 o exporta PATH."
+  exit 1
+}
+
+comoPostgres() { su postgres -c "PATH=$PATH $*"; }
+
+# --- Servidor desechable ----------------------------------------------------
+
+if ! comoPostgres "pg_ctl -D $DATOS status" >/dev/null 2>&1; then
+  echo "▸ Levantando PostgreSQL de pruebas en el puerto $PUERTO"
+  rm -rf "$DATOS"
+  mkdir -p "$DATOS"
+  chown -R postgres:postgres "$(dirname "$DATOS")"
+  chmod 700 "$DATOS"
+  comoPostgres "initdb -D $DATOS -A trust -E UTF8 --locale=C" >/dev/null
+  comoPostgres "pg_ctl -D $DATOS -o '-p $PUERTO -k /tmp' -l $DATOS/log start" >/dev/null
+  sleep 2
+fi
+
+psqlp() { comoPostgres "psql -h /tmp -p $PUERTO $*"; }
+
+echo "▸ Recreando la base $BASE"
+psqlp "-q -c 'drop database if exists $BASE;' -c 'create database $BASE;'" >/dev/null
+
+# --- Lo que Supabase aporta y las migraciones dan por hecho ------------------
+
+echo "▸ Simulando el entorno de Supabase"
+TMP_PREVIO=$(mktemp /tmp/boda-previo-XXXX.sql)
+cat > "$TMP_PREVIO" <<'SQL'
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
+
+do $$ begin
+  if not exists (select from pg_roles where rolname = 'anon')
+    then create role anon nologin noinherit; end if;
+  if not exists (select from pg_roles where rolname = 'authenticated')
+    then create role authenticated nologin noinherit; end if;
+  if not exists (select from pg_roles where rolname = 'service_role')
+    then create role service_role nologin noinherit bypassrls; end if;
+end $$;
+
+create schema if not exists auth;
+grant usage on schema auth, extensions to anon, authenticated, service_role;
+
+create table if not exists auth.users (
+  id                 uuid primary key default extensions.gen_random_uuid(),
+  email              text,
+  raw_user_meta_data jsonb default '{}'::jsonb
+);
+grant select on auth.users to authenticated, service_role;
+
+create or replace function auth.uid() returns uuid language sql stable as $$
+  select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid
+$$;
+
+create or replace function auth.role() returns text language sql stable as $$
+  select nullif(current_setting('request.jwt.claim.role', true), '')
+$$;
+
+create or replace function auth.jwt() returns jsonb language sql stable as $$
+  select coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb, '{}'::jsonb)
+$$;
+SQL
+chmod a+r "$TMP_PREVIO"
+psqlp "-d $BASE -q -v ON_ERROR_STOP=1 -f $TMP_PREVIO"
+rm -f "$TMP_PREVIO"
+
+# --- Migraciones ------------------------------------------------------------
+
+echo "▸ Aplicando migraciones"
+COPIA=$(mktemp -d /tmp/boda-mig-XXXX)
+cp "$RAIZ"/supabase/migrations/*.sql "$COPIA/"
+chmod -R a+rX "$COPIA"
+
+for fichero in $(ls "$COPIA"/*.sql | sort); do
+  nombre=$(basename "$fichero")
+  if psqlp "-d $BASE -q -v ON_ERROR_STOP=1 -f $fichero" 2>&1 | grep -q 'ERROR'; then
+    echo "  ✗ $nombre"
+    psqlp "-d $BASE -v ON_ERROR_STOP=1 -f $fichero" 2>&1 | grep -A3 'ERROR' | head -12
+    rm -rf "$COPIA"
+    exit 1
+  fi
+  echo "  ✓ $nombre"
+done
+rm -rf "$COPIA"
+
+# --- Datos mínimos para poder probar el flujo -------------------------------
+
+echo "▸ Preparando el primer propietario"
+TMP_ARRANQUE=$(mktemp /tmp/boda-arranque-XXXX.sql)
+cat > "$TMP_ARRANQUE" <<'SQL'
+insert into auth.users (id, email)
+values ('11111111-1111-1111-1111-111111111111', 'novios@ejemplo.es')
+on conflict (id) do nothing;
+
+begin;
+  set local role service_role;
+  select public.designar_primer_propietario(
+    '11111111-1111-1111-1111-111111111111', 'Propietario de pruebas'
+  );
+commit;
+SQL
+chmod a+r "$TMP_ARRANQUE"
+psqlp "-d $BASE -q -v ON_ERROR_STOP=1 -f $TMP_ARRANQUE" >/dev/null
+rm -f "$TMP_ARRANQUE"
+
+# --- Suite de seguridad -----------------------------------------------------
+
+SUITE=$(mktemp /tmp/boda-suite-XXXX.sql)
+{
+  echo "set request.jwt.claim.sub = '11111111-1111-1111-1111-111111111111';"
+  cat "$RAIZ/supabase/tests/seguridad.sql"
+} > "$SUITE"
+chmod a+r "$SUITE"
+
+SALIDA=$(psqlp "-d $BASE -f $SUITE" 2>&1 || true)
+rm -f "$SUITE"
+
+echo "$SALIDA" | { grep -E '(OK|FALLA) ' || true; } | sed -E 's/^.*(NOTICE|WARNING):  /  /'
+echo ""
+
+if echo "$SALIDA" | grep -q 'FALLA'; then
+  echo "✗ Hay comprobaciones de seguridad en rojo."
+  exit 1
+fi
+
+CORRECTAS=$(echo "$SALIDA" | { grep -c 'OK  ' || true; })
+echo "✓ $CORRECTAS comprobaciones de seguridad en verde."

--- a/supabase/migrations/20260803090000_base.sql
+++ b/supabase/migrations/20260803090000_base.sql
@@ -1,0 +1,1101 @@
+-- ============================================================================
+-- 20260803090000_base.sql
+-- Tickets: BODA-10 (esquema base y convenciones) · BODA-11 (configuración)
+-- Motor:   PostgreSQL 17 (Supabase)
+--
+-- Qué hace este fichero:
+--   1.  Cierra el esquema `public`: revoca los privilegios por defecto que
+--       Supabase concede a `anon` y `authenticated` sobre todo objeto nuevo.
+--   2.  Instala las extensiones en su propio esquema.
+--   3.  Crea las utilidades compartidas por TODO el esquema: sello de
+--       `actualizado_en`, normalización de correo, búsqueda sin acentos y el
+--       creador idempotente de enumerados.
+--   4.  Registro de auditoría con redacción de campos sensibles.
+--   5.  Perfiles ligados a `auth.users` + lista blanca de acceso al panel.
+--   6.  Configuración de la boda: parte pública y parte privada, separadas.
+--   7.  Catálogo de secciones de la landing (visibilidad y orden).
+--
+-- Invariantes que este fichero deja establecidos y que el resto respeta:
+--   · Toda tabla lleva `id uuid`, `creado_en`, `actualizado_en` y RLS activado
+--     en la sentencia INMEDIATAMENTE posterior al CREATE TABLE. Nunca existe
+--     una tabla, ni un instante, sin RLS.
+--   · Una sola función de sello temporal: `public.fijar_actualizado_en()`.
+--   · Nombres de restricción `<tabla>_<detalle>`; índices `<tabla>_<detalle>_idx`;
+--     claves foráneas `<tabla>_<columna>_fk`.
+--   · Ni un identificador en inglés.
+--
+-- Las políticas RLS viven en 20260803090400_rls.sql. Hasta entonces, RLS
+-- activado y sin políticas = denegado para todos, que es el estado seguro.
+-- Rollback: supabase/migrations/rollback/20260803090000_base.sql
+-- ============================================================================
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- 0. Roles de la API
+--    En Supabase ya existen. Se crean aquí sólo para que la migración también
+--    corra sobre un PostgreSQL limpio (CI, contenedor de pruebas).
+-- ----------------------------------------------------------------------------
+
+do $$
+begin
+  if not exists (select 1 from pg_catalog.pg_roles where rolname = 'anon') then
+    create role anon nologin noinherit;
+  end if;
+  if not exists (select 1 from pg_catalog.pg_roles where rolname = 'authenticated') then
+    create role authenticated nologin noinherit;
+  end if;
+end;
+$$;
+
+
+-- ----------------------------------------------------------------------------
+-- 1. Cierre del esquema público
+--
+--    Supabase deja puesto `alter default privileges ... grant all on tables to
+--    anon, authenticated`. Eso significa que en el mismo instante del CREATE
+--    TABLE, `anon` ya tiene SELECT/INSERT/UPDATE/DELETE/TRUNCATE sobre la tabla
+--    y lo único que lo tapa es RLS —que además no se aplica a TRUNCATE—.
+--    Se revoca ANTES de crear la primera tabla: así ninguna tabla de este
+--    proyecto nace concedida. Los permisos se devuelven uno a uno, y sólo los
+--    imprescindibles, en la migración de RLS.
+-- ----------------------------------------------------------------------------
+
+do $$
+begin
+  execute 'alter default privileges in schema public revoke all on tables    from anon, authenticated';
+  execute 'alter default privileges in schema public revoke all on sequences from anon, authenticated';
+  execute 'alter default privileges in schema public revoke all on functions from anon, authenticated';
+  execute 'alter default privileges in schema public revoke execute on functions from public';
+
+  -- Las default privileges son por rol creador: si las migraciones las aplica
+  -- `postgres` (lo habitual en Supabase) hay que desactivarlas también ahí.
+  if exists (select 1 from pg_catalog.pg_roles where rolname = 'postgres')
+     and pg_catalog.pg_has_role(current_user, 'postgres', 'member') then
+    execute 'alter default privileges for role postgres in schema public revoke all on tables    from anon, authenticated';
+    execute 'alter default privileges for role postgres in schema public revoke all on sequences from anon, authenticated';
+    execute 'alter default privileges for role postgres in schema public revoke all on functions from anon, authenticated';
+  end if;
+exception
+  when insufficient_privilege then
+    raise warning 'No se han podido revocar las default privileges del esquema public: %', sqlerrm;
+end;
+$$;
+
+revoke all on all tables    in schema public from anon, authenticated;
+revoke all on all sequences in schema public from anon, authenticated;
+
+-- El esquema hay que poder recorrerlo para llegar a lo que sí se conceda luego.
+grant usage on schema public to anon, authenticated;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Extensiones
+--    En el esquema `extensions` (convención de Supabase) para no contaminar
+--    `public`, que es el que publica la API.
+-- ----------------------------------------------------------------------------
+
+create schema if not exists extensions;
+grant usage on schema extensions to anon, authenticated;
+
+-- `gen_random_bytes` y `digest`: tokens de invitación con entropía criptográfica
+-- y su huella SHA-256. (`gen_random_uuid` ya es nativo en PostgreSQL 17.)
+create extension if not exists pgcrypto with schema extensions;
+
+-- Búsqueda de invitados tolerante a tildes y a erratas ("Nuñez" halla "Núñez").
+create extension if not exists unaccent with schema extensions;
+create extension if not exists pg_trgm  with schema extensions;
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Utilidades compartidas
+-- ----------------------------------------------------------------------------
+
+-- 3.1 Creación idempotente de enumerados -------------------------------------
+-- PostgreSQL no admite `create type if not exists` y las migraciones tienen que
+-- poder reaplicarse tras un fallo a mitad. En vez de repetir un bloque DO por
+-- cada enumerado en cuatro ficheros, se centraliza aquí.
+
+create or replace function public.asegurar_enum(p_nombre text, p_valores text[])
+returns void
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if exists (
+    select 1
+      from pg_catalog.pg_type t
+     where t.typname = p_nombre
+       and t.typnamespace = 'public'::regnamespace
+  ) then
+    return;
+  end if;
+
+  execute format(
+    'create type public.%I as enum (%s)',
+    p_nombre,
+    (select string_agg(quote_literal(v), ', ' order by o)
+       from unnest(p_valores) with ordinality as u(v, o))
+  );
+end;
+$$;
+
+comment on function public.asegurar_enum(text, text[]) is
+  'Crea un enumerado en `public` sólo si no existe. Hace reaplicables las '
+  'migraciones: un `supabase db push` que muera a mitad se puede reintentar sin '
+  'limpiar tipos a mano en producción, que es justo el momento en el que no se '
+  'quiere improvisar SQL. El orden de los valores se respeta porque define el '
+  'operador `<` del tipo, y con él el ORDER BY de los listados del panel.';
+
+
+-- 3.2 Sello de `actualizado_en` ----------------------------------------------
+-- UNA sola función para todo el esquema. Todos los triggers que la invocan
+-- llevan el mismo `when (old.* is distinct from new.*)`, de modo que la columna
+-- significa exactamente lo mismo en las 20 tablas: "cuándo cambió algo de
+-- verdad". Un UPDATE idempotente (un formulario que reenvía el objeto entero)
+-- no mueve la fecha en ninguna tabla.
+
+create or replace function public.fijar_actualizado_en()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  new.actualizado_en := now();
+  return new;
+end;
+$$;
+
+comment on function public.fijar_actualizado_en() is
+  'Trigger BEFORE UPDATE genérico: sella `actualizado_en` en el servidor. La '
+  'marca de tiempo nunca se confía al cliente, que puede mentir o traer el reloj '
+  'desajustado. Es la ÚNICA función de sello del esquema.';
+
+
+-- 3.3 Correo electrónico ------------------------------------------------------
+-- Se guarda como `text` normalizado a minúsculas por trigger, no como `citext`:
+-- así la comparación es la misma en las cinco tablas que guardan correo, no hace
+-- falta recordar dónde toca `lower()` y las funciones con `search_path = ''` no
+-- dependen de que los operadores de una extensión estén en el path.
+
+create or replace function public.es_correo_valido(p_correo text)
+returns boolean
+language sql
+immutable
+parallel safe
+set search_path = ''
+as $$
+  select p_correo is null
+      or p_correo ~ '^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]{2,}$';
+$$;
+
+comment on function public.es_correo_valido(text) is
+  'Forma mínima de un correo, en un solo sitio. Se usa desde los CHECK de todas '
+  'las tablas que guardan correo para que la regla no se escriba cinco veces '
+  'con cinco expresiones regulares distintas.';
+
+create or replace function public.normalizar_correo()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_columna text := tg_argv[0];
+  v_valor   text;
+begin
+  v_valor := nullif(btrim(lower(to_jsonb(new) ->> v_columna)), '');
+  new := jsonb_populate_record(new, jsonb_build_object(v_columna, v_valor));
+  return new;
+end;
+$$;
+
+comment on function public.normalizar_correo() is
+  'Trigger BEFORE INSERT/UPDATE: recorta y pasa a minúsculas la columna de correo '
+  'que se le indique como argumento. Evita que "Ana@X.com" y "ana@x.com" entren '
+  'como dos personas distintas al importar un CSV dos veces.';
+
+
+-- 3.4 Búsqueda sin acentos ----------------------------------------------------
+-- `unaccent()` no es IMMUTABLE (depende del diccionario activo) y por eso no se
+-- puede indexar tal cual. La forma con `regdictionary` sí lo es: fija el
+-- diccionario en la propia llamada.
+
+create or replace function public.sin_acentos(p_texto text)
+returns text
+language sql
+immutable
+strict
+parallel safe
+set search_path = ''
+as $$
+  select extensions.unaccent('extensions.unaccent'::regdictionary, p_texto);
+$$;
+
+comment on function public.sin_acentos(text) is
+  'Versión indexable de `unaccent`. Es la base de los índices trigrama del '
+  'buscador del panel: sin ella, "Nuñez" no encuentra a "Núñez" y cualquier '
+  'intento de indexar `unaccent(...)` falla con "must be marked IMMUTABLE".';
+
+
+-- 3.5 Rutas de Supabase Storage ----------------------------------------------
+
+create or replace function public.es_ruta_almacenamiento_valida(p_ruta text)
+returns boolean
+language sql
+immutable
+parallel safe
+set search_path = ''
+as $$
+  select p_ruta is not null
+     and p_ruta ~ '^[A-Za-z0-9][A-Za-z0-9._/-]{2,254}$'
+     and p_ruta !~ '\.\.';
+$$;
+
+comment on function public.es_ruta_almacenamiento_valida(text) is
+  'Ruta relativa dentro del bucket: sin barra inicial y sin `..`. Las políticas '
+  'de Storage se apoyan en el prefijo de carpeta, así que una ruta absoluta o con '
+  'travesía apuntaría fuera del prefijo esperado. Admite mayúsculas a propósito: '
+  '`galeria/DSC_0001.JPG` es una clave perfectamente legal y habitual.';
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Registro de auditoría
+-- ----------------------------------------------------------------------------
+
+select public.asegurar_enum('operacion_auditoria',
+  array['insercion', 'actualizacion', 'borrado']);
+
+comment on type public.operacion_auditoria is
+  'Tipo de operación registrada. En castellano para volcarlo directamente en la '
+  'interfaz sin tabla de traducción.';
+
+
+-- 4.1 Qué campos NO se copian a la bitácora ----------------------------------
+-- La auditoría guarda la fila entera en un `jsonb`. RLS filtra filas y los GRANT
+-- filtran columnas, pero un jsonb es una sola columna opaca: sin esta lista, la
+-- bitácora sería un almacén paralelo de secretos que anula toda restricción de
+-- columna aplicada en origen. Es una TABLA y no una lista dentro de la función
+-- porque es configuración: añadir un campo sensible no puede exigir migración.
+
+create table if not exists public.campos_auditoria_redactados (
+  tabla      text not null,
+  columna    text not null,
+  motivo     text,
+  creado_en  timestamptz not null default now(),
+
+  constraint campos_auditoria_redactados_pk primary key (tabla, columna),
+  constraint campos_auditoria_redactados_tabla_no_vacia
+    check (length(btrim(tabla)) > 0),
+  constraint campos_auditoria_redactados_columna_no_vacia
+    check (length(btrim(columna)) > 0)
+);
+alter table public.campos_auditoria_redactados enable row level security;
+
+comment on table public.campos_auditoria_redactados is
+  'Columnas cuyo valor se sustituye por un marcador antes de escribirlo en '
+  '`registro_auditoria`. El cambio se sigue detectando (aparece en '
+  '`campos_modificados`), pero el valor no queda almacenado por duplicado.';
+
+insert into public.campos_auditoria_redactados (tabla, columna, motivo) values
+  ('grupos_invitacion',    'huella_token',        'Credencial de acceso al RSVP.'),
+  ('configuracion_privada','iban_regalos',      'Dato bancario de los novios.'),
+  ('pagos',                'justificante_ruta', 'Ruta a un justificante bancario.')
+on conflict (tabla, columna) do nothing;
+
+
+-- 4.2 La bitácora ------------------------------------------------------------
+
+create table if not exists public.registro_auditoria (
+  id                  uuid not null default gen_random_uuid(),
+
+  esquema             text not null default 'public',
+  tabla               text not null,
+  registro_id         uuid,
+  operacion           public.operacion_auditoria not null,
+
+  datos_anteriores    jsonb,
+  datos_nuevos        jsonb,
+  campos_modificados  text[] not null default '{}',
+
+  usuario_id          uuid,
+  usuario_correo      text,
+  origen_cambio       text not null default 'panel',
+
+  creado_en           timestamptz not null default now(),
+
+  constraint registro_auditoria_pk primary key (id),
+  constraint registro_auditoria_usuario_id_fk
+    foreign key (usuario_id) references auth.users (id) on delete set null,
+
+  constraint registro_auditoria_tabla_no_vacia
+    check (length(btrim(tabla)) > 0),
+
+  -- Coherencia de la carga útil: una inserción no puede traer estado anterior,
+  -- un borrado no puede traer estado nuevo.
+  constraint registro_auditoria_carga_coherente check (
+    (operacion = 'insercion'     and datos_anteriores is null     and datos_nuevos is not null) or
+    (operacion = 'actualizacion' and datos_anteriores is not null and datos_nuevos is not null) or
+    (operacion = 'borrado'       and datos_anteriores is not null and datos_nuevos is null)
+  )
+);
+alter table public.registro_auditoria enable row level security;
+
+comment on table public.registro_auditoria is
+  'Bitácora de cambios: quién tocó qué, cuándo y con qué valores. De sólo '
+  'inserción: las políticas de BODA-14 no conceden UPDATE ni DELETE a nadie, y '
+  'sólo escribe en ella el trigger SECURITY DEFINER. Un histórico que se puede '
+  'editar no es un histórico. La lectura está reservada a `propietario`.';
+
+comment on column public.registro_auditoria.tabla is
+  'Nombre de la tabla auditada. Texto y no `regclass`: si la tabla se renombra o '
+  'se borra, el histórico debe seguir contando lo que pasó entonces.';
+comment on column public.registro_auditoria.datos_anteriores is
+  'Fila completa antes del cambio, con los campos sensibles redactados según '
+  '`campos_auditoria_redactados`. Permite reconstruir un borrado accidental de '
+  'invitados a pocas semanas de la boda.';
+comment on column public.registro_auditoria.campos_modificados is
+  'Columnas realmente distintas en un UPDATE, excluida `actualizado_en`. Se '
+  'calcula ANTES de redactar, así que un cambio de token se ve aunque su valor '
+  'no se guarde.';
+comment on column public.registro_auditoria.usuario_id is
+  'Autor del cambio. ON DELETE SET NULL, jamás CASCADE: borrar una cuenta no '
+  'puede borrar la traza de lo que esa cuenta hizo.';
+comment on column public.registro_auditoria.usuario_correo is
+  'Copia congelada del correo en el momento del cambio. Sobrevive al borrado de '
+  'la cuenta y hace legible el histórico sin cruzar con `auth.users`.';
+comment on column public.registro_auditoria.origen_cambio is
+  'De dónde vino la escritura: `panel`, `rsvp:<grupo>` cuando la hizo un invitado '
+  'por el enlace público, o `sistema` en migraciones y tareas programadas. Sin '
+  'esto, todo lo que entra por una función SECURITY DEFINER llamada con la clave '
+  'anónima aparecería como cambio del sistema, porque ahí `auth.uid()` es NULL.';
+
+-- "Histórico de este invitado, del más reciente al más antiguo".
+create index if not exists registro_auditoria_registro_idx
+  on public.registro_auditoria (tabla, registro_id, creado_en desc);
+
+-- Índice de la clave foránea: sin él, borrar una cuenta escanea la tabla entera.
+create index if not exists registro_auditoria_usuario_id_idx
+  on public.registro_auditoria (usuario_id);
+
+-- Vista cronológica del panel ("actividad reciente").
+create index if not exists registro_auditoria_creado_en_idx
+  on public.registro_auditoria (creado_en desc);
+
+
+-- 4.3 Redacción y trigger genérico -------------------------------------------
+
+create or replace function public.redactar_campos_auditados(p_tabla text, p_datos jsonb)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_columna   text;
+  v_resultado jsonb := p_datos;
+begin
+  if p_datos is null then
+    return null;
+  end if;
+
+  for v_columna in
+    select r.columna
+      from public.campos_auditoria_redactados as r
+     where r.tabla = p_tabla
+  loop
+    if v_resultado ? v_columna then
+      v_resultado := jsonb_set(v_resultado, array[v_columna], '"[redactado]"'::jsonb);
+    end if;
+  end loop;
+
+  return v_resultado;
+end;
+$$;
+
+comment on function public.redactar_campos_auditados(text, jsonb) is
+  'Sustituye por un marcador los valores de las columnas declaradas sensibles. '
+  'La clave se conserva para que el histórico siga siendo legible ("aquí cambió '
+  'el token"), pero el secreto no se almacena dos veces.';
+
+create or replace function public.registrar_auditoria()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_operacion          public.operacion_auditoria;
+  v_datos_anteriores   jsonb;
+  v_datos_nuevos       jsonb;
+  v_campos_modificados text[] := '{}';
+  v_registro_id        uuid;
+  v_origen             text;
+begin
+  case tg_op
+    when 'INSERT' then
+      v_operacion := 'insercion';
+      v_datos_nuevos := to_jsonb(new);
+    when 'UPDATE' then
+      v_operacion := 'actualizacion';
+      v_datos_anteriores := to_jsonb(old);
+      v_datos_nuevos := to_jsonb(new);
+    when 'DELETE' then
+      v_operacion := 'borrado';
+      v_datos_anteriores := to_jsonb(old);
+    else
+      raise exception 'Operación no auditable: %', tg_op;
+  end case;
+
+  if tg_op = 'UPDATE' then
+    -- Se calcula sobre los datos crudos, antes de redactar: un cambio de token
+    -- tiene que constar aunque su valor no se guarde.
+    select coalesce(array_agg(cambio.campo order by cambio.campo), '{}')
+      into v_campos_modificados
+      from jsonb_each(v_datos_nuevos) as cambio(campo, valor)
+     where cambio.campo <> 'actualizado_en'
+       and cambio.valor is distinct from v_datos_anteriores -> cambio.campo;
+
+    -- Un UPDATE que no cambia ningún dato de negocio no es un hecho auditable.
+    if cardinality(v_campos_modificados) = 0 then
+      return null;
+    end if;
+  end if;
+
+  v_registro_id := (coalesce(v_datos_nuevos, v_datos_anteriores) ->> 'id')::uuid;
+
+  v_origen := coalesce(
+    nullif(btrim(current_setting('boda.origen_cambio', true)), ''),
+    case when auth.uid() is null then 'sistema' else 'panel' end
+  );
+
+  insert into public.registro_auditoria (
+    esquema, tabla, registro_id, operacion,
+    datos_anteriores, datos_nuevos, campos_modificados,
+    usuario_id, usuario_correo, origen_cambio
+  )
+  values (
+    tg_table_schema,
+    tg_table_name,
+    v_registro_id,
+    v_operacion,
+    public.redactar_campos_auditados(tg_table_name, v_datos_anteriores),
+    public.redactar_campos_auditados(tg_table_name, v_datos_nuevos),
+    v_campos_modificados,
+    auth.uid(),
+    auth.jwt() ->> 'email',
+    v_origen
+  );
+
+  return null;  -- Trigger AFTER: el valor de retorno se ignora.
+end;
+$$;
+
+comment on function public.registrar_auditoria() is
+  'Trigger AFTER INSERT/UPDATE/DELETE genérico. Se cuelga de TODAS las tablas de '
+  'dominio en 20260803090300_organizacion.sql, cuando ya existen todas. '
+  'SECURITY DEFINER a propósito: quien edita una tabla auditada no necesita —ni '
+  'debe tener— permiso de escritura sobre el histórico, así nadie puede fabricar '
+  'ni suprimir entradas desde la API. Los triggers de fila también se disparan en '
+  'los borrados en cascada, de modo que la traza queda completa.';
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Acceso al panel: lista blanca y perfiles
+-- ----------------------------------------------------------------------------
+
+select public.asegurar_enum('rol_usuario',
+  array['propietario', 'editor', 'lector']);
+
+comment on type public.rol_usuario is
+  'Rol de un colaborador del panel. `propietario`: los novios, control total '
+  'incluida la gestión de usuarios. `editor`: gestiona datos de la boda pero no '
+  'usuarios. `lector`: sólo lectura (wedding planner, familiares que ayudan).';
+
+
+-- 5.1 Lista blanca ------------------------------------------------------------
+-- Sin esto, la única defensa contra "cualquiera con la clave anónima se fabrica
+-- una cuenta" sería desactivar el registro con una casilla del panel de
+-- Supabase: una casilla que nadie versiona, nadie testea y cualquiera puede
+-- volver a activar. La regla 4 del proyecto dice que la seguridad vive en la
+-- base de datos, así que vive aquí.
+
+create table if not exists public.invitaciones_panel (
+  correo_electronico  text not null,
+  rol                 public.rol_usuario not null default 'lector',
+  invitado_por        uuid,
+  creado_en           timestamptz not null default now(),
+  actualizado_en      timestamptz not null default now(),
+
+  constraint invitaciones_panel_pk primary key (correo_electronico),
+  constraint invitaciones_panel_correo_valido
+    check (public.es_correo_valido(correo_electronico)),
+  constraint invitaciones_panel_correo_normalizado
+    check (correo_electronico = lower(btrim(correo_electronico)))
+);
+alter table public.invitaciones_panel enable row level security;
+
+comment on table public.invitaciones_panel is
+  'Correos autorizados a entrar en el panel, con el rol que se les concede. Un '
+  'alta en `auth.users` cuyo correo NO esté aquí genera un perfil inactivo y sin '
+  'permisos: registrarse no concede absolutamente nada. Sólo `propietario` la '
+  'gestiona.';
+
+comment on column public.invitaciones_panel.rol is
+  'Rol que recibirá la persona al registrarse. Cambiarlo aquí NO altera un perfil '
+  'ya creado: para eso está el panel de usuarios, que pasa por '
+  '`proteger_privilegios_perfil()`.';
+
+create or replace trigger invitaciones_panel_normalizar_correo
+  before insert or update of correo_electronico on public.invitaciones_panel
+  for each row execute function public.normalizar_correo('correo_electronico');
+
+create or replace trigger invitaciones_panel_actualizado_en
+  before update on public.invitaciones_panel
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- 5.2 Perfiles ----------------------------------------------------------------
+
+create table if not exists public.perfiles (
+  id                  uuid not null default gen_random_uuid(),
+
+  usuario_id          uuid not null,
+
+  nombre_completo     text not null,
+  correo_electronico  text,
+  telefono            text,
+  url_avatar          text,
+
+  rol                 public.rol_usuario not null default 'lector',
+  activo              boolean not null default false,
+
+  creado_en           timestamptz not null default now(),
+  actualizado_en      timestamptz not null default now(),
+
+  constraint perfiles_pk primary key (id),
+  constraint perfiles_usuario_id_unico unique (usuario_id),
+  constraint perfiles_usuario_id_fk
+    foreign key (usuario_id) references auth.users (id) on delete cascade,
+
+  constraint perfiles_nombre_completo_longitud
+    check (length(btrim(nombre_completo)) between 1 and 120),
+  constraint perfiles_correo_valido
+    check (public.es_correo_valido(correo_electronico)),
+  constraint perfiles_telefono_formato
+    check (telefono is null or telefono ~ '^\+?[0-9][0-9 .()-]{5,19}$'),
+  constraint perfiles_url_avatar_formato
+    check (url_avatar is null or url_avatar ~ '^https?://')
+);
+alter table public.perfiles enable row level security;
+
+comment on table public.perfiles is
+  'Extiende `auth.users` con los datos de dominio de la aplicación. El esquema '
+  '`auth` es propiedad de Supabase y no se toca: rol, nombre visible y alta/baja '
+  'viven aquí.';
+
+comment on column public.perfiles.usuario_id is
+  'Cuenta de `auth.users` correspondiente. UNIQUE: un perfil por cuenta. '
+  'ON DELETE CASCADE porque un perfil sin cuenta no puede iniciar sesión; la '
+  'traza de sus cambios queda a salvo en `registro_auditoria`, que usa SET NULL.';
+comment on column public.perfiles.correo_electronico is
+  'Copia desnormalizada del correo de `auth.users`, mantenida por el trigger '
+  '`auth_users_sincronizar_perfil`. Existe para listar colaboradores sin consultar '
+  'el esquema `auth` en cada pantalla; la fuente de verdad sigue siendo '
+  '`auth.users`, que ya garantiza su unicidad. Por eso aquí el índice NO es único: '
+  'un choque de correo abortaría el alta de la cuenta con un 500 opaco.';
+comment on column public.perfiles.rol is
+  'Autorización real del panel; la interfaz sólo la refleja, las políticas RLS la '
+  'aplican. Sólo un `propietario` puede cambiarlo, y lo impide un trigger además '
+  'de la política.';
+comment on column public.perfiles.activo is
+  'Por defecto FALSE. Registrarse no da acceso a nada: hace falta estar en '
+  '`invitaciones_panel`. Permite además retirar el acceso a un colaborador sin '
+  'borrar su cuenta y, con ella, la legibilidad del histórico.';
+
+create index if not exists perfiles_correo_electronico_idx
+  on public.perfiles (correo_electronico)
+  where correo_electronico is not null;
+
+-- Filtro habitual: "colaboradores activos que pueden editar".
+create index if not exists perfiles_rol_idx
+  on public.perfiles (rol)
+  where activo;
+
+-- Lo consultan las funciones de rol en cada evaluación de política.
+create index if not exists perfiles_usuario_activo_idx
+  on public.perfiles (usuario_id)
+  where activo;
+
+create or replace trigger perfiles_normalizar_correo
+  before insert or update of correo_electronico on public.perfiles
+  for each row execute function public.normalizar_correo('correo_electronico');
+
+create or replace trigger perfiles_actualizado_en
+  before update on public.perfiles
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- 5.3 Congelar los campos de autorización ------------------------------------
+-- `rol` y `activo` viven en la misma fila que el usuario edita para cambiarse el
+-- nombre. Sin este trigger, "editar mi perfil" y "hacerme propietario" son la
+-- misma operación: es la escalada de privilegios clásica de Supabase. La política
+-- RLS lo prohíbe también (cinturón y tirantes), pero una defensa que sólo vive en
+-- una política se cae el día que alguien reescribe la política.
+
+create or replace function public.proteger_privilegios_perfil()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if (new.rol, new.activo, new.usuario_id)
+     is distinct from (old.rol, old.activo, old.usuario_id)
+     and not exists (
+       select 1
+         from public.perfiles as p
+        where p.usuario_id = auth.uid()
+          and p.rol = 'propietario'
+          and p.activo
+     )
+  then
+    raise exception 'PRF01'
+      using errcode  = 'insufficient_privilege',
+            detail   = format('perfil=%s', old.id),
+            hint     = 'Sólo un propietario puede cambiar el rol o el alta de un perfil.';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.proteger_privilegios_perfil() is
+  'Impide que nadie se ascienda a sí mismo. Lanza el código estable PRF01: el '
+  'texto visible vive en content/copy.es.json, no incrustado en la base de datos, '
+  'y el identificador afectado viaja en DETAIL, que PostgREST no devuelve al '
+  'cliente.';
+
+create or replace trigger perfiles_proteger_privilegios
+  before update on public.perfiles
+  for each row execute function public.proteger_privilegios_perfil();
+
+
+-- 5.4 Alta automática del perfil ---------------------------------------------
+
+create or replace function public.sincronizar_perfil_desde_auth()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_correo    text := nullif(btrim(lower(new.email)), '');
+  v_rol       public.rol_usuario;
+  v_invitado  boolean := false;
+begin
+  select i.rol, true
+    into v_rol, v_invitado
+    from public.invitaciones_panel as i
+   where i.correo_electronico = v_correo;
+
+  insert into public.perfiles (usuario_id, correo_electronico, nombre_completo, rol, activo)
+  values (
+    new.id,
+    v_correo,
+    coalesce(
+      nullif(btrim(new.raw_user_meta_data ->> 'nombre_completo'), ''),
+      nullif(split_part(coalesce(v_correo, ''), '@', 1), ''),
+      'Colaborador ' || left(new.id::text, 8)
+    ),
+    coalesce(v_rol, 'lector'),
+    coalesce(v_invitado, false)
+  )
+  on conflict (usuario_id) do update
+    set correo_electronico = excluded.correo_electronico,
+        actualizado_en     = now();
+    -- Nunca `rol` ni `activo`: un cambio de correo no reevalúa privilegios.
+
+  return new;
+exception
+  when others then
+    -- Un fallo sincronizando el perfil no puede tumbar el alta de la cuenta:
+    -- el trigger es AFTER sobre auth.users y la excepción abortaría toda la
+    -- transacción de Supabase Auth, dejando un 500 opaco al usuario.
+    raise warning 'No se pudo sincronizar el perfil de %: %', new.id, sqlerrm;
+    return new;
+end;
+$$;
+
+comment on function public.sincronizar_perfil_desde_auth() is
+  'Crea el perfil en cuanto nace la cuenta y mantiene el correo al día. El rol y '
+  'el alta salen de `invitaciones_panel`: si el correo no está invitado, el perfil '
+  'nace `lector` e INACTIVO, y todas las funciones de rol exigen `activo`. '
+  'Registrarse con la clave anónima, por tanto, no da acceso a ningún dato. '
+  'SECURITY DEFINER porque el registro ocurre antes de que exista sesión alguna.';
+
+create or replace trigger auth_users_sincronizar_perfil
+  after insert or update of email on auth.users
+  for each row execute function public.sincronizar_perfil_desde_auth();
+
+
+-- ----------------------------------------------------------------------------
+-- 6. Configuración de la boda
+--
+--    Dos tablas y no una. La landing pública necesita leer fecha, nombres,
+--    lugar y coordenadas; RLS filtra filas, no columnas, y aquí sólo hay UNA
+--    fila. Mezclar en ella el techo de gasto y el aforo contratado convierte
+--    cualquier lectura pública en una filtración comercial frente a los propios
+--    proveedores, que también leen la landing. Se separa por diseño:
+--    `configuracion_boda` es publicable entera; `configuracion_privada` no sale
+--    del panel jamás.
+-- ----------------------------------------------------------------------------
+
+-- 6.1 Parte pública ----------------------------------------------------------
+
+create table if not exists public.configuracion_boda (
+  id                    uuid not null default gen_random_uuid(),
+
+  -- Centinela que materializa la restricción de fila única.
+  fila_unica            boolean not null default true,
+
+  nombre_novia          text not null,
+  nombre_novio          text not null,
+  hashtag               text,
+
+  fecha_hora_ceremonia  timestamptz not null,
+  fecha_hora_banquete   timestamptz,
+  zona_horaria          text not null default 'Europe/Madrid',
+  fecha_limite_rsvp     timestamptz not null,
+
+  lugar_ceremonia       text,
+  direccion_ceremonia   text,
+  latitud_ceremonia     numeric(9, 6),
+  longitud_ceremonia    numeric(9, 6),
+
+  lugar_banquete        text,
+  direccion_banquete    text,
+  latitud_banquete      numeric(9, 6),
+  longitud_banquete     numeric(9, 6),
+
+  correo_contacto       text,
+
+  moneda                text not null default 'EUR',
+  idioma_por_defecto    text not null default 'es',
+
+  creado_en             timestamptz not null default now(),
+  actualizado_en        timestamptz not null default now(),
+
+  constraint configuracion_boda_pk primary key (id),
+
+  -- Fila única declarativa: el centinela sólo admite `true` y además es UNIQUE,
+  -- luego como mucho puede existir una fila. Una restricción no se esquiva.
+  constraint configuracion_boda_fila_unica_valor check (fila_unica),
+  constraint configuracion_boda_fila_unica unique (fila_unica),
+
+  constraint configuracion_boda_nombre_novia_longitud
+    check (length(btrim(nombre_novia)) between 1 and 80),
+  constraint configuracion_boda_nombre_novio_longitud
+    check (length(btrim(nombre_novio)) between 1 and 80),
+  constraint configuracion_boda_hashtag_formato
+    check (hashtag is null or hashtag ~ '^#[[:alnum:]_]{1,60}$'),
+  constraint configuracion_boda_zona_horaria_no_vacia
+    check (length(btrim(zona_horaria)) > 0),
+  constraint configuracion_boda_moneda_iso_4217
+    check (moneda ~ '^[A-Z]{3}$'),
+  constraint configuracion_boda_idioma_bcp_47
+    check (idioma_por_defecto ~ '^[a-z]{2}(-[A-Z]{2})?$'),
+  constraint configuracion_boda_correo_contacto_valido
+    check (public.es_correo_valido(correo_contacto)),
+
+  constraint configuracion_boda_lugar_ceremonia_longitud
+    check (lugar_ceremonia is null or char_length(lugar_ceremonia) <= 160),
+  constraint configuracion_boda_lugar_banquete_longitud
+    check (lugar_banquete is null or char_length(lugar_banquete) <= 160),
+  constraint configuracion_boda_direccion_ceremonia_longitud
+    check (direccion_ceremonia is null or char_length(direccion_ceremonia) <= 300),
+  constraint configuracion_boda_direccion_banquete_longitud
+    check (direccion_banquete is null or char_length(direccion_banquete) <= 300),
+
+  constraint configuracion_boda_latitud_ceremonia_rango
+    check (latitud_ceremonia is null or latitud_ceremonia between -90 and 90),
+  constraint configuracion_boda_longitud_ceremonia_rango
+    check (longitud_ceremonia is null or longitud_ceremonia between -180 and 180),
+  constraint configuracion_boda_latitud_banquete_rango
+    check (latitud_banquete is null or latitud_banquete between -90 and 90),
+  constraint configuracion_boda_longitud_banquete_rango
+    check (longitud_banquete is null or longitud_banquete between -180 and 180),
+
+  -- Media coordenada no pinta un mapa: o las dos, o ninguna.
+  constraint configuracion_boda_coordenadas_ceremonia_completas
+    check ((latitud_ceremonia is null) = (longitud_ceremonia is null)),
+  constraint configuracion_boda_coordenadas_banquete_completas
+    check ((latitud_banquete is null) = (longitud_banquete is null)),
+
+  constraint configuracion_boda_banquete_posterior_a_ceremonia
+    check (fecha_hora_banquete is null or fecha_hora_banquete >= fecha_hora_ceremonia),
+  -- Confirmar asistencia el día de la boda no le sirve al catering.
+  constraint configuracion_boda_plazo_rsvp_anterior_a_boda
+    check (fecha_limite_rsvp < fecha_hora_ceremonia)
+);
+alter table public.configuracion_boda enable row level security;
+
+comment on table public.configuracion_boda is
+  'Fila única con los datos PÚBLICOS de la boda: los que la landing enseña. Es la '
+  'única fuente de verdad: ninguna fecha, nombre, lugar ni coordenada puede vivir '
+  'en una constante del código. Cambiar la boda de sitio o de día es un UPDATE, no '
+  'un despliegue. Toda la fila es publicable; lo que no lo es vive en '
+  '`configuracion_privada`.';
+
+comment on column public.configuracion_boda.fila_unica is
+  'Centinela de la fila única: CHECK obliga a `true` y UNIQUE impide una segunda '
+  'fila. No tiene significado de negocio y no se muestra.';
+comment on column public.configuracion_boda.fecha_hora_ceremonia is
+  'Instante exacto de inicio, con zona horaria. `timestamptz` y no `date` + `time` '
+  'para que la cuenta atrás sea correcta también para quien la abre desde otro '
+  'país o con el móvil en otro huso.';
+comment on column public.configuracion_boda.zona_horaria is
+  'Huso IANA con el que se formatean fechas en la interfaz y en los correos. Se '
+  'guarda aparte del instante porque "las 12:00 en la finca" es lo que hay que '
+  'enseñar, sea cual sea el navegador del invitado.';
+comment on column public.configuracion_boda.fecha_limite_rsvp is
+  'Cierre del plazo de confirmación. Lo aplica `public.registrar_confirmacion()` '
+  'comparando siempre contra `now()`, nunca contra una fecha que mande el cliente: '
+  'el límite se cumple en la base de datos, no ocultando un botón en el navegador.';
+comment on column public.configuracion_boda.latitud_ceremonia is
+  '`numeric` y no `float`: la precisión de una coordenada es exacta y no debe '
+  'depender del redondeo binario. Seis decimales ≈ 11 cm, de sobra para un mapa.';
+comment on column public.configuracion_boda.moneda is
+  'Código ISO 4217 con el que se formatea todo el presupuesto.';
+comment on column public.configuracion_boda.idioma_por_defecto is
+  'Idioma de la landing y de los correos cuando el grupo de invitación no indica '
+  'otro (BCP 47). Es también el idioma que `medios` exige en el texto alternativo.';
+
+
+-- 6.2 Parte privada ----------------------------------------------------------
+
+create table if not exists public.configuracion_privada (
+  id                    uuid not null default gen_random_uuid(),
+  fila_unica            boolean not null default true,
+
+  presupuesto_objetivo  numeric(12, 2),
+  aforo_maximo          integer,
+  telefono_contacto     text,
+  iban_regalos          text,
+  notas_privadas        text,
+
+  creado_en             timestamptz not null default now(),
+  actualizado_en        timestamptz not null default now(),
+
+  constraint configuracion_privada_pk primary key (id),
+  constraint configuracion_privada_fila_unica_valor check (fila_unica),
+  constraint configuracion_privada_fila_unica unique (fila_unica),
+
+  constraint configuracion_privada_presupuesto_no_negativo
+    check (presupuesto_objetivo is null or presupuesto_objetivo >= 0),
+  constraint configuracion_privada_aforo_maximo_rango
+    check (aforo_maximo is null or aforo_maximo between 1 and 5000),
+  constraint configuracion_privada_telefono_formato
+    check (telefono_contacto is null or telefono_contacto ~ '^\+?[0-9][0-9 .()-]{5,19}$'),
+  constraint configuracion_privada_iban_formato
+    check (iban_regalos is null or iban_regalos ~ '^[A-Z]{2}[0-9]{2}[A-Z0-9]{10,30}$'),
+  constraint configuracion_privada_notas_longitud
+    check (notas_privadas is null or char_length(notas_privadas) <= 4000)
+);
+alter table public.configuracion_privada enable row level security;
+
+comment on table public.configuracion_privada is
+  'Fila única con lo que NUNCA sale del panel: techo de gasto, aforo contratado, '
+  'teléfono de los novios y cuenta para los regalos. Separada de '
+  '`configuracion_boda` porque RLS filtra filas y no columnas: con una sola tabla, '
+  'la política de lectura pública que necesita la landing expondría la fila entera.';
+
+comment on column public.configuracion_privada.presupuesto_objetivo is
+  'Techo de gasto previsto, contra el que se compara `v_resumen_presupuesto`. '
+  'Información comercialmente sensible frente a los propios proveedores.';
+comment on column public.configuracion_privada.aforo_maximo is
+  'Tope de comensales que admite la finca. El panel avisa cuando las '
+  'confirmaciones se acercan al límite.';
+
+
+-- 6.3 La fila de configuración no se borra -----------------------------------
+-- La restricción de fila única garantiza COMO MUCHO una fila, nunca AL MENOS
+-- una. Sin esto, la cardinalidad real es 0..1: un DELETE desde el panel deja la
+-- landing sin fecha ni nombres, y como la regla 1 prohíbe valores por defecto en
+-- el código, la portada revienta en el primer render.
+
+create or replace function public.impedir_borrado_configuracion()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  raise exception 'CFG01'
+    using errcode = 'restrict_violation',
+          hint    = 'La configuración de la boda no se borra: se edita.';
+end;
+$$;
+
+comment on function public.impedir_borrado_configuracion() is
+  'Convierte la cardinalidad 0..1 de la configuración en exactamente 1. La fila '
+  'la siembra esta misma migración y ya no se puede eliminar.';
+
+create or replace trigger configuracion_boda_no_borrar
+  before delete on public.configuracion_boda
+  for each row execute function public.impedir_borrado_configuracion();
+
+create or replace trigger configuracion_privada_no_borrar
+  before delete on public.configuracion_privada
+  for each row execute function public.impedir_borrado_configuracion();
+
+create or replace trigger configuracion_boda_normalizar_correo
+  before insert or update of correo_contacto on public.configuracion_boda
+  for each row execute function public.normalizar_correo('correo_contacto');
+
+create or replace trigger configuracion_boda_actualizado_en
+  before update on public.configuracion_boda
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+create or replace trigger configuracion_privada_actualizado_en
+  before update on public.configuracion_privada
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+-- Semilla idempotente. Valores deliberadamente evidentes: la boda real se
+-- configura desde el panel, nunca desde una migración.
+insert into public.configuracion_boda (
+  nombre_novia, nombre_novio, fecha_hora_ceremonia, fecha_limite_rsvp
+)
+values (
+  'Por definir',
+  'Por definir',
+  date_trunc('day', now()) + interval '1 year',
+  date_trunc('day', now()) + interval '10 months'
+)
+on conflict (fila_unica) do nothing;
+
+insert into public.configuracion_privada (fila_unica)
+values (true)
+on conflict (fila_unica) do nothing;
+
+
+-- ----------------------------------------------------------------------------
+-- 7. Secciones de la landing
+--
+--    Un solo vocabulario. Antes esto vivía dos veces —un enumerado para las
+--    fotos y nueve columnas `mostrar_*` en la configuración— con nombres que no
+--    casaban entre sí ("lugar" frente a "ubicaciones", "regalo" frente a
+--    "regalos") y secciones que existían en una lista y no en la otra. Con dos
+--    listas paralelas, el frontend necesita un diccionario de traducción a mano:
+--    exactamente el hardcode que prohíbe la regla 1.
+-- ----------------------------------------------------------------------------
+
+select public.asegurar_enum('seccion_landing', array[
+  'portada',
+  'reserva_la_fecha',
+  'cuenta_atras',
+  'historia',
+  'galeria',
+  'ubicaciones',
+  'transporte',
+  'alojamiento',
+  'regalos',
+  'preguntas_frecuentes',
+  'rsvp'
+]);
+
+comment on type public.seccion_landing is
+  'Secciones que puede tener la landing. Es un enumerado y no texto libre porque '
+  'el frontend tiene un componente por sección: un valor desconocido no se sabría '
+  'pintar, y fallar en la base de datos es mejor que fallar en el render. Su '
+  'visibilidad y su orden se configuran en `public.secciones_landing`.';
+
+create table if not exists public.secciones_landing (
+  seccion         public.seccion_landing not null,
+  visible         boolean not null default true,
+  orden           smallint not null,
+  creado_en       timestamptz not null default now(),
+  actualizado_en  timestamptz not null default now(),
+
+  constraint secciones_landing_pk primary key (seccion),
+  constraint secciones_landing_orden_no_negativo check (orden >= 0),
+  -- DEFERRABLE para poder permutar dos secciones en una sola transacción sin
+  -- pasar por valores intermedios ficticios.
+  constraint secciones_landing_orden_unico unique (orden) deferrable initially deferred
+);
+alter table public.secciones_landing enable row level security;
+
+comment on table public.secciones_landing is
+  'Qué secciones se enseñan en la landing y en qué orden. Sustituye a las nueve '
+  'columnas `mostrar_*`: añadir una sección es una fila, no una migración de '
+  'esquema más un despliegue de frontend.';
+
+create index if not exists secciones_landing_visibles_idx
+  on public.secciones_landing (orden)
+  where visible;
+
+create or replace trigger secciones_landing_actualizado_en
+  before update on public.secciones_landing
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+insert into public.secciones_landing (seccion, visible, orden) values
+  ('portada',              true,   0),
+  ('cuenta_atras',         true,  10),
+  ('historia',             true,  20),
+  ('galeria',              true,  30),
+  ('ubicaciones',          true,  40),
+  ('transporte',           true,  50),
+  ('alojamiento',          true,  60),
+  ('preguntas_frecuentes', true,  70),
+  ('rsvp',                 true,  80),
+  ('reserva_la_fecha',     false, 90),
+  -- Apagada por defecto: la sección de regalos es delicada y se publica sólo
+  -- cuando los novios lo deciden expresamente.
+  ('regalos',              false, 100)
+on conflict (seccion) do nothing;
+
+
+-- ----------------------------------------------------------------------------
+-- 8. Cierre de permisos sobre las funciones creadas aquí
+--    `revoke ... from public` NO basta en Supabase: las default privileges
+--    conceden EXECUTE explícitamente a `anon` y `authenticated`, que no son el
+--    pseudo-rol PUBLIC. Hay que nombrarlos.
+-- ----------------------------------------------------------------------------
+
+revoke execute on function public.asegurar_enum(text, text[])                  from public, anon, authenticated;
+revoke execute on function public.fijar_actualizado_en()                       from public, anon, authenticated;
+revoke execute on function public.normalizar_correo()                          from public, anon, authenticated;
+revoke execute on function public.sin_acentos(text)                            from public, anon, authenticated;
+revoke execute on function public.es_correo_valido(text)                       from public, anon, authenticated;
+revoke execute on function public.es_ruta_almacenamiento_valida(text)          from public, anon, authenticated;
+revoke execute on function public.redactar_campos_auditados(text, jsonb)       from public, anon, authenticated;
+revoke execute on function public.registrar_auditoria()                        from public, anon, authenticated;
+revoke execute on function public.proteger_privilegios_perfil()                from public, anon, authenticated;
+revoke execute on function public.sincronizar_perfil_desde_auth()              from public, anon, authenticated;
+revoke execute on function public.impedir_borrado_configuracion()              from public, anon, authenticated;
+
+-- Excepción medida y comprobada: PostgreSQL SÍ exige EXECUTE sobre las funciones
+-- que aparecen en un CHECK o en una expresión de índice, y las comprueba en cada
+-- INSERT/UPDATE del rol que escribe. Sin estas tres concesiones, un editor no
+-- podría dar de alta un invitado ("permission denied for function
+-- es_correo_valido"). Son funciones puras e inmutables que no leen ninguna tabla
+-- y no revelan nada: conceder EXECUTE no amplía la superficie de ataque.
+-- `anon` queda fuera a propósito: no tiene INSERT ni UPDATE sobre ninguna tabla,
+-- así que nunca llega a evaluarlas.
+grant execute on function public.es_correo_valido(text)              to authenticated;
+grant execute on function public.es_ruta_almacenamiento_valida(text) to authenticated;
+grant execute on function public.sin_acentos(text)                   to authenticated;
+
+commit;

--- a/supabase/migrations/20260803090100_invitados.sql
+++ b/supabase/migrations/20260803090100_invitados.sql
@@ -1,0 +1,955 @@
+-- ============================================================================
+-- 20260803090100_invitados.sql
+-- Ticket: BODA-12 (invitados, grupos de invitación y confirmaciones)
+-- Motor:  PostgreSQL 17 (Supabase)
+--
+-- Qué hace este fichero:
+--   El núcleo del RSVP. La unidad de invitación (un grupo, con su token), las
+--   personas que la componen y el historial de respuestas.
+--
+-- Tres decisiones que gobiernan todo el bloque:
+--
+--   1. El token NO se guarda en claro. Se guarda su SHA-256. El texto plano
+--      existe una sola vez, en el enlace que se manda al invitado. Un token en
+--      claro convierte cualquier lectura de más sobre esta tabla —una política
+--      mal escrita, la propia bitácora, un volcado— en el compromiso simultáneo
+--      de los 150 enlaces de la boda, no de uno.
+--
+--   2. Las notas privadas de los novios viven en OTRAS tablas
+--      (`notas_grupo`, `notas_invitado`). RLS es control de fila, no de columna,
+--      y la ruta pública del RSVP tiene que poder alcanzar `grupos_invitacion` e
+--      `invitados`. Lo que no puede leer el invitado, sencillamente no está ahí.
+--
+--   3. Los invariantes de negocio con impacto económico —plazo de RSVP y tope de
+--      acompañantes— se defienden con triggers, no con un `if` en una función de
+--      aplicación. Regla 4 del proyecto.
+--
+-- Las políticas RLS viven en 20260803090400_rls.sql.
+-- Rollback: supabase/migrations/rollback/20260803090100_invitados.sql
+-- ============================================================================
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- 1. Tipos enumerados
+--    El orden de declaración fija el operador `<` del tipo, así que se declara
+--    en el orden en que queremos ver los valores en los listados del panel.
+-- ----------------------------------------------------------------------------
+
+select public.asegurar_enum('lado_invitacion', array['novia', 'novio', 'ambos']);
+
+comment on type public.lado_invitacion is
+  'De qué parte viene la invitación. Sirve para repartir mesas y para las '
+  'estadísticas del panel.';
+
+select public.asegurar_enum('evento_boda', array['ceremonia', 'banquete', 'fiesta']);
+
+comment on type public.evento_boda is
+  'Eventos a los que se puede invitar por separado: hay gente invitada sólo a la '
+  'ceremonia o sólo a la fiesta.';
+
+select public.asegurar_enum('tipo_menu', array[
+  'estandar', 'vegetariano', 'vegano', 'infantil', 'sin_gluten', 'otro'
+]);
+
+comment on type public.tipo_menu is
+  'Menú que se comunica al catering. `otro` obliga a detallar en `alergias`.';
+
+select public.asegurar_enum('estado_confirmacion', array[
+  'pendiente', 'tentativo', 'confirmado', 'rechazado'
+]);
+
+comment on type public.estado_confirmacion is
+  'Estado del RSVP de un invitado. Orden de declaración = orden del embudo (sin '
+  'respuesta → respuesta firme), para que ORDER BY estado sea legible. '
+  '`tentativo` existe porque mucha gente contesta "casi seguro" y conviene no '
+  'contarlo como confirmado.';
+
+select public.asegurar_enum('origen_confirmacion', array['publico', 'panel', 'sistema']);
+
+comment on type public.origen_confirmacion is
+  'Quién registró la respuesta: el propio invitado desde /rsvp/[token] '
+  '(`publico`), los novios a mano tras una llamada (`panel`), o el alta '
+  'automática de la fila inicial (`sistema`).';
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Tokens de invitación
+-- ----------------------------------------------------------------------------
+
+create or replace function public.generar_token_invitacion()
+returns text
+language sql
+volatile
+set search_path = ''
+as $$
+  select translate(encode(extensions.gen_random_bytes(24), 'base64'), '+/=', '-_');
+$$;
+
+comment on function public.generar_token_invitacion() is
+  'Genera el token del enlace público de RSVP: 24 bytes (192 bits) aleatorios en '
+  'base64 "url-safe", 32 caracteres sin +, / ni =, para que viaje limpio en '
+  '/rsvp/[token] y dentro de un QR. Es la única credencial del invitado, así que '
+  'no puede ser corto ni predecible; un uuid sería adivinable en formato y corto '
+  'para este uso.';
+
+create or replace function public.huella_token(p_token text)
+returns bytea
+language sql
+immutable
+strict
+parallel safe
+set search_path = ''
+as $$
+  select extensions.digest(p_token, 'sha256');
+$$;
+
+comment on function public.huella_token(text) is
+  'SHA-256 del token. Es lo ÚNICO que se guarda en la base de datos: la tabla '
+  'nunca contiene la credencial en claro, de modo que ni un volcado ni una '
+  'política de lectura mal escrita entregan enlaces utilizables.';
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Grupos de invitación
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.grupos_invitacion (
+  id                  uuid not null default gen_random_uuid(),
+
+  nombre              text not null,
+
+  -- Sin valor por defecto utilizable a propósito: el enlace se emite con
+  -- `public.rotar_token_invitacion()`, que es quien devuelve el texto plano una
+  -- única vez. Un grupo recién creado tiene una huella aleatoria que no
+  -- corresponde a ningún token conocido, es decir: no se puede entrar con él.
+  huella_token        bytea not null default public.huella_token(public.generar_token_invitacion()),
+  token_emitido_en    timestamptz,
+
+  maximo_acompanantes smallint not null default 0,
+  lado                public.lado_invitacion not null default 'ambos',
+  invitado_a          public.evento_boda[] not null
+                        default array['ceremonia', 'banquete', 'fiesta']::public.evento_boda[],
+
+  -- Dirección postal desglosada: se usa para el envío físico de invitaciones, y
+  -- en un solo campo de texto libre no hay forma de ordenar ni de exportar.
+  direccion           text,
+  codigo_postal       text,
+  ciudad              text,
+  provincia           text,
+  pais                text,
+
+  idioma              text,
+
+  creado_en           timestamptz not null default now(),
+  actualizado_en      timestamptz not null default now(),
+
+  constraint grupos_invitacion_pk primary key (id),
+  constraint grupos_invitacion_huella_token_unico unique (huella_token),
+
+  constraint grupos_invitacion_nombre_longitud
+    check (btrim(nombre) <> '' and char_length(nombre) <= 120),
+
+  constraint grupos_invitacion_maximo_acompanantes_rango
+    check (maximo_acompanantes between 0 and 20),
+
+  -- Al menos un evento y sin NULL dentro del array. La cota superior NO se
+  -- escribe a mano: el número de eventos es un dato derivable del enumerado y
+  -- copiarlo aquí obligaría a tocar el CHECK cada vez que se añada un evento.
+  -- La ausencia de duplicados la garantiza el trigger de normalización.
+  constraint grupos_invitacion_eventos_no_vacio
+    check (cardinality(invitado_a) >= 1 and array_position(invitado_a, null) is null),
+
+  constraint grupos_invitacion_codigo_postal_formato
+    check (codigo_postal is null or codigo_postal ~ '^[0-9A-Za-z .-]{3,12}$'),
+  constraint grupos_invitacion_idioma_bcp_47
+    check (idioma is null or idioma ~ '^[a-z]{2}(-[A-Z]{2})?$'),
+
+  -- Campos que el propio invitado puede corregir desde el formulario público:
+  -- se acotan para que un POST no pueda inflar la tabla.
+  constraint grupos_invitacion_direccion_longitud
+    check (direccion is null or char_length(direccion) <= 200),
+  constraint grupos_invitacion_codigo_postal_longitud
+    check (codigo_postal is null or char_length(codigo_postal) <= 12),
+  constraint grupos_invitacion_ciudad_longitud
+    check (ciudad is null or char_length(ciudad) <= 80),
+  constraint grupos_invitacion_provincia_longitud
+    check (provincia is null or char_length(provincia) <= 80),
+  constraint grupos_invitacion_pais_longitud
+    check (pais is null or char_length(pais) <= 80)
+);
+alter table public.grupos_invitacion enable row level security;
+
+comment on table public.grupos_invitacion is
+  'Unidad de invitación: una familia o una pareja. Es lo que recibe un enlace y lo '
+  'que responde al RSVP; las personas concretas cuelgan de aquí.';
+
+comment on column public.grupos_invitacion.nombre is
+  'Cómo se dirige uno al grupo en la invitación: "Familia Pérez Gómez", "Ana y '
+  'Luis". No es un nombre de persona.';
+comment on column public.grupos_invitacion.huella_token is
+  'SHA-256 del secreto que da acceso a /rsvp/[token]. Lo resuelve '
+  '`public.obtener_invitacion()`. El texto plano NO se almacena: se devuelve una '
+  'sola vez, al emitirlo con `public.rotar_token_invitacion()`.';
+comment on column public.grupos_invitacion.token_emitido_en is
+  'Cuándo se emitió el enlace vigente. NULL = el grupo existe pero todavía no '
+  'tiene enlace utilizable. Sirve para saber a quién falta mandarle la invitación.';
+comment on column public.grupos_invitacion.maximo_acompanantes is
+  'Plazas extra que el grupo puede añadir por su cuenta al confirmar (0 = lista '
+  'cerrada). El tope lo garantiza el trigger `invitados_validar_aforo_grupo`, no '
+  'la aplicación.';
+comment on column public.grupos_invitacion.invitado_a is
+  'Eventos a los que está invitado el grupo. Array y no tres booleanos porque la '
+  'landing y los correos iteran sobre la lista tal cual. Se normaliza (sin '
+  'duplicados y ordenado) en un trigger.';
+comment on column public.grupos_invitacion.idioma is
+  'Idioma preferido del grupo en BCP 47 (es, en, ca). NULL = usar '
+  '`public.configuracion_boda.idioma_por_defecto`, para no duplicar el idioma '
+  'general en cada fila.';
+
+-- El índice único de `huella_token` resuelve la búsqueda de `obtener_invitacion()`:
+-- es la consulta más caliente de la parte pública y tiene que ser index scan.
+
+create index if not exists grupos_invitacion_lado_idx
+  on public.grupos_invitacion (lado);
+
+-- GIN sobre el array: "quién está invitado a la fiesta" sin recorrer la tabla.
+create index if not exists grupos_invitacion_eventos_idx
+  on public.grupos_invitacion using gin (invitado_a);
+
+-- Buscador del panel, tolerante a tildes y erratas.
+create index if not exists grupos_invitacion_nombre_trgm_idx
+  on public.grupos_invitacion using gin (public.sin_acentos(nombre) extensions.gin_trgm_ops);
+
+
+-- 3.1 Normalización de los eventos -------------------------------------------
+-- Ni la cardinalidad ni `<@` impiden repeticiones: array['fiesta','fiesta'] pasa
+-- cualquier CHECK razonable. Y sin orden canónico, dos grupos con la misma
+-- invitación guardan arrays distintos e incomparables. Se normaliza en un
+-- trigger porque un CHECK no admite subconsultas.
+
+create or replace function public.normalizar_eventos_grupo()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  new.invitado_a := array(
+    select distinct e from unnest(new.invitado_a) as e order by e
+  );
+  return new;
+end;
+$$;
+
+comment on function public.normalizar_eventos_grupo() is
+  'Deduplica y ordena `invitado_a`. Sin esto, un PATCH mal construido guarda '
+  '{banquete,banquete}: la invitación enseña "Banquete" dos veces y el grupo '
+  'desaparece del listado de la fiesta sin que nada haya fallado.';
+
+create or replace trigger grupos_invitacion_normalizar_eventos
+  before insert or update of invitado_a on public.grupos_invitacion
+  for each row execute function public.normalizar_eventos_grupo();
+
+
+-- 3.2 Congelar los campos de autorización ------------------------------------
+-- `invitado_a`, `maximo_acompanantes`, `lado` y el token no son datos: son
+-- privilegios. Definen a cuántos eventos entra el grupo y cuántas personas puede
+-- añadir. Viven en una tabla que la ruta pública necesita poder actualizar
+-- (dirección e idioma al confirmar), así que se congelan explícitamente. Un
+-- `with check` de RLS sobre el token no ayuda: comprueba que la fila sigue
+-- siendo la suya, no que no se haya ascendido a sí misma.
+
+create or replace function public.congelar_privilegios_grupo()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if (new.huella_token, new.invitado_a, new.maximo_acompanantes, new.lado)
+     is distinct from
+     (old.huella_token, old.invitado_a, old.maximo_acompanantes, old.lado)
+     and not public.puede_editar()
+  then
+    raise exception 'RSV06'
+      using errcode = 'insufficient_privilege',
+            detail  = format('grupo=%s', old.id),
+            hint    = 'Sólo un editor puede cambiar los privilegios de una invitación.';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.congelar_privilegios_grupo() is
+  'Impide que el propio invitado se cuele en más eventos, se suba el cupo de '
+  'acompañantes o reescriba su token dejando al grupo real fuera de su enlace. '
+  'Dentro de las funciones públicas del RSVP `auth.uid()` es NULL, luego '
+  '`puede_editar()` es falso y las cuatro columnas quedan congeladas.';
+
+create or replace trigger grupos_invitacion_congelar_privilegios
+  before update on public.grupos_invitacion
+  for each row execute function public.congelar_privilegios_grupo();
+
+create or replace trigger grupos_invitacion_actualizado_en
+  before update on public.grupos_invitacion
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- 3.3 Notas privadas del grupo ------------------------------------------------
+
+create table if not exists public.notas_grupo (
+  grupo_id        uuid not null,
+  texto           text,
+  creado_en       timestamptz not null default now(),
+  actualizado_en  timestamptz not null default now(),
+
+  constraint notas_grupo_pk primary key (grupo_id),
+  constraint notas_grupo_grupo_id_fk
+    foreign key (grupo_id) references public.grupos_invitacion (id) on delete cascade,
+  constraint notas_grupo_texto_longitud
+    check (texto is null or char_length(texto) <= 2000)
+);
+alter table public.notas_grupo enable row level security;
+
+comment on table public.notas_grupo is
+  'Notas privadas de los novios sobre un grupo ("los primos de Madrid, mesa lejos '
+  'de la música"). Tabla aparte y no columna de `grupos_invitacion`: la ruta '
+  'pública del RSVP tiene que leer el grupo, y lo que el invitado no debe ver no '
+  'puede estar en la fila que se le devuelve. Nunca la toca ninguna función '
+  'pública.';
+
+create or replace trigger notas_grupo_actualizado_en
+  before update on public.notas_grupo
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Invitados
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.invitados (
+  id                  uuid not null default gen_random_uuid(),
+
+  grupo_id            uuid not null,
+
+  -- La clave foránea a `public.mesas` se ata en 20260803090300_organizacion.sql,
+  -- que es donde nace la tabla referenciada. La COLUMNA se declara aquí, donde
+  -- nace la tabla que la contiene: repartir la responsabilidad entre dos ficheros
+  -- es cómo se acaba con una columna que no crea nadie.
+  mesa_id             uuid,
+
+  nombre              text not null,
+  apellidos           text,
+
+  -- Columna real mantenida por trigger, y NO `generated always as ... stored`.
+  -- Motivo: PostgreSQL prohíbe `when (old.* is distinct from new.*)` en un
+  -- trigger BEFORE de una tabla con columnas generadas ("BEFORE trigger's WHEN
+  -- condition cannot reference NEW generated columns"). Sin esa cláusula, esta
+  -- tabla —y sólo ésta— movería `actualizado_en` en UPDATEs que no cambian nada,
+  -- y la columna dejaría de significar lo mismo en todo el esquema. El valor lo
+  -- sigue poniendo la base de datos en cada INSERT/UPDATE, nunca el cliente.
+  nombre_completo     text not null default '',
+
+  correo_electronico  text,
+  telefono            text,
+
+  es_nino             boolean not null default false,
+  es_acompanante      boolean not null default false,
+
+  tipo_menu           public.tipo_menu not null default 'estandar',
+  alergias            text,
+
+  creado_en           timestamptz not null default now(),
+  actualizado_en      timestamptz not null default now(),
+
+  constraint invitados_pk primary key (id),
+
+  -- ON DELETE CASCADE: un invitado no tiene existencia propia fuera de su grupo.
+  -- RESTRICT obligaría a un borrado manual en dos pasos y SET NULL dejaría
+  -- exactamente los huérfanos que queremos evitar. La traza del borrado queda en
+  -- `registro_auditoria`, que también audita las cascadas.
+  constraint invitados_grupo_id_fk
+    foreign key (grupo_id) references public.grupos_invitacion (id) on delete cascade,
+
+  constraint invitados_nombre_longitud
+    check (btrim(nombre) <> '' and char_length(nombre) between 1 and 80),
+  constraint invitados_apellidos_longitud
+    check (apellidos is null or char_length(apellidos) <= 120),
+
+  constraint invitados_correo_valido
+    check (public.es_correo_valido(correo_electronico)),
+  constraint invitados_telefono_formato
+    check (telefono is null or telefono ~ '^\+?[0-9 ().-]{6,25}$'),
+
+  -- Implicación en UN solo sentido. La equivalencia estricta
+  -- `(tipo_menu = 'infantil') = es_nino` hacía imposible registrar a un niño
+  -- celíaco, vegano o vegetariano: la única salida era marcarlo como adulto
+  -- (descuadrando trona, autobús y espacio infantil) o darle gluten. El menú
+  -- infantil sigue siendo exclusivo de menores; el recuento de niños se hace por
+  -- `es_nino`, que es el dato fiable, no por `tipo_menu`.
+  constraint invitados_menu_infantil_solo_ninos
+    check (tipo_menu <> 'infantil' or es_nino),
+
+  constraint invitados_alergias_longitud
+    check (alergias is null or char_length(alergias) <= 500)
+);
+alter table public.invitados enable row level security;
+
+comment on table public.invitados is
+  'Persona concreta dentro de un grupo de invitación. Es la unidad que confirma, '
+  'que come un menú y que se sienta en una mesa.';
+
+comment on column public.invitados.grupo_id is
+  'Grupo al que pertenece. ON DELETE CASCADE: borrar el grupo borra a sus '
+  'invitados, nunca los deja huérfanos.';
+comment on column public.invitados.mesa_id is
+  'Mesa asignada en el plano del banquete. NULL = todavía sin sentar. La clave '
+  'foránea (ON DELETE SET NULL) se ata en la migración de organización: quitar '
+  'una mesa del plano devuelve a su gente a la bolsa de "sin mesa", jamás la '
+  'borra.';
+comment on column public.invitados.nombre_completo is
+  'Nombre y apellidos ya compuestos, para listar, ordenar y buscar sin '
+  'recomponerlos en cada consulta ni en el frontend. Lo mantiene el trigger '
+  '`invitados_componer_nombre_completo`: lo que mande el cliente en esta columna '
+  'se descarta siempre.';
+comment on column public.invitados.correo_electronico is
+  'Puede repetirse dentro de un grupo (una pareja que comparte buzón), por eso no '
+  'lleva índice único. Se normaliza a minúsculas por trigger para que reimportar '
+  'un CSV no duplique personas.';
+comment on column public.invitados.es_nino is
+  'Marca a los menores: cuentan aparte para el catering, el autobús y el espacio '
+  'infantil. Es el dato con el que se hacen los recuentos, no `tipo_menu`.';
+comment on column public.invitados.es_acompanante is
+  'La persona la añadió el grupo al confirmar y consume una plaza de '
+  '`maximo_acompanantes`.';
+comment on column public.invitados.alergias is
+  'Alergias e intolerancias en texto libre. Lo escribe el invitado desde el RSVP, '
+  'de ahí el límite de longitud. Dato de salud (art. 9 RGPD): no sale nunca de la '
+  'invitación de su propio grupo.';
+
+-- Índice de la clave foránea: sin él, tanto los JOIN del panel como el propio
+-- ON DELETE CASCADE recorren la tabla entera.
+create index if not exists invitados_grupo_id_idx
+  on public.invitados (grupo_id);
+
+create index if not exists invitados_nombre_completo_idx
+  on public.invitados (nombre_completo);
+
+-- Buscador del panel: `ilike '%algo%'` no puede usar un btree, y el btree plano
+-- tampoco cumple la promesa de las tildes con la que se instaló `unaccent`.
+create index if not exists invitados_nombre_trgm_idx
+  on public.invitados using gin (public.sin_acentos(nombre_completo) extensions.gin_trgm_ops);
+
+-- Parcial: la mayoría de invitados no tiene correo y sólo interesa buscar por él
+-- cuando existe (recordatorios, deduplicado en la importación CSV).
+create index if not exists invitados_correo_electronico_idx
+  on public.invitados (correo_electronico)
+  where correo_electronico is not null;
+
+create index if not exists invitados_tipo_menu_idx
+  on public.invitados (tipo_menu);
+
+create or replace function public.componer_nombre_completo()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  new.nombre_completo := btrim(new.nombre || ' ' || coalesce(new.apellidos, ''));
+  return new;
+end;
+$$;
+
+comment on function public.componer_nombre_completo() is
+  'Mantiene `invitados.nombre_completo` a partir de nombre y apellidos. Se ejecuta '
+  'en cada INSERT y en cada UPDATE de esas dos columnas, de modo que el valor es '
+  'siempre derivado y el cliente no lo puede falsear.';
+
+create or replace trigger invitados_componer_nombre_completo
+  before insert or update of nombre, apellidos on public.invitados
+  for each row execute function public.componer_nombre_completo();
+
+create or replace trigger invitados_normalizar_correo
+  before insert or update of correo_electronico on public.invitados
+  for each row execute function public.normalizar_correo('correo_electronico');
+
+create or replace trigger invitados_actualizado_en
+  before update on public.invitados
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- 4.1 Notas privadas de la persona -------------------------------------------
+
+create table if not exists public.notas_invitado (
+  invitado_id     uuid not null,
+  texto           text,
+  creado_en       timestamptz not null default now(),
+  actualizado_en  timestamptz not null default now(),
+
+  constraint notas_invitado_pk primary key (invitado_id),
+  constraint notas_invitado_invitado_id_fk
+    foreign key (invitado_id) references public.invitados (id) on delete cascade,
+  constraint notas_invitado_texto_longitud
+    check (texto is null or char_length(texto) <= 2000)
+);
+alter table public.notas_invitado enable row level security;
+
+comment on table public.notas_invitado is
+  'Notas privadas de los novios sobre una persona. Fuera de `invitados` por el '
+  'mismo motivo que `notas_grupo`: la ruta pública lee `invitados`.';
+
+create or replace trigger notas_invitado_actualizado_en
+  before update on public.notas_invitado
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- 4.2 Tope de acompañantes ----------------------------------------------------
+-- El único control anterior era `check (maximo_acompanantes between 0 and 20)`,
+-- que acota el campo pero no cuenta nada. Contarlo en la función de aplicación
+-- deja una carrera ganable: en READ COMMITTED, treinta llamadas concurrentes
+-- leen todas `count(*) = 0`, todas pasan la validación y todas insertan. Con un
+-- aforo cerrado con la finca, eso es coste real.
+
+create or replace function public.invitados_validar_aforo_grupo()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_maximo    smallint;
+  v_ocupadas  bigint;
+begin
+  -- El bloqueo de la fila padre es el punto de serialización natural: dos altas
+  -- del mismo grupo se ordenan, y el recuento de la segunda ya ve a la primera.
+  select g.maximo_acompanantes
+    into v_maximo
+    from public.grupos_invitacion as g
+   where g.id = new.grupo_id
+     for update;
+
+  select count(*)
+    into v_ocupadas
+    from public.invitados as i
+   where i.grupo_id = new.grupo_id
+     and i.es_acompanante;
+
+  if v_ocupadas > coalesce(v_maximo, 0) then
+    raise exception 'RSV05'
+      using errcode = 'check_violation',
+            detail  = format('grupo=%s maximo=%s ocupadas=%s',
+                             new.grupo_id, coalesce(v_maximo, 0), v_ocupadas),
+            hint    = 'El grupo ha agotado sus plazas de acompañante.';
+  end if;
+
+  return null;
+end;
+$$;
+
+comment on function public.invitados_validar_aforo_grupo() is
+  'Garantiza en la base de datos el tope de acompañantes de cada grupo, pase la '
+  'escritura por donde pase: formulario público, alta manual del panel, '
+  'importación CSV o `service_role`. Es un CONSTRAINT TRIGGER para poder contar '
+  'después de la sentencia (y no fila a fila), y bloquea el grupo para que el '
+  'recuento no sea una carrera.';
+
+drop trigger if exists invitados_aforo_grupo on public.invitados;
+create constraint trigger invitados_aforo_grupo
+  after insert or update of grupo_id, es_acompanante on public.invitados
+  deferrable initially immediate
+  for each row execute function public.invitados_validar_aforo_grupo();
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Confirmaciones de asistencia (histórico, sólo inserción)
+--    Cada respuesta es una fila nueva y la anterior deja de ser vigente. Así se
+--    ve quién cambió de opinión y cuándo, algo que importa cuando el catering ya
+--    tiene un número cerrado.
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.confirmaciones (
+  id                    uuid not null default gen_random_uuid(),
+
+  invitado_id           uuid not null,
+
+  estado                public.estado_confirmacion not null default 'pendiente',
+
+  -- Por defecto el origen MENOS fiable. Con `panel` por defecto, un INSERT que
+  -- se olvide de fijarlo queda registrado como si lo hubiera tecleado un novio.
+  origen                public.origen_confirmacion not null default 'publico',
+
+  respondido_en         timestamptz,
+  necesita_autobus      boolean,
+  necesita_alojamiento  boolean,
+  cancion_solicitada    text,
+  mensaje               text,
+
+  registrado_por        uuid,
+
+  es_vigente            boolean not null default true,
+
+  creado_en             timestamptz not null default now(),
+  actualizado_en        timestamptz not null default now(),
+
+  constraint confirmaciones_pk primary key (id),
+
+  -- ON DELETE CASCADE: la respuesta no significa nada sin la persona, y borrar a
+  -- un invitado (derecho de supresión del RGPD) tiene que llevarse sus datos.
+  constraint confirmaciones_invitado_id_fk
+    foreign key (invitado_id) references public.invitados (id) on delete cascade,
+
+  -- ON DELETE SET NULL: si un colaborador deja el proyecto se pierde la autoría,
+  -- nunca el historial de respuestas.
+  constraint confirmaciones_registrado_por_fk
+    foreign key (registrado_por) references public.perfiles (id) on delete set null,
+
+  -- Si hay respuesta real, hay fecha de respuesta.
+  constraint confirmaciones_respondido_en_coherente
+    check (estado = 'pendiente' or respondido_en is not null),
+
+  -- Quien confirma ha contestado a la logística: el autobús y el alojamiento se
+  -- contratan con esos números.
+  constraint confirmaciones_logistica_completa
+    check (
+      estado <> 'confirmado'
+      or (necesita_autobus is not null and necesita_alojamiento is not null)
+    ),
+
+  -- La autoría tiene que ser coherente con el origen: `registrado_por` no puede
+  -- apuntar a la novia en una respuesta que llegó por el enlace público.
+  constraint confirmaciones_autoria_coherente
+    check (
+      (origen = 'panel'                  and registrado_por is not null)
+      or (origen in ('publico','sistema') and registrado_por is null)
+    ),
+
+  constraint confirmaciones_cancion_longitud
+    check (cancion_solicitada is null
+           or (btrim(cancion_solicitada) <> '' and char_length(cancion_solicitada) <= 200)),
+  constraint confirmaciones_mensaje_longitud
+    check (mensaje is null
+           or (btrim(mensaje) <> '' and char_length(mensaje) <= 2000))
+);
+alter table public.confirmaciones enable row level security;
+
+comment on table public.confirmaciones is
+  'Historial de respuestas al RSVP, una fila por respuesta. Nunca se edita una '
+  'respuesta: se inserta la siguiente y la anterior deja de ser vigente.';
+
+comment on column public.confirmaciones.invitado_id is
+  'Persona que responde. ON DELETE CASCADE: borrar al invitado borra su historial '
+  '(derecho de supresión).';
+comment on column public.confirmaciones.origen is
+  'Distingue la respuesta que llegó por el enlace público de la que metieron los '
+  'novios a mano y del alta automática inicial. Por defecto `publico` (el menos '
+  'fiable) para que un olvido nunca disfrace una respuesta de más fiable.';
+comment on column public.confirmaciones.respondido_en is
+  'Cuándo respondió el invitado. En el origen público lo sella el servidor; en el '
+  'panel puede ser anterior a `creado_en` si los novios registran a posteriori una '
+  'respuesta dada por teléfono. Nunca puede estar en el futuro.';
+comment on column public.confirmaciones.necesita_autobus is
+  'NULL = todavía no ha contestado. Obligatorio en cuanto el estado es '
+  '`confirmado`.';
+comment on column public.confirmaciones.registrado_por is
+  'Perfil que registró la respuesta desde el panel. NULL cuando respondió el '
+  'propio invitado o cuando el perfil se ha borrado. Lo fija el servidor a partir '
+  'de `auth.uid()`, jamás el cliente.';
+comment on column public.confirmaciones.es_vigente is
+  'Marca la última respuesta de cada invitado. Lo mantiene un trigger y lo '
+  'garantiza un índice único parcial: consultar el estado actual no necesita ni '
+  'subconsultas ni DISTINCT ON.';
+
+-- Índice de la clave foránea, que además lee el historial de una persona ya
+-- ordenado de la respuesta más reciente a la más antigua.
+create index if not exists confirmaciones_invitado_id_idx
+  on public.confirmaciones (invitado_id, creado_en desc);
+
+-- Garantía dura de que sólo hay una respuesta vigente por invitado.
+create unique index if not exists confirmaciones_vigente_por_invitado_idx
+  on public.confirmaciones (invitado_id)
+  where es_vigente;
+
+-- Recuentos del panel: confirmados, pendientes, rechazados.
+create index if not exists confirmaciones_estado_vigente_idx
+  on public.confirmaciones (estado)
+  where es_vigente;
+
+-- Lista del autobús: pocas filas cumplen el predicado, el índice es diminuto.
+create index if not exists confirmaciones_autobus_idx
+  on public.confirmaciones (invitado_id)
+  where es_vigente and necesita_autobus;
+
+create index if not exists confirmaciones_registrado_por_idx
+  on public.confirmaciones (registrado_por)
+  where registrado_por is not null;
+
+
+-- 5.1 Vigencia ----------------------------------------------------------------
+
+create or replace function public.marcar_confirmacion_vigente()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- Toda respuesta que entra es la vigente. Que el cliente pueda insertar una
+  -- fila con `es_vigente = false` es cómo un invitado se queda sin ninguna
+  -- respuesta vigente y desaparece en silencio de los recuentos.
+  new.es_vigente := true;
+
+  -- Bloqueo de la persona: es el punto de serialización. Sin él, un doble clic
+  -- en "Confirmar" hace que las dos transacciones lean la vieja fila vigente,
+  -- ninguna degrade a la otra y la segunda choque contra el índice único (23505).
+  perform 1 from public.invitados as i where i.id = new.invitado_id for update;
+
+  -- BEFORE INSERT y no AFTER: el índice único parcial se comprueba al insertar
+  -- la fila, así que la anterior tiene que dejar de ser vigente antes.
+  update public.confirmaciones
+     set es_vigente = false
+   where invitado_id = new.invitado_id
+     and es_vigente;
+
+  return new;
+end;
+$$;
+
+comment on function public.marcar_confirmacion_vigente() is
+  'Al registrar una respuesta nueva, degrada la anterior de la misma persona y se '
+  'asegura de que la entrante quede vigente. SECURITY DEFINER porque el histórico '
+  'es de sólo inserción y ningún rol tiene UPDATE sobre él: con SECURITY INVOKER, '
+  'el UPDATE afectaría a 0 filas en silencio y el INSERT chocaría con el índice '
+  'único, dejando a los invitados sin poder rectificar su respuesta.';
+
+create or replace trigger confirmaciones_vigente
+  before insert on public.confirmaciones
+  for each row execute function public.marcar_confirmacion_vigente();
+
+
+-- 5.2 Sellado de la respuesta -------------------------------------------------
+
+create or replace function public.sellar_respuesta_confirmacion()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  -- El invitado no fecha su propia respuesta: la fecha la pone el servidor.
+  if new.origen = 'publico' then
+    new.respondido_en := now();
+  end if;
+
+  if new.respondido_en is not null and new.respondido_en > now() then
+    raise exception 'RSV07'
+      using errcode = 'check_violation',
+            hint    = 'Una respuesta no puede estar fechada en el futuro.';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.sellar_respuesta_confirmacion() is
+  'Sella `respondido_en` en el origen público y prohíbe siempre las fechas '
+  'futuras. Sin esto, el histórico de "quién cambió de opinión y cuándo" lo dicta '
+  'el cliente, incluidas fechas del año 3000 que descolocan cualquier orden.';
+
+create or replace trigger confirmaciones_sellar_respuesta
+  before insert on public.confirmaciones
+  for each row execute function public.sellar_respuesta_confirmacion();
+
+
+-- 5.3 Plazo de RSVP -----------------------------------------------------------
+
+create or replace function public.validar_plazo_confirmacion()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_limite timestamptz;
+begin
+  if new.origen <> 'publico' then
+    -- Los novios pueden registrar a mano una respuesta fuera de plazo: es
+    -- justamente lo que hacen cuando alguien llama por teléfono tarde.
+    return new;
+  end if;
+
+  select c.fecha_limite_rsvp into v_limite
+    from public.configuracion_boda as c
+   limit 1;
+
+  if v_limite is null or now() > v_limite then
+    raise exception 'RSV03'
+      using errcode = 'check_violation',
+            hint    = 'El plazo para confirmar asistencia está cerrado.';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.validar_plazo_confirmacion() is
+  'Aplica `configuracion_boda.fecha_limite_rsvp` en la base de datos, comparando '
+  'siempre contra `now()` y nunca contra una fecha enviada por el cliente. El '
+  'plazo deja de depender de que la función de aplicación se acuerde de mirarlo, '
+  'y ninguna segunda ruta de escritura (importación, panel, futura política) se '
+  'lo puede saltar.';
+
+create or replace trigger confirmaciones_validar_plazo
+  before insert on public.confirmaciones
+  for each row execute function public.validar_plazo_confirmacion();
+
+
+-- 5.4 Inmutabilidad del histórico ---------------------------------------------
+
+create or replace function public.proteger_historial_confirmaciones()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  -- Lista blanca POR SUSTRACCIÓN: cubre `id`, `creado_en` y toda columna que se
+  -- añada en el futuro sin que nadie tenga que acordarse de ampliar una lista.
+  -- Con la enumeración cerrada anterior se podía reescribir `creado_en` y
+  -- reordenar la cronología de quién dijo qué y cuándo, que es lo único que esta
+  -- tabla existe para probar.
+  if to_jsonb(new) - 'es_vigente' - 'actualizado_en'
+     is distinct from
+     to_jsonb(old) - 'es_vigente' - 'actualizado_en'
+  then
+    raise exception 'CNF01'
+      using errcode = 'restrict_violation',
+            detail  = format('confirmacion=%s', old.id),
+            hint    = 'Las confirmaciones son inmutables: registra una respuesta nueva.';
+  end if;
+
+  -- La vigencia sólo se apaga; nunca se vuelve a encender a mano. Si no,
+  -- `es_vigente = true` sobre una fila antigua resucita una respuesta caducada y
+  -- la convierte en la oficial.
+  if new.es_vigente and not old.es_vigente then
+    raise exception 'CNF02'
+      using errcode = 'restrict_violation',
+            detail  = format('confirmacion=%s', old.id),
+            hint    = 'No se puede reactivar una respuesta caducada.';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.proteger_historial_confirmaciones() is
+  'Impide reescribir una respuesta ya registrada. Los mensajes son códigos '
+  'estables (CNF01/CNF02) y no copy: el texto visible vive en '
+  'content/copy.es.json. Los identificadores viajan en DETAIL, que PostgREST no '
+  'expone al cliente, para no convertir un error en un oráculo de existencia de '
+  'uuids ajenos.';
+
+create or replace trigger confirmaciones_inmutables
+  before update on public.confirmaciones
+  for each row execute function public.proteger_historial_confirmaciones();
+
+create or replace trigger confirmaciones_actualizado_en
+  before update on public.confirmaciones
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- 5.5 Toda persona tiene siempre una respuesta vigente ------------------------
+
+create or replace function public.crear_confirmacion_inicial()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into public.confirmaciones (invitado_id, estado, origen)
+  values (new.id, 'pendiente', 'sistema');
+
+  return null;
+end;
+$$;
+
+comment on function public.crear_confirmacion_inicial() is
+  'Da de alta la fila "pendiente" de cada invitado nuevo, de modo que las '
+  'consultas de estado sean un JOIN limpio, sin COALESCE ni LEFT JOIN por todas '
+  'partes. SECURITY DEFINER: el histórico no concede INSERT directo a nadie, así '
+  'que con SECURITY INVOKER dar de alta un invitado desde el panel moriría con '
+  '42501.';
+
+create or replace trigger invitados_confirmacion_inicial
+  after insert on public.invitados
+  for each row execute function public.crear_confirmacion_inicial();
+
+
+create or replace function public.exigir_confirmacion_vigente()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if exists (select 1 from public.invitados as i where i.id = old.invitado_id)
+     and not exists (
+       select 1 from public.confirmaciones as c
+        where c.invitado_id = old.invitado_id and c.es_vigente
+     )
+  then
+    raise exception 'CNF03'
+      using errcode = 'restrict_violation',
+            detail  = format('invitado=%s', old.invitado_id),
+            hint    = 'Un invitado no puede quedarse sin respuesta vigente.';
+  end if;
+
+  return null;
+end;
+$$;
+
+comment on function public.exigir_confirmacion_vigente() is
+  'El índice único parcial garantiza COMO MUCHO una respuesta vigente por '
+  'persona, nunca AL MENOS una. Esto cierra el otro lado: sin ello, un invitado '
+  'sin fila vigente desaparece en silencio del recuento de confirmados, del '
+  'reparto de menús y de la lista del autobús —ningún error, sólo números que no '
+  'cuadran—. Diferido, para tolerar los pasos intermedios de una transacción.';
+
+drop trigger if exists confirmaciones_siempre_vigente on public.confirmaciones;
+create constraint trigger confirmaciones_siempre_vigente
+  after update or delete on public.confirmaciones
+  deferrable initially deferred
+  for each row execute function public.exigir_confirmacion_vigente();
+
+
+-- ----------------------------------------------------------------------------
+-- 6. Permisos sobre las funciones de este bloque
+-- ----------------------------------------------------------------------------
+
+revoke execute on function public.componer_nombre_completo()                from public, anon, authenticated;
+revoke execute on function public.generar_token_invitacion()                from public, anon, authenticated;
+revoke execute on function public.huella_token(text)                        from public, anon, authenticated;
+revoke execute on function public.normalizar_eventos_grupo()                from public, anon, authenticated;
+revoke execute on function public.congelar_privilegios_grupo()              from public, anon, authenticated;
+revoke execute on function public.invitados_validar_aforo_grupo()           from public, anon, authenticated;
+revoke execute on function public.marcar_confirmacion_vigente()             from public, anon, authenticated;
+revoke execute on function public.sellar_respuesta_confirmacion()           from public, anon, authenticated;
+revoke execute on function public.validar_plazo_confirmacion()              from public, anon, authenticated;
+revoke execute on function public.proteger_historial_confirmaciones()       from public, anon, authenticated;
+revoke execute on function public.crear_confirmacion_inicial()              from public, anon, authenticated;
+revoke execute on function public.exigir_confirmacion_vigente()             from public, anon, authenticated;
+
+commit;

--- a/supabase/migrations/20260803090200_economia.sql
+++ b/supabase/migrations/20260803090200_economia.sql
@@ -1,0 +1,545 @@
+-- ============================================================================
+-- 20260803090200_economia.sql
+-- Ticket: BODA-13 (proveedores, servicios, presupuesto y pagos)
+-- Motor:  PostgreSQL 17 (Supabase)
+--
+-- Qué hace este fichero:
+--   El dinero. A quién se le pide presupuesto, qué se le contrata, en qué
+--   categoría cae el gasto y cuándo hay que pagarlo.
+--
+-- Dos criterios que se aplican en todo el bloque:
+--
+--   · El rastro económico no se borra por arrastre. Facturas, contratos, gasto
+--     y pagos sobreviven al borrado del proveedor: son contabilidad. Sólo
+--     cascadean las filas que no significan nada sin su padre.
+--   · Toda tabla activa RLS en la sentencia inmediatamente posterior a su
+--     CREATE TABLE, antes de índices, comentarios y triggers. Con el ENABLE al
+--     final de cada sección, un fallo a mitad de fichero deja tablas creadas y
+--     sin RLS; y como los privilegios por defecto del esquema ya se revocaron en
+--     la migración base, aquí nada nace concedido.
+--
+-- Todo el fichero va dentro de una transacción: o entra entero o no entra nada.
+-- Las políticas RLS viven en 20260803090400_rls.sql.
+-- Rollback: supabase/migrations/rollback/20260803090200_economia.sql
+-- ============================================================================
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- 1. Tipos enumerados
+-- ----------------------------------------------------------------------------
+
+select public.asegurar_enum('estado_proveedor', array[
+  'investigando', 'contactado', 'presupuesto_recibido', 'contratado', 'descartado'
+]);
+
+comment on type public.estado_proveedor is
+  'Fases del embudo de contratación. El orden de declaración es el orden natural '
+  'de avance, así que ORDER BY estado ya sale ordenado por lo avanzada que está '
+  'la negociación.';
+
+select public.asegurar_enum('tipo_documento_proveedor', array[
+  'presupuesto', 'contrato', 'factura', 'otro'
+]);
+
+comment on type public.tipo_documento_proveedor is
+  'Naturaleza del fichero adjunto. Determina qué documentos son vinculantes '
+  '(contrato, factura) frente a los meramente informativos.';
+
+select public.asegurar_enum('metodo_pago', array[
+  'transferencia', 'tarjeta', 'efectivo', 'bizum', 'domiciliacion', 'otro'
+]);
+
+comment on type public.metodo_pago is
+  'Forma en que se liquida un pago. Se guarda por trazabilidad contable; no '
+  'condiciona ninguna lógica de la aplicación.';
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Categorías de proveedor
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.categorias_proveedor (
+  id              uuid not null default gen_random_uuid(),
+  nombre          text not null,
+  descripcion     text,
+  orden           smallint not null default 0,
+  creado_en       timestamptz not null default now(),
+  actualizado_en  timestamptz not null default now(),
+
+  constraint categorias_proveedor_pk primary key (id),
+  constraint categorias_proveedor_nombre_longitud
+    check (length(btrim(nombre)) between 1 and 80),
+  constraint categorias_proveedor_descripcion_longitud
+    check (descripcion is null or char_length(descripcion) <= 500),
+  constraint categorias_proveedor_orden_no_negativo
+    check (orden >= 0)
+);
+alter table public.categorias_proveedor enable row level security;
+
+comment on table public.categorias_proveedor is
+  'Catálogo de tipos de proveedor (catering, fotografía, música, flores…). Es '
+  'tabla y no enumerado porque los novios deben poder añadir categorías desde el '
+  'panel sin migración de por medio.';
+comment on column public.categorias_proveedor.orden is
+  'Posición manual en los listados. Se separa del nombre para poder reordenar sin '
+  'renombrar; los empates se resuelven alfabéticamente.';
+
+-- Nombre único sin distinguir mayúsculas ni espaciado: evita «Catering» y
+-- «catering» como dos categorías distintas.
+create unique index if not exists categorias_proveedor_nombre_unico_idx
+  on public.categorias_proveedor (lower(btrim(nombre)));
+
+create index if not exists categorias_proveedor_orden_idx
+  on public.categorias_proveedor (orden, nombre);
+
+create or replace trigger categorias_proveedor_actualizado_en
+  before update on public.categorias_proveedor
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Proveedores
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.proveedores (
+  id                     uuid not null default gen_random_uuid(),
+
+  categoria_id           uuid not null,
+
+  nombre                 text not null,
+  persona_contacto       text,
+  correo_electronico     text,
+  telefono               text,
+  sitio_web              text,
+  estado                 public.estado_proveedor not null default 'investigando',
+  valoracion             smallint,
+  importe_presupuestado  numeric(12, 2),
+  importe_acordado       numeric(12, 2),
+  notas                  text,
+  creado_en              timestamptz not null default now(),
+  actualizado_en         timestamptz not null default now(),
+
+  constraint proveedores_pk primary key (id),
+
+  -- ON DELETE RESTRICT: borrar una categoría que aún tiene proveedores dejaría
+  -- el embudo sin clasificar. Obliga a recategorizar antes de borrar.
+  constraint proveedores_categoria_id_fk
+    foreign key (categoria_id) references public.categorias_proveedor (id) on delete restrict,
+
+  constraint proveedores_nombre_longitud
+    check (length(btrim(nombre)) between 1 and 160),
+  constraint proveedores_persona_contacto_longitud
+    check (persona_contacto is null or char_length(persona_contacto) <= 120),
+  constraint proveedores_correo_valido
+    check (public.es_correo_valido(correo_electronico)),
+  constraint proveedores_telefono_formato
+    check (telefono is null or telefono ~ '^\+?[0-9 ().-]{6,25}$'),
+  constraint proveedores_sitio_web_formato
+    check (sitio_web is null or sitio_web ~* '^https?://'),
+  constraint proveedores_valoracion_rango
+    check (valoracion is null or valoracion between 1 and 5),
+  constraint proveedores_importes_no_negativos
+    check (coalesce(importe_presupuestado, 0) >= 0 and coalesce(importe_acordado, 0) >= 0),
+  constraint proveedores_notas_longitud
+    check (notas is null or char_length(notas) <= 4000)
+);
+alter table public.proveedores enable row level security;
+
+comment on table public.proveedores is
+  'Empresas y profesionales candidatos o contratados. Guarda tanto los '
+  'descartados como los contratados: el histórico de a quién se preguntó y qué '
+  'presupuestó es parte del valor de la herramienta.';
+comment on column public.proveedores.estado is
+  'Fase del embudo. Un proveedor descartado no se borra, se marca: así no se '
+  'vuelve a pedir presupuesto a quien ya dijo que no.';
+comment on column public.proveedores.valoracion is
+  'Impresión subjetiva de los novios, de 1 a 5. NULL mientras no se ha valorado; '
+  'no se usa 0 como «sin valorar» para poder distinguir ambos casos.';
+comment on column public.proveedores.importe_presupuestado is
+  'Lo que el proveedor ofertó. Se conserva aunque luego se acuerde otra cifra, '
+  'para poder comparar ofertas dentro de la misma categoría.';
+comment on column public.proveedores.importe_acordado is
+  'Lo finalmente pactado. Es una cifra de cabecera del embudo; el desglose real '
+  'de lo que se paga vive en `servicios`, `partidas_presupuesto` y `pagos`.';
+
+create index if not exists proveedores_categoria_id_idx
+  on public.proveedores (categoria_id);
+
+-- El panel filtra el embudo por estado en casi cada pantalla.
+create index if not exists proveedores_estado_idx
+  on public.proveedores (estado);
+
+create index if not exists proveedores_nombre_trgm_idx
+  on public.proveedores using gin (public.sin_acentos(nombre) extensions.gin_trgm_ops);
+
+create or replace trigger proveedores_normalizar_correo
+  before insert or update of correo_electronico on public.proveedores
+  for each row execute function public.normalizar_correo('correo_electronico');
+
+create or replace trigger proveedores_actualizado_en
+  before update on public.proveedores
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Documentos del proveedor
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.documentos_proveedor (
+  id                   uuid not null default gen_random_uuid(),
+
+  proveedor_id         uuid not null,
+  subido_por           uuid,
+
+  tipo                 public.tipo_documento_proveedor not null default 'otro',
+  nombre               text not null,
+  ruta_almacenamiento  text not null,
+  tipo_mime            text,
+  tamano_bytes         bigint,
+  creado_en            timestamptz not null default now(),
+  actualizado_en       timestamptz not null default now(),
+
+  constraint documentos_proveedor_pk primary key (id),
+
+  -- ON DELETE RESTRICT y NO cascade: una factura o un contrato son documentación
+  -- contable y no pueden desaparecer porque alguien pulse «Borrar» en la ficha
+  -- del fotógrafo en vez de marcarlo como descartado. Además, tras una cascada la
+  -- aplicación ya no ve estas filas y los objetos quedarían huérfanos para
+  -- siempre en el bucket, sin nada que los referencie ni forma de encontrarlos.
+  constraint documentos_proveedor_proveedor_id_fk
+    foreign key (proveedor_id) references public.proveedores (id) on delete restrict,
+
+  -- ON DELETE SET NULL: si quien subió el documento deja el proyecto, el
+  -- documento sigue siendo válido; sólo se pierde la autoría.
+  constraint documentos_proveedor_subido_por_fk
+    foreign key (subido_por) references public.perfiles (id) on delete set null,
+
+  constraint documentos_proveedor_nombre_longitud
+    check (length(btrim(nombre)) between 1 and 200),
+  constraint documentos_proveedor_ruta_valida
+    check (public.es_ruta_almacenamiento_valida(ruta_almacenamiento)),
+  constraint documentos_proveedor_tipo_mime_longitud
+    check (tipo_mime is null or char_length(tipo_mime) <= 120),
+  constraint documentos_proveedor_tamano_positivo
+    check (tamano_bytes is null or tamano_bytes > 0)
+);
+alter table public.documentos_proveedor enable row level security;
+
+comment on table public.documentos_proveedor is
+  'Adjuntos de un proveedor (presupuestos, contratos, facturas) alojados en '
+  'Supabase Storage. La tabla guarda la referencia y los metadatos; el binario '
+  'nunca vive en la base de datos.';
+comment on column public.documentos_proveedor.ruta_almacenamiento is
+  'Ruta dentro del bucket. Única en toda la tabla para que dos filas no apunten al '
+  'mismo objeto y un borrado deje la otra rota. Validada contra rutas absolutas y '
+  'travesía de directorios: las políticas de Storage se apoyan en el prefijo de '
+  'carpeta y un `../` apuntaría fuera del prefijo esperado.';
+comment on column public.documentos_proveedor.tamano_bytes is
+  'Se guarda en el alta para poder listar y avisar de adjuntos pesados sin '
+  'consultar Storage en cada render.';
+
+create unique index if not exists documentos_proveedor_ruta_unica_idx
+  on public.documentos_proveedor (ruta_almacenamiento);
+
+create index if not exists documentos_proveedor_proveedor_id_idx
+  on public.documentos_proveedor (proveedor_id, tipo);
+
+create index if not exists documentos_proveedor_subido_por_idx
+  on public.documentos_proveedor (subido_por)
+  where subido_por is not null;
+
+create or replace trigger documentos_proveedor_actualizado_en
+  before update on public.documentos_proveedor
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Servicios contratados
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.servicios (
+  id               uuid not null default gen_random_uuid(),
+
+  proveedor_id     uuid not null,
+
+  nombre           text not null,
+  descripcion      text,
+  precio_unitario  numeric(12, 2) not null default 0,
+  cantidad         integer not null default 1,
+  por_invitado     boolean not null default false,
+
+  -- Importe cerrado sólo cuando no depende de los confirmados. Si el precio es
+  -- por invitado, el total es variable y se calcula en `v_servicios_importe`
+  -- cruzando con las confirmaciones vigentes, no aquí.
+  importe_fijo     numeric(12, 2)
+    generated always as (
+      case when por_invitado then null else precio_unitario * cantidad end
+    ) stored,
+
+  creado_en        timestamptz not null default now(),
+  actualizado_en   timestamptz not null default now(),
+
+  constraint servicios_pk primary key (id),
+
+  -- ON DELETE RESTRICT, igual que los documentos: el desglose de lo contratado
+  -- es la justificación del gasto que sigue apareciendo en `pagos` y en
+  -- `partidas_presupuesto`. Borrar al proveedor obliga a resolverlo a mano.
+  constraint servicios_proveedor_id_fk
+    foreign key (proveedor_id) references public.proveedores (id) on delete restrict,
+
+  constraint servicios_nombre_longitud
+    check (length(btrim(nombre)) between 1 and 160),
+  constraint servicios_descripcion_longitud
+    check (descripcion is null or char_length(descripcion) <= 2000),
+  constraint servicios_precio_no_negativo
+    check (precio_unitario >= 0),
+  constraint servicios_cantidad_positiva
+    check (cantidad > 0)
+);
+alter table public.servicios enable row level security;
+
+comment on table public.servicios is
+  'Desglose de lo contratado a cada proveedor (menú adulto, barra libre, horas '
+  'extra de fotógrafo…). Permite que el presupuesto se mueva solo cuando cambia '
+  'el número de invitados confirmados.';
+comment on column public.servicios.por_invitado is
+  'Si es cierto, `precio_unitario` se multiplica por los invitados confirmados en '
+  'lugar de por una cantidad fija: al confirmarse un invitado, el coste sube solo.';
+comment on column public.servicios.cantidad is
+  'Multiplicador. Con `por_invitado = false` es el número de unidades '
+  'contratadas; con `por_invitado = true`, cuántas unidades tocan por cabeza '
+  '(normalmente 1).';
+comment on column public.servicios.importe_fijo is
+  'Total calculado por la base de datos para los servicios de precio cerrado. '
+  'NULL a propósito en los de precio por invitado, para que nadie lo confunda con '
+  'un total real; ése lo da `public.v_servicios_importe`.';
+
+create index if not exists servicios_proveedor_id_idx
+  on public.servicios (proveedor_id);
+
+-- El recálculo al confirmarse invitados sólo mira los servicios variables.
+create index if not exists servicios_por_invitado_idx
+  on public.servicios (proveedor_id)
+  where por_invitado;
+
+-- `servicios` tiene columna generada: la comparación de fila entera no se puede
+-- usar en el WHEN de un trigger BEFORE, así que se enumeran las columnas de
+-- negocio. El efecto es el mismo: un UPDATE que no cambia nada no mueve la fecha.
+create or replace trigger servicios_actualizado_en
+  before update on public.servicios
+  for each row
+  when (
+    (old.proveedor_id, old.nombre, old.descripcion, old.precio_unitario,
+     old.cantidad, old.por_invitado)
+    is distinct from
+    (new.proveedor_id, new.nombre, new.descripcion, new.precio_unitario,
+     new.cantidad, new.por_invitado)
+  )
+  execute function public.fijar_actualizado_en();
+
+
+-- ----------------------------------------------------------------------------
+-- 6. Categorías de presupuesto
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.categorias_presupuesto (
+  id                uuid not null default gen_random_uuid(),
+  nombre            text not null,
+  descripcion       text,
+  importe_previsto  numeric(12, 2) not null default 0,
+  orden             smallint not null default 0,
+  creado_en         timestamptz not null default now(),
+  actualizado_en    timestamptz not null default now(),
+
+  constraint categorias_presupuesto_pk primary key (id),
+  constraint categorias_presupuesto_nombre_longitud
+    check (length(btrim(nombre)) between 1 and 80),
+  constraint categorias_presupuesto_descripcion_longitud
+    check (descripcion is null or char_length(descripcion) <= 500),
+  constraint categorias_presupuesto_importe_no_negativo
+    check (importe_previsto >= 0),
+  constraint categorias_presupuesto_orden_no_negativo
+    check (orden >= 0)
+);
+alter table public.categorias_presupuesto enable row level security;
+
+comment on table public.categorias_presupuesto is
+  'Grandes bloques de gasto con su techo previsto (banquete, fotografía, '
+  'música…). Es la referencia contra la que se compara el gasto real en '
+  '`public.v_resumen_presupuesto`.';
+comment on column public.categorias_presupuesto.importe_previsto is
+  'Lo que los novios decidieron destinar a esta categoría antes de pedir '
+  'presupuestos. Se conserva aunque se dispare el gasto real: la desviación es '
+  'justo el dato interesante.';
+
+create unique index if not exists categorias_presupuesto_nombre_unico_idx
+  on public.categorias_presupuesto (lower(btrim(nombre)));
+
+create index if not exists categorias_presupuesto_orden_idx
+  on public.categorias_presupuesto (orden, nombre);
+
+create or replace trigger categorias_presupuesto_actualizado_en
+  before update on public.categorias_presupuesto
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- ----------------------------------------------------------------------------
+-- 7. Partidas de gasto
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.partidas_presupuesto (
+  id                uuid not null default gen_random_uuid(),
+
+  categoria_id      uuid not null,
+  proveedor_id      uuid,
+
+  concepto          text not null,
+  descripcion       text,
+  importe_estimado  numeric(12, 2) not null default 0,
+  importe_real      numeric(12, 2),
+  pagada            boolean not null default false,
+  creado_en         timestamptz not null default now(),
+  actualizado_en    timestamptz not null default now(),
+
+  constraint partidas_presupuesto_pk primary key (id),
+
+  -- ON DELETE RESTRICT: borrar una categoría con gasto asociado falsearía el
+  -- presupuesto. Primero se reasignan las partidas, luego se borra.
+  constraint partidas_presupuesto_categoria_id_fk
+    foreign key (categoria_id) references public.categorias_presupuesto (id) on delete restrict,
+
+  -- ON DELETE SET NULL: el gasto ocurrió y debe seguir contando aunque el
+  -- proveedor se elimine de la agenda. Se pierde el vínculo, no el importe.
+  constraint partidas_presupuesto_proveedor_id_fk
+    foreign key (proveedor_id) references public.proveedores (id) on delete set null,
+
+  constraint partidas_presupuesto_concepto_longitud
+    check (length(btrim(concepto)) between 1 and 160),
+  constraint partidas_presupuesto_descripcion_longitud
+    check (descripcion is null or char_length(descripcion) <= 2000),
+  constraint partidas_presupuesto_importes_no_negativos
+    check (importe_estimado >= 0 and coalesce(importe_real, 0) >= 0)
+);
+alter table public.partidas_presupuesto enable row level security;
+
+comment on table public.partidas_presupuesto is
+  'Línea concreta de gasto dentro de una categoría. Es la unidad sobre la que se '
+  'comparan previsión y realidad, y de la que cuelgan los pagos.';
+comment on column public.partidas_presupuesto.importe_real is
+  'Coste definitivo una vez conocido. NULL mientras sólo hay estimación: sirve '
+  'para distinguir «aún no cerrado» de «cerrado en 0 €».';
+comment on column public.partidas_presupuesto.pagada is
+  'Marca manual de partida liquidada, para gastos pequeños que no se desglosan en '
+  'pagos. Cuando hay pagos registrados, manda la suma de pagos.';
+
+create index if not exists partidas_presupuesto_categoria_id_idx
+  on public.partidas_presupuesto (categoria_id);
+
+create index if not exists partidas_presupuesto_proveedor_id_idx
+  on public.partidas_presupuesto (proveedor_id)
+  where proveedor_id is not null;
+
+-- El panel destaca lo que queda por liquidar.
+create index if not exists partidas_presupuesto_pendientes_idx
+  on public.partidas_presupuesto (categoria_id)
+  where not pagada;
+
+create or replace trigger partidas_presupuesto_actualizado_en
+  before update on public.partidas_presupuesto
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- ----------------------------------------------------------------------------
+-- 8. Pagos
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.pagos (
+  id                 uuid not null default gen_random_uuid(),
+
+  partida_id         uuid not null,
+  registrado_por     uuid,
+
+  importe            numeric(12, 2) not null,
+  fecha_vencimiento  date not null,
+  pagado_en          date,
+  metodo             public.metodo_pago,
+  justificante_ruta  text,
+  notas              text,
+  creado_en          timestamptz not null default now(),
+  actualizado_en     timestamptz not null default now(),
+
+  constraint pagos_pk primary key (id),
+
+  -- ON DELETE RESTRICT: el histórico de pagos es contabilidad, no se borra por
+  -- arrastre. Si una partida tiene pagos, hay que resolverlos explícitamente.
+  constraint pagos_partida_id_fk
+    foreign key (partida_id) references public.partidas_presupuesto (id) on delete restrict,
+
+  -- ON DELETE SET NULL: el pago sigue existiendo aunque el usuario que lo
+  -- registró desaparezca; sólo se pierde quién lo anotó.
+  constraint pagos_registrado_por_fk
+    foreign key (registrado_por) references public.perfiles (id) on delete set null,
+
+  constraint pagos_importe_positivo
+    check (importe > 0),
+  constraint pagos_justificante_solo_si_pagado
+    check (justificante_ruta is null or pagado_en is not null),
+  constraint pagos_justificante_ruta_valida
+    check (justificante_ruta is null or public.es_ruta_almacenamiento_valida(justificante_ruta)),
+  constraint pagos_notas_longitud
+    check (notas is null or char_length(notas) <= 2000)
+);
+alter table public.pagos enable row level security;
+
+comment on table public.pagos is
+  'Calendario de pagos de cada partida: señales, plazos y liquidación final. '
+  'Responde a la pregunta operativa «qué hay que pagar y cuándo», que no se '
+  'deduce del importe total de la partida.';
+comment on column public.pagos.fecha_vencimiento is
+  'Cuándo hay que pagar. Obligatoria: un pago sin fecha no se puede recordar ni '
+  'avisar, que es el motivo de que exista esta tabla.';
+comment on column public.pagos.pagado_en is
+  'NULL mientras el pago está pendiente. Su presencia, y no un booleano, es lo que '
+  'marca un pago como realizado.';
+comment on column public.pagos.justificante_ruta is
+  'Ruta en Supabase Storage del recibo o la transferencia. Sólo puede existir si '
+  'el pago está hecho. Se redacta en la bitácora de auditoría.';
+
+create index if not exists pagos_partida_id_idx
+  on public.pagos (partida_id);
+
+-- Consulta más frecuente del panel: próximos vencimientos sin pagar.
+create index if not exists pagos_pendientes_vencimiento_idx
+  on public.pagos (fecha_vencimiento)
+  where pagado_en is null;
+
+create index if not exists pagos_pagados_idx
+  on public.pagos (pagado_en)
+  where pagado_en is not null;
+
+create index if not exists pagos_registrado_por_idx
+  on public.pagos (registrado_por)
+  where registrado_por is not null;
+
+create unique index if not exists pagos_justificante_unico_idx
+  on public.pagos (justificante_ruta)
+  where justificante_ruta is not null;
+
+create or replace trigger pagos_actualizado_en
+  before update on public.pagos
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+commit;

--- a/supabase/migrations/20260803090300_organizacion.sql
+++ b/supabase/migrations/20260803090300_organizacion.sql
@@ -1,0 +1,484 @@
+-- ============================================================================
+-- 20260803090300_organizacion.sql
+-- Ticket: BODA-13 (tareas, mesas del banquete y medios de la landing)
+-- Motor:  PostgreSQL 17 (Supabase)
+--
+-- Qué hace este fichero:
+--   1. Tareas de organización.
+--   2. Mesas del banquete, con su posición en el plano, y la clave foránea que
+--      ata `invitados.mesa_id` (la COLUMNA ya existe: la declara la migración de
+--      invitados, que es donde nace la tabla que la contiene).
+--   3. Medios: las imágenes de la landing.
+--   4. Engancha el trigger de auditoría a TODAS las tablas de dominio. Se hace
+--      aquí, en la última migración de esquema, porque es el primer punto en el
+--      que existen todas.
+--
+-- Este fichero es el último que crea tablas: a partir de aquí sólo hay
+-- seguridad, funciones y vistas.
+-- Rollback: supabase/migrations/rollback/20260803090300_organizacion.sql
+-- ============================================================================
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- 1. Tipos enumerados
+--    El orden de los valores no es decorativo: define el `<` del tipo, así que
+--    `order by estado` y `order by prioridad desc` ordenan de forma natural sin
+--    tablas auxiliares ni CASE en las consultas.
+-- ----------------------------------------------------------------------------
+
+select public.asegurar_enum('estado_tarea', array['pendiente', 'en_progreso', 'hecha']);
+
+comment on type public.estado_tarea is 'Ciclo de vida de una tarea, en orden de progreso.';
+
+select public.asegurar_enum('prioridad_tarea', array['baja', 'media', 'alta', 'urgente']);
+
+comment on type public.prioridad_tarea is 'Prioridad de una tarea, en orden ascendente de urgencia.';
+
+select public.asegurar_enum('forma_mesa', array[
+  'redonda', 'ovalada', 'rectangular', 'cuadrada', 'imperial'
+]);
+
+comment on type public.forma_mesa is
+  'Forma física de la mesa. El plano del banquete la usa para dibujar la silueta '
+  'correcta.';
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Tareas
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.tareas (
+  id              uuid not null default gen_random_uuid(),
+
+  titulo          text not null,
+  descripcion     text,
+  estado          public.estado_tarea    not null default 'pendiente',
+  prioridad       public.prioridad_tarea not null default 'media',
+  fecha_limite    date,
+  completada_en   timestamptz,
+
+  responsable_id  uuid,
+  proveedor_id    uuid,
+  categoria       text,
+
+  creado_en       timestamptz not null default now(),
+  actualizado_en  timestamptz not null default now(),
+
+  constraint tareas_pk primary key (id),
+
+  -- ON DELETE SET NULL: si se revoca el acceso a un colaborador, su tarea sigue
+  -- existiendo y queda sin responsable, visible en el panel para reasignarla. Un
+  -- CASCADE aquí borraría trabajo pendiente de la boda al borrar un usuario.
+  constraint tareas_responsable_id_fk
+    foreign key (responsable_id) references public.perfiles (id) on delete set null,
+
+  -- ON DELETE SET NULL: descartar un proveedor no debe borrar la tarea («pedir
+  -- presupuesto a X»); la tarea pierde el vínculo, no la existencia.
+  constraint tareas_proveedor_id_fk
+    foreign key (proveedor_id) references public.proveedores (id) on delete set null,
+
+  constraint tareas_titulo_longitud
+    check (length(btrim(titulo)) between 1 and 160),
+  constraint tareas_descripcion_longitud
+    check (descripcion is null or char_length(descripcion) <= 4000),
+  constraint tareas_categoria_longitud
+    check (categoria is null or length(btrim(categoria)) between 1 and 60),
+
+  -- Coherencia dura: «hecha» y sólo «hecha» tiene fecha de cierre. Evita el
+  -- clásico dato zombi de una tarea reabierta que conserva su `completada_en`.
+  constraint tareas_completada_coherente
+    check ((estado = 'hecha') = (completada_en is not null))
+);
+alter table public.tareas enable row level security;
+
+comment on table public.tareas is
+  'Lista de tareas de organización de la boda. Alimenta el tablero del panel y el '
+  'aviso de vencimientos.';
+comment on column public.tareas.completada_en is
+  'Cuándo se cerró la tarea. Lo rellena y lo limpia un trigger a partir de '
+  '`estado`: el cliente nunca lo envía, así el dato no depende de que el frontend '
+  'se acuerde.';
+comment on column public.tareas.responsable_id is
+  'Quién se encarga. NULL = sin asignar, que es un estado legítimo y frecuente.';
+comment on column public.tareas.categoria is
+  'Agrupación libre para el tablero (papeleo, música, viaje…). Texto y no '
+  'enumerado porque las categorías las inventan los novios sobre la marcha.';
+
+create or replace function public.sellar_tarea_completada()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if new.estado = 'hecha' and new.completada_en is null then
+    new.completada_en := now();
+  elsif new.estado <> 'hecha' then
+    new.completada_en := null;
+  end if;
+  return new;
+end;
+$$;
+
+comment on function public.sellar_tarea_completada() is
+  'Mantiene `completada_en` en sintonía con `estado`, de modo que la restricción '
+  '`tareas_completada_coherente` se cumpla siempre sin trabajo del cliente.';
+
+create or replace trigger tareas_sellar_completada
+  before insert or update of estado on public.tareas
+  for each row execute function public.sellar_tarea_completada();
+
+create or replace trigger tareas_actualizado_en
+  before update on public.tareas
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+-- Vista principal del tablero: lo abierto, por fecha límite. Parcial porque las
+-- tareas hechas se acumulan y nunca se consultan así.
+create index if not exists tareas_abiertas_fecha_limite_idx
+  on public.tareas (fecha_limite nulls last)
+  where estado <> 'hecha';
+
+-- Filtro por columna del tablero y orden por urgencia dentro de cada una.
+create index if not exists tareas_estado_prioridad_idx
+  on public.tareas (estado, prioridad desc);
+
+-- Índices de claves foráneas: sin ellos, borrar un perfil o un proveedor obliga
+-- a un recorrido completo de `tareas` para aplicar el SET NULL, y «mis tareas»
+-- tampoco usa índice.
+create index if not exists tareas_responsable_id_idx on public.tareas (responsable_id);
+create index if not exists tareas_proveedor_id_idx   on public.tareas (proveedor_id);
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Mesas
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.mesas (
+  id              uuid not null default gen_random_uuid(),
+  nombre          text not null,
+  capacidad       smallint not null,
+  forma           public.forma_mesa not null default 'redonda',
+  posicion_x      numeric(8, 2),
+  posicion_y      numeric(8, 2),
+  notas           text,
+  creado_en       timestamptz not null default now(),
+  actualizado_en  timestamptz not null default now(),
+
+  constraint mesas_pk primary key (id),
+
+  constraint mesas_nombre_longitud
+    check (length(btrim(nombre)) between 1 and 60),
+
+  -- Cota superior generosa (mesa imperial): no es una regla de producto, es una
+  -- red contra el dedazo (un 200 en vez de un 20 descuadraría todo el reparto).
+  constraint mesas_capacidad_rango
+    check (capacidad between 1 and 30),
+
+  -- O la mesa está colocada en el plano, o no lo está. Media coordenada no
+  -- significa nada y rompería el render.
+  constraint mesas_posicion_completa
+    check (num_nulls(posicion_x, posicion_y) in (0, 2)),
+
+  -- El lienzo del plano es un espacio propio de coordenadas positivas; el límite
+  -- superior atrapa arrastres corruptos que sacarían la mesa fuera del plano.
+  constraint mesas_posicion_dentro_del_lienzo
+    check (
+      posicion_x is null
+      or (posicion_x between 0 and 10000 and posicion_y between 0 and 10000)
+    ),
+
+  constraint mesas_notas_longitud
+    check (notas is null or char_length(notas) <= 1000)
+);
+alter table public.mesas enable row level security;
+
+comment on table public.mesas is
+  'Mesas del banquete. Además del reparto de invitados, guarda la posición en el '
+  'plano visual para que el diseño de sala sobreviva a recargas y a cambios de '
+  'dispositivo.';
+comment on column public.mesas.capacidad is
+  'Comensales que caben. El panel avisa cuando los invitados asignados la superan; '
+  'la base de datos no lo bloquea porque durante el reparto se sobrepasa '
+  'temporalmente.';
+comment on column public.mesas.posicion_x is
+  'Coordenada horizontal en el lienzo del plano (unidades del plano, no píxeles). '
+  'NULL = mesa creada pero aún no colocada.';
+
+-- «Mesa 4» y «mesa 4 » son la misma mesa para quien organiza: la unicidad se
+-- aplica sobre el nombre normalizado, no sobre los bytes.
+create unique index if not exists mesas_nombre_unico_idx
+  on public.mesas (lower(btrim(nombre)));
+
+create or replace trigger mesas_actualizado_en
+  before update on public.mesas
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+
+-- 3.1 Asignación de mesa ------------------------------------------------------
+-- La columna `invitados.mesa_id` ya existe: la declara la migración de invitados.
+-- Aquí sólo se ata la clave foránea, que es donde nace la tabla referenciada.
+-- ON DELETE SET NULL: eliminar una mesa del plano NO puede borrar personas; sus
+-- invitados vuelven a la bolsa de «sin mesa» y se reasignan.
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_catalog.pg_constraint where conname = 'invitados_mesa_id_fk'
+  ) then
+    alter table public.invitados
+      add constraint invitados_mesa_id_fk
+      foreign key (mesa_id) references public.mesas (id) on delete set null;
+  end if;
+end;
+$$;
+
+-- Necesario para el SET NULL del borrado y para listar «los de esta mesa».
+create index if not exists invitados_mesa_id_idx on public.invitados (mesa_id);
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Medios
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.medios (
+  id                   uuid not null default gen_random_uuid(),
+
+  ruta_almacenamiento  text not null,
+  texto_alternativo    jsonb not null,
+  seccion              public.seccion_landing not null,
+  orden                smallint,
+  ancho                integer,
+  alto                 integer,
+  marcador_borroso            text,
+  publicado            boolean not null default false,
+
+  subido_por           uuid,
+
+  creado_en            timestamptz not null default now(),
+  actualizado_en       timestamptz not null default now(),
+
+  constraint medios_pk primary key (id),
+
+  -- ON DELETE SET NULL: la foto de la landing no desaparece porque se dé de baja
+  -- a quien la subió; sólo se pierde la autoría.
+  constraint medios_subido_por_fk
+    foreign key (subido_por) references public.perfiles (id) on delete set null,
+
+  constraint medios_ruta_valida
+    check (public.es_ruta_almacenamiento_valida(ruta_almacenamiento)),
+
+  -- La obligatoriedad del idioma se comprueba en un trigger contra
+  -- `configuracion_boda.idioma_por_defecto`: aquí sólo se exige que sea un
+  -- objeto. Fijar 'es' en el CHECK duplicaría en código un dato que ya es
+  -- configuración y que los novios pueden cambiar (regla 1).
+  constraint medios_texto_alternativo_objeto
+    check (jsonb_typeof(texto_alternativo) = 'object'),
+
+  constraint medios_orden_no_negativo
+    check (orden is null or orden >= 0),
+
+  -- Ancho y alto viajan juntos: con uno solo no se puede reservar el hueco y
+  -- volvería el desplazamiento de layout que el plan maestro quiere evitar.
+  constraint medios_dimensiones_coherentes
+    check (
+      (ancho is null) = (alto is null)
+      and (ancho is null or (ancho between 1 and 20000 and alto between 1 and 20000))
+    ),
+
+  constraint medios_marcador_borroso_longitud
+    check (marcador_borroso is null or length(marcador_borroso) between 6 and 200)
+);
+alter table public.medios enable row level security;
+
+comment on table public.medios is
+  'Imágenes de la landing. Única fuente de verdad: ninguna foto pública vive en '
+  '`/public`, todas se suben y ordenan desde el panel y se sirven desde Storage.';
+
+comment on column public.medios.ruta_almacenamiento is
+  'Ruta del objeto dentro del bucket. La base de datos guarda la ruta, nunca la '
+  'URL firmada, que caduca. Admite mayúsculas: `galeria/DSC_0001.JPG` es una clave '
+  'legal y habitual, y rechazarla dejaba ficheros huérfanos en el bucket con un '
+  'error que el usuario no podía corregir.';
+comment on column public.medios.texto_alternativo is
+  'Texto alternativo por idioma: {"es": "…", "en": "…"}. Obligatorio en el idioma '
+  'por defecto de la boda.';
+comment on column public.medios.orden is
+  'Posición dentro de su sección. Si se deja a NULL al insertar, un trigger coloca '
+  'la imagen al final.';
+comment on column public.medios.publicado is
+  'Por defecto FALSE: una foto recién subida no aparece en la landing hasta que '
+  'alguien la publica a conciencia. Es la columna que filtra la política RLS de '
+  '`anon`.';
+
+-- Un mismo objeto de Storage no puede estar dado de alta dos veces.
+create unique index if not exists medios_ruta_unica_idx
+  on public.medios (ruta_almacenamiento);
+
+-- Orden determinista dentro de cada sección. DEFERRABLE para poder permutar dos
+-- imágenes en una sola transacción sin pasar por valores intermedios ficticios.
+do $$
+begin
+  if not exists (
+    select 1 from pg_catalog.pg_constraint where conname = 'medios_orden_unico_por_seccion'
+  ) then
+    alter table public.medios
+      add constraint medios_orden_unico_por_seccion
+      unique (seccion, orden) deferrable initially deferred;
+  end if;
+end;
+$$;
+
+create or replace function public.asignar_orden_medio()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if new.orden is null then
+    select coalesce(max(m.orden), -1) + 1
+      into new.orden
+      from public.medios as m
+     where m.seccion = new.seccion;
+  end if;
+  return new;
+end;
+$$;
+
+comment on function public.asignar_orden_medio() is
+  'Coloca al final de su sección los medios insertados sin `orden`. SECURITY '
+  'INVOKER a propósito: quien inserta una foto es un editor, que ya tiene SELECT '
+  'sobre `medios` por política, así que no hace falta ningún privilegio elevado '
+  'para leer el máximo. Dos altas simultáneas en la misma sección pueden chocar '
+  'contra la unicidad: el cliente reintenta, que es preferible a serializar toda '
+  'la tabla.';
+
+create or replace trigger medios_asignar_orden
+  before insert on public.medios
+  for each row execute function public.asignar_orden_medio();
+
+
+-- 4.1 Texto alternativo obligatorio en el idioma de la boda -------------------
+
+create or replace function public.validar_texto_alternativo_medio()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_idioma text;
+begin
+  select c.idioma_por_defecto into v_idioma
+    from public.configuracion_boda as c
+   limit 1;
+
+  v_idioma := coalesce(v_idioma, 'es');
+
+  if not (new.texto_alternativo ? v_idioma)
+     or length(btrim(new.texto_alternativo ->> v_idioma)) not between 3 and 300
+  then
+    raise exception 'MED01'
+      using errcode = 'check_violation',
+            detail  = format('idioma=%s', v_idioma),
+            hint    = 'Falta el texto alternativo en el idioma por defecto de la boda.';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.validar_texto_alternativo_medio() is
+  'Accesibilidad AA: ninguna imagen entra sin texto alternativo en el idioma que '
+  'la landing sirve realmente. Lo lee de `configuracion_boda` en vez de fijar '
+  '"es" en un CHECK, porque el idioma por defecto es configuración: si los novios '
+  'lo cambian a "ca", la restricción tiene que seguir protegiendo el idioma que '
+  'se muestra, no uno escrito a mano en una migración.';
+
+create or replace trigger medios_validar_texto_alternativo
+  before insert or update of texto_alternativo on public.medios
+  for each row execute function public.validar_texto_alternativo_medio();
+
+create or replace trigger medios_actualizado_en
+  before update on public.medios
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+-- Consulta de la landing pública: lo publicado de una sección, ya ordenado.
+-- Parcial: los borradores no se piden nunca por esta vía.
+create index if not exists medios_publicados_idx
+  on public.medios (seccion, orden)
+  where publicado;
+
+create index if not exists medios_subido_por_idx
+  on public.medios (subido_por)
+  where subido_por is not null;
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Auditoría de TODAS las tablas de dominio
+--
+--    El trigger genérico se construyó en la migración base describiéndose como
+--    «reutilizable por cualquier tabla del esquema», y hasta ahora sólo colgaba
+--    de dos. Sin esto, borrar el grupo «Familia Pérez Gómez» se lleva por
+--    cascada a 5 invitados y todo su historial de confirmaciones —menús,
+--    alergias, autobús— sin dejar ni una fila que diga quién lo hizo, cuándo, ni
+--    con qué datos. Los triggers de fila SÍ se disparan en los borrados en
+--    cascada, así que la traza queda completa y el borrado es reconstruible.
+--
+--    Se hace aquí porque ésta es la primera migración en la que existen todas
+--    las tablas.
+-- ----------------------------------------------------------------------------
+
+do $$
+declare
+  v_tabla text;
+begin
+  foreach v_tabla in array array[
+    'perfiles',
+    'invitaciones_panel',
+    'configuracion_boda',
+    'configuracion_privada',
+    'secciones_landing',
+    'grupos_invitacion',
+    'notas_grupo',
+    'invitados',
+    'notas_invitado',
+    'confirmaciones',
+    'categorias_proveedor',
+    'proveedores',
+    'documentos_proveedor',
+    'servicios',
+    'categorias_presupuesto',
+    'partidas_presupuesto',
+    'pagos',
+    'tareas',
+    'mesas',
+    'medios'
+  ]
+  loop
+    execute format(
+      'create or replace trigger %I after insert or update or delete on public.%I
+         for each row execute function public.registrar_auditoria()',
+      v_tabla || '_auditoria', v_tabla
+    );
+  end loop;
+end;
+$$;
+
+
+-- ----------------------------------------------------------------------------
+-- 6. Permisos sobre las funciones de este bloque
+-- ----------------------------------------------------------------------------
+
+revoke execute on function public.sellar_tarea_completada()           from public, anon, authenticated;
+revoke execute on function public.asignar_orden_medio()               from public, anon, authenticated;
+revoke execute on function public.validar_texto_alternativo_medio()   from public, anon, authenticated;
+
+commit;

--- a/supabase/migrations/20260803090400_rls.sql
+++ b/supabase/migrations/20260803090400_rls.sql
@@ -1,0 +1,633 @@
+-- ============================================================================
+-- 20260803090400_rls.sql
+-- Ticket: BODA-14 (políticas RLS, privilegios y límite de intentos)
+-- Motor:  PostgreSQL 17 (Supabase)
+--
+-- Qué hace este fichero:
+--   1. Parámetros de seguridad y bitácora de intentos contra el RSVP.
+--   2. Funciones de rol (`rol_actual`, `puede_leer`, `puede_editar`,
+--      `es_propietario`), todas exigiendo perfil ACTIVO.
+--   3. Privilegios: se conceden uno a uno, y sólo los imprescindibles. Los
+--      privilegios por defecto ya se revocaron en la migración base, así que
+--      hasta aquí ninguna tabla del proyecto era accesible por la API.
+--   4. Políticas RLS de las 22 tablas.
+--   5. `force row level security` donde ninguna función interna lo impide.
+--
+-- El modelo, en una frase: `anon` sólo ve la landing (configuración pública,
+-- secciones visibles y fotos publicadas) y llega al RSVP únicamente a través de
+-- dos funciones; un colaborador ve lo que su rol permite; nadie escribe en el
+-- histórico ni en la bitácora.
+--
+-- TRUNCATE: nunca se concede. RLS no se aplica a TRUNCATE, así que conceder
+-- `all` sobre una tabla equivale a regalar un borrado total inmune a políticas.
+-- Por eso aquí los GRANT enumeran siempre las operaciones.
+--
+-- Rollback: supabase/migrations/rollback/20260803090400_rls.sql
+-- ============================================================================
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- 1. Parámetros de seguridad
+--    Los límites del cortafuegos del RSVP son configuración, no código: se
+--    ajustan sin migración y sin desplegar (regla 1).
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.parametros_seguridad (
+  id                        uuid not null default gen_random_uuid(),
+  fila_unica                boolean not null default true,
+
+  maximo_intentos_rsvp      smallint not null default 10,
+  ventana_intentos_minutos  smallint not null default 15,
+  dias_retencion_intentos   smallint not null default 30,
+
+  creado_en                 timestamptz not null default now(),
+  actualizado_en            timestamptz not null default now(),
+
+  constraint parametros_seguridad_pk primary key (id),
+  constraint parametros_seguridad_fila_unica_valor check (fila_unica),
+  constraint parametros_seguridad_fila_unica unique (fila_unica),
+
+  constraint parametros_seguridad_maximo_intentos_rango
+    check (maximo_intentos_rsvp between 1 and 1000),
+  constraint parametros_seguridad_ventana_rango
+    check (ventana_intentos_minutos between 1 and 1440),
+  constraint parametros_seguridad_retencion_rango
+    check (dias_retencion_intentos between 1 and 365)
+);
+alter table public.parametros_seguridad enable row level security;
+
+comment on table public.parametros_seguridad is
+  'Fila única con los límites del cortafuegos del RSVP. Un token de 192 bits no '
+  'se adivina por fuerza bruta, pero el límite evita que alguien use el endpoint '
+  'público como amplificador o para sondear el esquema.';
+
+create or replace trigger parametros_seguridad_actualizado_en
+  before update on public.parametros_seguridad
+  for each row
+  when (old.* is distinct from new.*)
+  execute function public.fijar_actualizado_en();
+
+insert into public.parametros_seguridad (fila_unica) values (true)
+on conflict (fila_unica) do nothing;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Intentos contra el RSVP
+-- ----------------------------------------------------------------------------
+
+create table if not exists public.intentos_rsvp (
+  id           uuid not null default gen_random_uuid(),
+  huella       text not null,
+  huella_token   bytea,
+  exito        boolean not null default false,
+  creado_en    timestamptz not null default now(),
+
+  constraint intentos_rsvp_pk primary key (id),
+  constraint intentos_rsvp_huella_longitud
+    check (length(btrim(huella)) between 1 and 200)
+);
+alter table public.intentos_rsvp enable row level security;
+
+comment on table public.intentos_rsvp is
+  'Bitácora de intentos de resolver un token de invitación. Sólo la escriben las '
+  'funciones públicas del RSVP; ningún rol tiene INSERT.';
+comment on column public.intentos_rsvp.huella is
+  'Identificación aproximada del origen (IP reenviada por el proxy de Supabase). '
+  'No es una identidad: es lo único con lo que se puede contar intentos en un '
+  'endpoint anónimo.';
+comment on column public.intentos_rsvp.huella_token is
+  'Huella SHA-256 del token que se intentó, nunca el token. Permite distinguir '
+  '"alguien se equivoca de enlace" de "alguien prueba enlaces al azar" sin '
+  'guardar la credencial.';
+
+create index if not exists intentos_rsvp_huella_idx
+  on public.intentos_rsvp (huella, creado_en desc);
+
+create index if not exists intentos_rsvp_creado_en_idx
+  on public.intentos_rsvp (creado_en);
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Funciones de rol
+--
+--    Todas exigen `activo`. Es la pieza que hace que registrarse con la clave
+--    anónima no conceda absolutamente nada: el perfil nace inactivo salvo que el
+--    correo figure en `invitaciones_panel`.
+--
+--    SECURITY DEFINER y no INVOKER porque una política sobre `perfiles` que
+--    consultara `perfiles` provocaría recursión infinita (42P17).
+-- ----------------------------------------------------------------------------
+
+create or replace function public.rol_actual()
+returns public.rol_usuario
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select p.rol
+    from public.perfiles as p
+   where p.usuario_id = (select auth.uid())
+     and p.activo
+   limit 1;
+$$;
+
+comment on function public.rol_actual() is
+  'Rol efectivo de quien hace la petición, o NULL si no hay sesión, no hay perfil '
+  'o el perfil está dado de baja. Es la única fuente de autorización del panel.';
+
+create or replace function public.puede_leer()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select public.rol_actual() is not null;
+$$;
+
+comment on function public.puede_leer() is
+  'Cierto para cualquier colaborador activo (lector, editor o propietario).';
+
+create or replace function public.puede_editar()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select coalesce(public.rol_actual() in ('propietario', 'editor'), false);
+$$;
+
+comment on function public.puede_editar() is
+  'Cierto para editor y propietario. Nunca devuelve NULL: un NULL en una política '
+  'se comporta como falso, pero en un `not ...` de un trigger sería un agujero.';
+
+create or replace function public.es_propietario()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select coalesce(public.rol_actual() = 'propietario', false);
+$$;
+
+comment on function public.es_propietario() is
+  'Cierto sólo para los novios. Gobierna la gestión de usuarios, la configuración '
+  'privada y la lectura de la bitácora de auditoría.';
+
+
+-- Valores declarados del propio perfil, para el `with check` de la política de
+-- autoedición. Van en funciones SECURITY DEFINER por el mismo motivo de
+-- recursión: una política de `perfiles` no puede leer `perfiles`.
+
+create or replace function public.rol_declarado()
+returns public.rol_usuario
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select p.rol from public.perfiles as p where p.usuario_id = (select auth.uid()) limit 1;
+$$;
+
+create or replace function public.alta_declarada()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select p.activo from public.perfiles as p where p.usuario_id = (select auth.uid()) limit 1;
+$$;
+
+comment on function public.rol_declarado() is
+  'Rol almacenado del propio perfil, con independencia de si está activo. Sólo lo '
+  'usa la política de autoedición para congelar la columna.';
+comment on function public.alta_declarada() is
+  'Valor almacenado de `activo` del propio perfil. Sólo lo usa la política de '
+  'autoedición para congelar la columna.';
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Privilegios
+--    Se parte de cero (la migración base revocó las default privileges) y se
+--    concede lo mínimo. RLS filtra filas ENCIMA de esto; el GRANT decide a qué
+--    tablas se puede siquiera dirigir una petición.
+-- ----------------------------------------------------------------------------
+
+revoke all on all tables in schema public from anon, authenticated;
+
+-- 4.1 anon: sólo lo que pinta la landing ------------------------------------
+grant select on public.configuracion_boda to anon;
+grant select on public.secciones_landing  to anon;
+grant select on public.medios             to anon;
+
+-- 4.2 authenticated: lectura -------------------------------------------------
+grant select on
+  public.configuracion_boda,
+  public.configuracion_privada,
+  public.secciones_landing,
+  public.perfiles,
+  public.invitaciones_panel,
+  public.registro_auditoria,
+  public.campos_auditoria_redactados,
+  public.parametros_seguridad,
+  public.intentos_rsvp,
+  public.grupos_invitacion,
+  public.notas_grupo,
+  public.invitados,
+  public.notas_invitado,
+  public.confirmaciones,
+  public.categorias_proveedor,
+  public.proveedores,
+  public.documentos_proveedor,
+  public.servicios,
+  public.categorias_presupuesto,
+  public.partidas_presupuesto,
+  public.pagos,
+  public.tareas,
+  public.mesas,
+  public.medios
+  to authenticated;
+
+-- 4.3 authenticated: escritura ------------------------------------------------
+-- `confirmaciones` queda deliberadamente FUERA: el histórico es de sólo
+-- inserción, y el UPDATE de vigencia lo hace un trigger SECURITY DEFINER.
+grant insert, update, delete on
+  public.grupos_invitacion,
+  public.notas_grupo,
+  public.invitados,
+  public.notas_invitado,
+  public.categorias_proveedor,
+  public.proveedores,
+  public.documentos_proveedor,
+  public.servicios,
+  public.categorias_presupuesto,
+  public.partidas_presupuesto,
+  public.pagos,
+  public.tareas,
+  public.mesas,
+  public.medios
+  to authenticated;
+
+grant insert on public.confirmaciones to authenticated;
+
+grant update on
+  public.configuracion_boda,
+  public.configuracion_privada,
+  public.secciones_landing,
+  public.perfiles,
+  public.parametros_seguridad
+  to authenticated;
+
+grant insert, update, delete on public.invitaciones_panel to authenticated;
+
+-- Funciones de rol. Primero se cierran y después se abren SÓLO a
+-- `authenticated`, nombrando explícitamente a `public` y a `anon`.
+--
+-- El `revoke ... from public` NO es decorativo ni redundante con las default
+-- privileges revocadas en la migración base: se ha comprobado que toda función
+-- nueva sigue naciendo con EXECUTE para el pseudo-rol PUBLIC, del que `anon`
+-- hereda. Sin estas líneas, `select public.rol_actual()` sería invocable como
+-- RPC con la clave anónima.
+revoke execute on function public.rol_actual()      from public, anon, authenticated;
+revoke execute on function public.puede_leer()      from public, anon, authenticated;
+revoke execute on function public.puede_editar()    from public, anon, authenticated;
+revoke execute on function public.es_propietario()  from public, anon, authenticated;
+revoke execute on function public.rol_declarado()   from public, anon, authenticated;
+revoke execute on function public.alta_declarada()  from public, anon, authenticated;
+
+-- Las evalúan las propias políticas, así que el rol que consulta necesita
+-- EXECUTE. No revelan nada que quien llama no sepa ya de sí mismo. `anon` queda
+-- fuera: ninguna política suya las usa.
+grant execute on function public.rol_actual()      to authenticated;
+grant execute on function public.puede_leer()      to authenticated;
+grant execute on function public.puede_editar()    to authenticated;
+grant execute on function public.es_propietario()  to authenticated;
+grant execute on function public.rol_declarado()   to authenticated;
+grant execute on function public.alta_declarada()  to authenticated;
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Políticas
+--    Convención: `<tabla>_<quién>_<qué>`. Todas llevan cláusula TO explícita
+--    (`auth.role()` está obsoleto y además se rompe con inicios de sesión
+--    anónimos), y todas envuelven las funciones en `(select ...)` para que se
+--    evalúen una vez por sentencia y no una vez por fila.
+--
+--    Antes de crearlas se borran TODAS las políticas del esquema público.
+--    PostgreSQL no admite `create policy if not exists`, así que sin esto la
+--    migración no se puede reaplicar: muere en la primera política que ya
+--    exista, justo cuando se está reintentando un despliegue que falló a mitad.
+--
+--    Además, borrar y recrear es la semántica correcta para una migración de
+--    seguridad: reaplicarla CONVERGE el estado exacto de las políticas en vez
+--    de acumularlas. Si alguien añadió una política a mano en el panel de
+--    Supabase, ésta desaparece; y una política de más es precisamente el tipo
+--    de deriva que no queremos que sobreviva a un despliegue.
+-- ----------------------------------------------------------------------------
+
+do $$
+declare
+  v_politica record;
+begin
+  for v_politica in
+    select schemaname, tablename, policyname
+      from pg_policies
+     where schemaname = 'public'
+  loop
+    execute format('drop policy if exists %I on %I.%I',
+                   v_politica.policyname, v_politica.schemaname, v_politica.tablename);
+  end loop;
+end;
+$$;
+
+-- 5.1 Configuración pública ---------------------------------------------------
+
+create policy configuracion_boda_publica_leer on public.configuracion_boda
+  for select to anon, authenticated using (true);
+
+create policy configuracion_boda_editor_actualizar on public.configuracion_boda
+  for update to authenticated
+  using ((select public.puede_editar()))
+  with check ((select public.puede_editar()));
+
+comment on policy configuracion_boda_publica_leer on public.configuracion_boda is
+  'La fila entera es publicable por diseño: todo lo sensible vive en '
+  '`configuracion_privada`. Por eso `using (true)` aquí es seguro y no lo sería '
+  'si ambas cosas compartieran tabla.';
+
+-- 5.2 Configuración privada ---------------------------------------------------
+
+create policy configuracion_privada_editor_leer on public.configuracion_privada
+  for select to authenticated using ((select public.puede_editar()));
+
+create policy configuracion_privada_propietario_actualizar on public.configuracion_privada
+  for update to authenticated
+  using ((select public.es_propietario()))
+  with check ((select public.es_propietario()));
+
+-- 5.3 Secciones de la landing -------------------------------------------------
+
+create policy secciones_landing_publica_leer on public.secciones_landing
+  for select to anon using (visible);
+
+create policy secciones_landing_colaborador_leer on public.secciones_landing
+  for select to authenticated using ((select public.puede_leer()));
+
+create policy secciones_landing_editor_actualizar on public.secciones_landing
+  for update to authenticated
+  using ((select public.puede_editar()))
+  with check ((select public.puede_editar()));
+
+-- 5.4 Perfiles ----------------------------------------------------------------
+
+create policy perfiles_propio_leer on public.perfiles
+  for select to authenticated using (usuario_id = (select auth.uid()));
+
+create policy perfiles_colaborador_leer on public.perfiles
+  for select to authenticated using ((select public.puede_leer()));
+
+create policy perfiles_propio_actualizar on public.perfiles
+  for update to authenticated
+  using (usuario_id = (select auth.uid()))
+  with check (
+    usuario_id = (select auth.uid())
+    -- Cinturón, además de los tirantes del trigger
+    -- `perfiles_proteger_privilegios`: cambiar el nombre y ascenderse a
+    -- propietario no pueden ser la misma operación.
+    and rol    = (select public.rol_declarado())
+    and activo = (select public.alta_declarada())
+  );
+
+create policy perfiles_propietario_gestionar on public.perfiles
+  for all to authenticated
+  using ((select public.es_propietario()))
+  with check ((select public.es_propietario()));
+
+-- 5.5 Lista blanca de acceso al panel ----------------------------------------
+
+create policy invitaciones_panel_propietario_gestionar on public.invitaciones_panel
+  for all to authenticated
+  using ((select public.es_propietario()))
+  with check ((select public.es_propietario()));
+
+-- 5.6 Auditoría ---------------------------------------------------------------
+-- Sólo SELECT y sólo propietario. Sin política de INSERT: la única vía de
+-- escritura es el trigger SECURITY DEFINER, de modo que nadie puede fabricar ni
+-- suprimir entradas desde la API. Y sin UPDATE ni DELETE para nadie: un
+-- histórico que se puede editar no es un histórico.
+
+create policy registro_auditoria_propietario_leer on public.registro_auditoria
+  for select to authenticated using ((select public.es_propietario()));
+
+create policy campos_auditoria_redactados_propietario_leer on public.campos_auditoria_redactados
+  for select to authenticated using ((select public.es_propietario()));
+
+-- 5.7 Seguridad del RSVP ------------------------------------------------------
+
+create policy parametros_seguridad_propietario_leer on public.parametros_seguridad
+  for select to authenticated using ((select public.es_propietario()));
+
+create policy parametros_seguridad_propietario_actualizar on public.parametros_seguridad
+  for update to authenticated
+  using ((select public.es_propietario()))
+  with check ((select public.es_propietario()));
+
+create policy intentos_rsvp_propietario_leer on public.intentos_rsvp
+  for select to authenticated using ((select public.es_propietario()));
+
+-- 5.8 Invitados, grupos y confirmaciones --------------------------------------
+-- `anon` NO tiene ninguna política aquí, ni ningún GRANT: la ruta pública del
+-- RSVP pasa exclusivamente por `obtener_invitacion()` y `registrar_confirmacion()`.
+
+create policy grupos_invitacion_colaborador_leer on public.grupos_invitacion
+  for select to authenticated using ((select public.puede_leer()));
+
+create policy grupos_invitacion_editor_escribir on public.grupos_invitacion
+  for all to authenticated
+  using ((select public.puede_editar()))
+  with check ((select public.puede_editar()));
+
+create policy invitados_colaborador_leer on public.invitados
+  for select to authenticated using ((select public.puede_leer()));
+
+create policy invitados_editor_escribir on public.invitados
+  for all to authenticated
+  using ((select public.puede_editar()))
+  with check ((select public.puede_editar()));
+
+create policy confirmaciones_colaborador_leer on public.confirmaciones
+  for select to authenticated using ((select public.puede_leer()));
+
+create policy confirmaciones_editor_insertar on public.confirmaciones
+  for insert to authenticated with check ((select public.puede_editar()));
+
+comment on policy confirmaciones_editor_insertar on public.confirmaciones is
+  'Sólo INSERT. No hay política de UPDATE ni de DELETE para ningún rol: el '
+  'historial es de sólo inserción y quien cambia de opinión genera una fila '
+  'nueva. La degradación de la respuesta anterior la hace un trigger SECURITY '
+  'DEFINER, no el cliente.';
+
+-- Las notas privadas quedan fuera del alcance del rol `lector`: son comentarios
+-- de los novios sobre sus invitados.
+create policy notas_grupo_editor_gestionar on public.notas_grupo
+  for all to authenticated
+  using ((select public.puede_editar()))
+  with check ((select public.puede_editar()));
+
+create policy notas_invitado_editor_gestionar on public.notas_invitado
+  for all to authenticated
+  using ((select public.puede_editar()))
+  with check ((select public.puede_editar()));
+
+-- 5.9 Economía y organización -------------------------------------------------
+-- Mismo patrón para las nueve tablas: lectura para cualquier colaborador activo,
+-- escritura para editor y propietario. Se generan en bucle para que ninguna se
+-- quede sin política por un despiste al copiar y pegar.
+
+do $$
+declare
+  v_tabla text;
+begin
+  foreach v_tabla in array array[
+    'categorias_proveedor',
+    'proveedores',
+    'documentos_proveedor',
+    'servicios',
+    'categorias_presupuesto',
+    'partidas_presupuesto',
+    'pagos',
+    'tareas',
+    'mesas'
+  ]
+  loop
+    execute format(
+      'create policy %I on public.%I for select to authenticated
+         using ((select public.puede_leer()))',
+      v_tabla || '_colaborador_leer', v_tabla);
+
+    execute format(
+      'create policy %I on public.%I for all to authenticated
+         using ((select public.puede_editar()))
+         with check ((select public.puede_editar()))',
+      v_tabla || '_editor_escribir', v_tabla);
+  end loop;
+end;
+$$;
+
+-- 5.10 Medios -----------------------------------------------------------------
+
+create policy medios_publica_leer on public.medios
+  for select to anon using (publicado);
+
+create policy medios_colaborador_leer on public.medios
+  for select to authenticated using ((select public.puede_leer()));
+
+create policy medios_editor_escribir on public.medios
+  for all to authenticated
+  using ((select public.puede_editar()))
+  with check ((select public.puede_editar()));
+
+comment on policy medios_publica_leer on public.medios is
+  'La landing sólo ve lo publicado. Un borrador subido y aún sin revisar no se '
+  'filtra por pedir la tabla entera con la clave anónima.';
+
+
+-- ----------------------------------------------------------------------------
+-- 6. `force row level security`
+--
+--    `enable` no aplica al PROPIETARIO de la tabla, que en Supabase es también
+--    el propietario de las funciones SECURITY DEFINER. Sin `force`, dentro de
+--    cualquier función definer —presente o futura— la RLS de estas tablas está
+--    sencillamente desactivada, y la seguridad pasa a depender de que el WHERE
+--    de esa función esté bien escrito.
+--
+--    Se fuerza en todas las tablas MENOS en aquellas que la maquinaria interna
+--    necesita tocar como propietario. Cada excepción está justificada; no son
+--    olvidos:
+--
+--      · perfiles, invitaciones_panel .... las leen las funciones de rol y el
+--                                          trigger de alta, que se ejecutan
+--                                          antes de que exista sesión.
+--      · registro_auditoria ............. la escribe el trigger de auditoría.
+--      · campos_auditoria_redactados .... la lee ese mismo trigger.
+--      · configuracion_boda ............. es pública entera; la leen los
+--                                          triggers de plazo y de accesibilidad.
+--      · parametros_seguridad ........... la lee el cortafuegos del RSVP.
+--      · intentos_rsvp .................. la escribe el cortafuegos del RSVP.
+--      · grupos_invitacion, invitados,
+--        confirmaciones ................. las recorren las dos funciones
+--                                          públicas del RSVP.
+--
+--    Para esas siete últimas, la compensación es de diseño y está en
+--    20260803090500_funciones_publicas.sql: ninguna función pública declara
+--    `returns setof <tabla>` ni usa `select *`, y el filtro por token va SIEMPRE
+--    en la misma sentencia que lee o escribe, nunca en una comprobación previa.
+-- ----------------------------------------------------------------------------
+
+do $$
+declare
+  v_tabla text;
+begin
+  foreach v_tabla in array array[
+    'configuracion_privada',
+    'secciones_landing',
+    'notas_grupo',
+    'notas_invitado',
+    'categorias_proveedor',
+    'proveedores',
+    'documentos_proveedor',
+    'servicios',
+    'categorias_presupuesto',
+    'partidas_presupuesto',
+    'pagos',
+    'tareas',
+    'mesas',
+    'medios'
+  ]
+  loop
+    execute format('alter table public.%I force row level security', v_tabla);
+  end loop;
+end;
+$$;
+
+
+-- ----------------------------------------------------------------------------
+-- 7. Guardias para el CI
+--    Las tres consultas siguientes DEBEN devolver cero filas. Van como
+--    comentario porque su sitio es la suite de tests (regla 4 del proyecto),
+--    pero se dejan aquí escritas para que nadie tenga que reinventarlas.
+--
+--    a) Ninguna tabla del esquema público sin RLS:
+--       select c.relname from pg_class c join pg_namespace n on n.oid = c.relnamespace
+--        where n.nspname = 'public' and c.relkind = 'r' and not c.relrowsecurity;
+--
+--    b) Ninguna vista sin `security_invoker`, ninguna vista materializada.
+--       Ojo: PostgreSQL guarda la opción tal cual se escribió, así que vale
+--       tanto `on` como `true`. Comparar sólo contra 'true' marca como
+--       inseguras las ocho vistas del proyecto, que sí lo llevan; y un guardia
+--       que da falsos positivos acaba desactivado, que es peor que no tenerlo:
+--       select c.relname, c.relkind
+--         from pg_class c join pg_namespace n on n.oid = c.relnamespace
+--        where n.nspname = 'public'
+--          and (c.relkind = 'm'
+--               or (c.relkind = 'v' and coalesce((select lower(option_value)
+--                     from pg_options_to_table(c.reloptions)
+--                    where option_name = 'security_invoker'), 'false')
+--                   not in ('true', 'on')));
+--
+--    c) Ninguna función ejecutable por anon salvo las dos RPC del RSVP:
+--       select p.proname, r.rolname
+--         from pg_proc p
+--         cross join lateral (values ('anon')) as r(rolname)
+--        where p.pronamespace = 'public'::regnamespace
+--          and has_function_privilege(r.rolname, p.oid, 'execute')
+--          and p.proname not in ('obtener_invitacion', 'registrar_confirmacion',
+--                                'anadir_acompanante');
+-- ----------------------------------------------------------------------------
+
+commit;

--- a/supabase/migrations/20260803090500_funciones_publicas.sql
+++ b/supabase/migrations/20260803090500_funciones_publicas.sql
@@ -1,0 +1,594 @@
+-- ============================================================================
+-- 20260803090500_funciones_publicas.sql
+-- Ticket: BODA-14 (funciones públicas del RSVP y emisión de enlaces)
+-- Motor:  PostgreSQL 17 (Supabase)
+--
+-- Qué hace este fichero:
+--   1. Emisión de enlaces de invitación (`rotar_token_invitacion`,
+--      `crear_grupo_invitacion`): el único sitio donde existe el token en claro.
+--   2. Cortafuegos de intentos.
+--   3. Las TRES funciones que puede llamar `anon`, y ninguna más:
+--        · obtener_invitacion(token)
+--        · registrar_confirmacion(token, respuestas)
+--        · anadir_acompanante(token, ...)
+--   4. Purga programada de la bitácora de intentos.
+--
+-- ---------------------------------------------------------------------------
+-- REGLAS DE ESCRITURA DE ESTE FICHERO. No son estilo: son la compensación por
+-- que `grupos_invitacion`, `invitados` y `confirmaciones` no lleven `force row
+-- level security` (ver el apartado 6 de la migración de RLS). Dentro de estas
+-- funciones, que son SECURITY DEFINER y propiedad del dueño de las tablas, la
+-- RLS NO se evalúa. Lo único que separa a un invitado de los datos de otro es
+-- cómo está escrito el SQL de aquí:
+--
+--   a) Ninguna función declara `returns setof <tabla>` ni usa `select *`. El
+--      tipo de retorno se enumera columna a columna, de modo que añadir mañana
+--      una columna sensible a `invitados` no la publica sola.
+--   b) `invitado_id` JAMÁS se acepta como dato de entrada suelto: se deriva del
+--      token DENTRO de la misma sentencia que lee o escribe. Un identificador
+--      ajeno no produce un error: produce cero filas.
+--   c) Prohibido `jsonb_populate_record` / `jsonb_to_record` contra el tipo de
+--      una tabla completa. Se enumeran uno a uno los campos que el invitado
+--      puede escribir; el resto (origen, registrado_por, respondido_en,
+--      es_vigente) lo fija el servidor.
+--   d) El plazo se comprueba siempre contra `now()`, nunca contra una fecha que
+--      venga en la petición.
+-- ---------------------------------------------------------------------------
+--
+-- ---------------------------------------------------------------------------
+-- UN ENLACE NO VÁLIDO NO LANZA EXCEPCIÓN: DEVUELVE VACÍO. Y no es un capricho.
+--
+-- El cortafuegos cuenta los intentos fallidos guardándolos en `intentos_rsvp`.
+-- Si al detectar un token inválido la función lanzara una excepción, PostgREST
+-- abortaría la transacción y ese INSERT se iría con ella: la bitácora sólo
+-- acabaría conteniendo intentos con ÉXITO y el límite no saltaría jamás. Se ha
+-- comprobado sobre la base real —quince intentos fallidos seguidos dejaban cero
+-- filas registradas—, así que el cortafuegos habría sido decorativo.
+--
+-- PostgreSQL no tiene transacciones autónomas, de modo que la única forma de que
+-- el registro del intento sobreviva es no abortar. Contrato resultante:
+--
+--   · obtener_invitacion      → cero filas   = enlace no válido
+--   · registrar_confirmacion  → devuelve 0   = enlace no válido
+--   · anadir_acompanante      → devuelve NULL = enlace no válido
+--
+-- Las excepciones se reservan para lo que SÍ tiene que deshacer escritura.
+-- ---------------------------------------------------------------------------
+--
+-- Códigos de error (el copy visible vive en content/copy.es.json):
+--   RSV01  enlace no válido      — NO es excepción: es un resultado vacío
+--   RSV02  demasiados intentos                     (excepción: corta en seco)
+--   RSV03  plazo de confirmación cerrado           (lo lanza el trigger de plazo)
+--   RSV04  el invitado no pertenece a esta invitación
+--   RSV05  el grupo ha agotado sus acompañantes    (lo lanza el trigger de aforo)
+--   RSV06  intento de cambiar privilegios de la invitación
+--   RSV07  respuesta fechada en el futuro
+--
+-- Rollback: supabase/migrations/rollback/20260803090500_funciones_publicas.sql
+-- ============================================================================
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- 1. Emisión de enlaces
+--    El texto plano del token existe exactamente una vez: como valor devuelto
+--    por estas funciones. No se guarda, no se registra y no se puede recuperar;
+--    si se pierde, se emite otro.
+-- ----------------------------------------------------------------------------
+
+create or replace function public.rotar_token_invitacion(p_grupo_id uuid)
+returns text
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_token text;
+begin
+  if not public.puede_editar() then
+    raise exception 'RSV06'
+      using errcode = 'insufficient_privilege',
+            hint    = 'Sólo un editor puede emitir enlaces de invitación.';
+  end if;
+
+  v_token := public.generar_token_invitacion();
+
+  update public.grupos_invitacion
+     set huella_token       = public.huella_token(v_token),
+         token_emitido_en = now()
+   where id = p_grupo_id;
+
+  if not found then
+    raise exception 'RSV01'
+      using errcode = 'no_data_found',
+            hint    = 'No existe esa invitación.';
+  end if;
+
+  return v_token;
+end;
+$$;
+
+comment on function public.rotar_token_invitacion(uuid) is
+  'Emite un enlace nuevo para un grupo y devuelve el token en claro UNA sola vez. '
+  'Invalida el anterior en el acto, así que sirve tanto para mandar la invitación '
+  'como para revocarla si se filtra. El trigger de congelación de privilegios no '
+  'estorba: esta función comprueba `puede_editar()` antes de tocar nada.';
+
+create or replace function public.crear_grupo_invitacion(
+  p_nombre               text,
+  p_maximo_acompanantes  smallint default 0,
+  p_lado                 public.lado_invitacion default 'ambos',
+  p_invitado_a           public.evento_boda[] default array['ceremonia','banquete','fiesta']::public.evento_boda[]
+)
+returns table (grupo_id uuid, token text)
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_grupo_id uuid;
+  v_token    text;
+begin
+  if not public.puede_editar() then
+    raise exception 'RSV06'
+      using errcode = 'insufficient_privilege',
+            hint    = 'Sólo un editor puede crear invitaciones.';
+  end if;
+
+  v_token := public.generar_token_invitacion();
+
+  insert into public.grupos_invitacion (
+    nombre, maximo_acompanantes, lado, invitado_a, huella_token, token_emitido_en
+  )
+  values (
+    p_nombre, p_maximo_acompanantes, p_lado, p_invitado_a,
+    public.huella_token(v_token), now()
+  )
+  returning id into v_grupo_id;
+
+  return query select v_grupo_id, v_token;
+end;
+$$;
+
+comment on function public.crear_grupo_invitacion(text, smallint, public.lado_invitacion, public.evento_boda[]) is
+  'Crea un grupo y devuelve su enlace en un solo paso, que es lo que necesita el '
+  'panel al dar de alta una familia. Sin esto habría que crear el grupo y rotar '
+  'el token en dos llamadas, con una ventana en la que el grupo no tiene enlace.';
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Cortafuegos de intentos
+-- ----------------------------------------------------------------------------
+
+create or replace function public.huella_peticion()
+returns text
+language sql
+stable
+set search_path = ''
+as $$
+  select coalesce(
+    nullif(btrim(split_part(
+      coalesce(current_setting('request.headers', true)::jsonb ->> 'x-forwarded-for', ''),
+      ',', 1)), ''),
+    'desconocido'
+  );
+$$;
+
+comment on function public.huella_peticion() is
+  'Origen aproximado de la petición, a partir de la cabecera que reenvía el proxy '
+  'de Supabase. En un endpoint anónimo no hay identidad: esto es lo único con lo '
+  'que se pueden contar intentos.';
+
+create or replace function public.exigir_cupo_rsvp()
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_maximo   smallint;
+  v_ventana  smallint;
+  v_intentos bigint;
+begin
+  select s.maximo_intentos_rsvp, s.ventana_intentos_minutos
+    into v_maximo, v_ventana
+    from public.parametros_seguridad as s
+   limit 1;
+
+  -- Sin parámetros configurados se aplica el criterio conservador: cerrar.
+  if v_maximo is null or v_ventana is null then
+    raise exception 'RSV02'
+      using errcode = 'insufficient_privilege',
+            hint    = 'El servicio de confirmación no está disponible.';
+  end if;
+
+  select count(*)
+    into v_intentos
+    from public.intentos_rsvp as i
+   where i.huella = public.huella_peticion()
+     and not i.exito
+     and i.creado_en > now() - make_interval(mins => v_ventana);
+
+  if v_intentos >= v_maximo then
+    raise exception 'RSV02'
+      using errcode = 'insufficient_privilege',
+            hint    = 'Demasiados intentos. Probad de nuevo dentro de un rato.';
+  end if;
+end;
+$$;
+
+comment on function public.exigir_cupo_rsvp() is
+  'Corta el sondeo de tokens al azar contra /rsvp/[token]. Sólo cuentan los '
+  'intentos FALLIDOS: una familia que abre su enlace veinte veces no se '
+  'autobloquea.';
+
+create or replace function public.registrar_intento_rsvp(p_token text, p_exito boolean)
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+begin
+  insert into public.intentos_rsvp (huella, huella_token, exito)
+  values (public.huella_peticion(), public.huella_token(p_token), p_exito);
+end;
+$$;
+
+comment on function public.registrar_intento_rsvp(text, boolean) is
+  'Anota el intento. Guarda la huella del token, nunca el token: la bitácora de '
+  'seguridad no puede convertirse en un almacén de credenciales.';
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Resolver una invitación
+-- ----------------------------------------------------------------------------
+
+create or replace function public.obtener_invitacion(p_token text)
+returns table (
+  grupo_id             uuid,
+  grupo_nombre         text,
+  lado                 public.lado_invitacion,
+  invitado_a           public.evento_boda[],
+  maximo_acompanantes  smallint,
+  acompanantes_usados  bigint,
+  idioma               text,
+  invitado_id          uuid,
+  nombre               text,
+  apellidos            text,
+  es_nino              boolean,
+  es_acompanante       boolean,
+  tipo_menu            public.tipo_menu,
+  alergias             text,
+  estado               public.estado_confirmacion,
+  respondido_en        timestamptz,
+  necesita_autobus     boolean,
+  necesita_alojamiento boolean,
+  cancion_solicitada   text,
+  mensaje              text
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_grupo_id uuid;
+begin
+  perform public.exigir_cupo_rsvp();
+
+  -- El token se resuelve por su huella. La tabla no contiene el secreto.
+  select g.id into v_grupo_id
+    from public.grupos_invitacion as g
+   where g.huella_token = public.huella_token(p_token);
+
+  -- RSV01: se anota el fallo y se devuelve vacío. Lanzar aquí borraría el propio
+  -- registro del intento al abortar la transacción (ver cabecera del fichero).
+  if v_grupo_id is null then
+    perform public.registrar_intento_rsvp(p_token, false);
+    return;
+  end if;
+
+  perform public.registrar_intento_rsvp(p_token, true);
+
+  -- Tipo de retorno enumerado columna a columna. NO existe aquí `notas`, ni
+  -- `huella_token`, ni la dirección postal de nadie más: lo que el invitado no
+  -- debe ver, sencillamente no se selecciona.
+  return query
+    select
+      g.id,
+      g.nombre,
+      g.lado,
+      g.invitado_a,
+      g.maximo_acompanantes,
+      (select count(*) from public.invitados as a
+        where a.grupo_id = g.id and a.es_acompanante),
+      coalesce(g.idioma, c.idioma_por_defecto),
+      i.id,
+      i.nombre,
+      i.apellidos,
+      i.es_nino,
+      i.es_acompanante,
+      i.tipo_menu,
+      i.alergias,
+      f.estado,
+      f.respondido_en,
+      f.necesita_autobus,
+      f.necesita_alojamiento,
+      f.cancion_solicitada,
+      f.mensaje
+    from public.grupos_invitacion as g
+    cross join lateral (
+      select cb.idioma_por_defecto from public.configuracion_boda as cb limit 1
+    ) as c
+    join public.invitados as i on i.grupo_id = g.id
+    left join public.confirmaciones as f
+      on f.invitado_id = i.id and f.es_vigente
+   where g.id = v_grupo_id
+   order by i.es_acompanante, i.nombre_completo;
+end;
+$$;
+
+comment on function public.obtener_invitacion(text) is
+  'Única puerta de lectura del RSVP público. CERO FILAS significa enlace no '
+  'válido: no lanza excepción, porque al abortar se perdería el registro del '
+  'intento y el cortafuegos dejaría de contar. Devuelve el grupo del token y sus '
+  'personas, con la respuesta vigente de cada una. El tipo de retorno se enumera '
+  'a mano a propósito: con `returns setof public.invitados` el invitado recibiría '
+  'también teléfonos, correos y notas privadas de sus coinvitados, y cualquier '
+  'columna que se añadiera en el futuro se publicaría sola.';
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Registrar la respuesta
+-- ----------------------------------------------------------------------------
+
+create or replace function public.registrar_confirmacion(p_token text, p_respuestas jsonb)
+returns integer
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_grupo_id  uuid;
+  v_insertadas integer;
+  v_recibidas  integer;
+begin
+  perform public.exigir_cupo_rsvp();
+
+  select g.id into v_grupo_id
+    from public.grupos_invitacion as g
+   where g.huella_token = public.huella_token(p_token);
+
+  -- RSV01: 0 = enlace no válido. Una llamada legítima siempre registra al menos
+  -- una respuesta (si no, se aborta con RSV04 más abajo), así que el 0 no es
+  -- ambiguo.
+  if v_grupo_id is null then
+    perform public.registrar_intento_rsvp(p_token, false);
+    return 0;
+  end if;
+
+  perform public.registrar_intento_rsvp(p_token, true);
+
+  if jsonb_typeof(p_respuestas) <> 'array' then
+    raise exception 'RSV04'
+      using errcode = 'invalid_parameter_value',
+            hint    = 'El formato de las respuestas no es válido.';
+  end if;
+
+  v_recibidas := jsonb_array_length(p_respuestas);
+
+  -- Deja constancia del origen para la bitácora de auditoría: dentro de una
+  -- función SECURITY DEFINER llamada con la clave anónima, `auth.uid()` es NULL
+  -- y sin esto el cambio sería indistinguible de una migración.
+  perform set_config('boda.origen_cambio', 'rsvp:' || v_grupo_id::text, true);
+
+  -- El JOIN con `invitados` y `grupos_invitacion` es lo que ata cada respuesta
+  -- al grupo del token, DENTRO de la misma sentencia que inserta. Un
+  -- `invitado_id` de otro grupo no casa y no inserta nada: no hay ventana entre
+  -- comprobar y escribir, ni forma de degradar la confirmación de un tercero.
+  with entrada as (
+    select
+      (r ->> 'invitado_id')::uuid                          as invitado_id,
+      (r ->> 'estado')::public.estado_confirmacion         as estado,
+      -- Una casilla que el navegador no envía significa «no marcada», es decir
+      -- «no», no «no lo sé». Sin este coalesce llegaría NULL y la restricción
+      -- `confirmaciones_logistica_completa` abortaría la confirmación entera con
+      -- un 23514 en la cara del invitado, sin nada que él pudiera hacer para
+      -- arreglarlo. Sólo se normaliza cuando la respuesta es `confirmado`: quien
+      -- no viene no tiene por qué opinar sobre el autobús, y ahí el NULL es el
+      -- valor correcto.
+      case when (r ->> 'estado') = 'confirmado'
+           then coalesce((r ->> 'necesita_autobus')::boolean, false)
+           else (r ->> 'necesita_autobus')::boolean end     as necesita_autobus,
+      case when (r ->> 'estado') = 'confirmado'
+           then coalesce((r ->> 'necesita_alojamiento')::boolean, false)
+           else (r ->> 'necesita_alojamiento')::boolean end as necesita_alojamiento,
+      nullif(btrim(r ->> 'cancion_solicitada'), '')        as cancion_solicitada,
+      nullif(btrim(r ->> 'mensaje'), '')                   as mensaje
+    from jsonb_array_elements(p_respuestas) as r
+  )
+  insert into public.confirmaciones (
+    invitado_id, estado, origen, respondido_en,
+    necesita_autobus, necesita_alojamiento, cancion_solicitada, mensaje,
+    registrado_por
+  )
+  select
+    i.id,
+    e.estado,
+    'publico',      -- fijado por el servidor, jamás leído de la petición
+    now(),          -- idem: el invitado no fecha su propia respuesta
+    e.necesita_autobus,
+    e.necesita_alojamiento,
+    e.cancion_solicitada,
+    e.mensaje,
+    null            -- una respuesta pública no tiene autor del panel
+  from entrada as e
+  join public.invitados as i
+    on i.id = e.invitado_id
+   and i.grupo_id = v_grupo_id;
+
+  get diagnostics v_insertadas = row_count;
+
+  -- Si alguna respuesta no cuajó, o sobra o era de otro grupo. En ambos casos se
+  -- deshace todo: una confirmación a medias es peor que ninguna.
+  if v_insertadas <> v_recibidas then
+    raise exception 'RSV04'
+      using errcode = 'insufficient_privilege',
+            detail  = format('grupo=%s recibidas=%s insertadas=%s',
+                             v_grupo_id, v_recibidas, v_insertadas),
+            hint    = 'Alguna de las personas no pertenece a esta invitación.';
+  end if;
+
+  return v_insertadas;
+end;
+$$;
+
+comment on function public.registrar_confirmacion(text, jsonb) is
+  'Única puerta de escritura del RSVP público. Devuelve cuántas respuestas ha '
+  'registrado; 0 significa enlace no válido. El plazo lo aplica el trigger '
+  '`confirmaciones_validar_plazo` contra `now()`; el origen, la fecha de respuesta '
+  'y la autoría los fija esta función y no la petición; y la pertenencia al grupo '
+  'se resuelve en el propio INSERT. Si el número de filas insertadas no coincide '
+  'con el de respuestas recibidas, la transacción entera se deshace.';
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Añadir un acompañante
+--    El tope lo garantiza el constraint trigger `invitados_aforo_grupo`, que
+--    bloquea la fila del grupo: treinta llamadas concurrentes no pueden colar
+--    treinta acompañantes en un grupo que sólo admite uno.
+-- ----------------------------------------------------------------------------
+
+create or replace function public.anadir_acompanante(
+  p_token      text,
+  p_nombre     text,
+  p_apellidos  text default null,
+  p_es_nino    boolean default false,
+  p_tipo_menu  public.tipo_menu default 'estandar',
+  p_alergias   text default null
+)
+returns uuid
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_grupo_id    uuid;
+  v_invitado_id uuid;
+begin
+  perform public.exigir_cupo_rsvp();
+
+  select g.id into v_grupo_id
+    from public.grupos_invitacion as g
+   where g.huella_token = public.huella_token(p_token);
+
+  -- RSV01: NULL = enlace no válido.
+  if v_grupo_id is null then
+    perform public.registrar_intento_rsvp(p_token, false);
+    return null;
+  end if;
+
+  perform public.registrar_intento_rsvp(p_token, true);
+  perform set_config('boda.origen_cambio', 'rsvp:' || v_grupo_id::text, true);
+
+  insert into public.invitados (
+    grupo_id, nombre, apellidos, es_nino, es_acompanante, tipo_menu, alergias
+  )
+  values (
+    v_grupo_id, p_nombre, p_apellidos, p_es_nino, true, p_tipo_menu, p_alergias
+  )
+  returning id into v_invitado_id;
+
+  return v_invitado_id;
+end;
+$$;
+
+comment on function public.anadir_acompanante(text, text, text, boolean, public.tipo_menu, text) is
+  'Da de alta un acompañante en el grupo del token; devuelve NULL si el enlace no '
+  'es válido. `grupo_id` y `es_acompanante` '
+  'los fija el servidor: el invitado no puede añadir gente a otra invitación ni '
+  'colar a alguien como titular para no consumir plaza.';
+
+
+-- ----------------------------------------------------------------------------
+-- 6. Purga de la bitácora de intentos
+-- ----------------------------------------------------------------------------
+
+create or replace function public.purgar_intentos_rsvp()
+returns integer
+language plpgsql
+volatile
+security definer
+set search_path = ''
+as $$
+declare
+  v_dias     smallint;
+  v_borradas integer;
+begin
+  select s.dias_retencion_intentos into v_dias
+    from public.parametros_seguridad as s
+   limit 1;
+
+  delete from public.intentos_rsvp
+   where creado_en < now() - make_interval(days => coalesce(v_dias, 30));
+
+  get diagnostics v_borradas = row_count;
+  return v_borradas;
+end;
+$$;
+
+comment on function public.purgar_intentos_rsvp() is
+  'Limpia los intentos antiguos. Se programa con pg_cron; el periodo de retención '
+  'es configuración (`parametros_seguridad.dias_retencion_intentos`), no un '
+  'literal dentro de la función.';
+
+
+-- ----------------------------------------------------------------------------
+-- 7. Privilegios
+--    Sólo tres funciones son públicas. Todo lo demás queda cerrado, y se cierra
+--    nombrando a `anon` y `authenticated`: `revoke ... from public` NO les quita
+--    nada, porque su EXECUTE viene de un GRANT explícito de Supabase y no del
+--    pseudo-rol PUBLIC.
+-- ----------------------------------------------------------------------------
+
+revoke execute on function public.rotar_token_invitacion(uuid)                      from public, anon, authenticated;
+revoke execute on function public.crear_grupo_invitacion(text, smallint, public.lado_invitacion, public.evento_boda[]) from public, anon, authenticated;
+revoke execute on function public.huella_peticion()                                 from public, anon, authenticated;
+revoke execute on function public.exigir_cupo_rsvp()                                from public, anon, authenticated;
+revoke execute on function public.registrar_intento_rsvp(text, boolean)             from public, anon, authenticated;
+revoke execute on function public.purgar_intentos_rsvp()                            from public, anon, authenticated;
+revoke execute on function public.obtener_invitacion(text)                          from public, anon, authenticated;
+revoke execute on function public.registrar_confirmacion(text, jsonb)               from public, anon, authenticated;
+revoke execute on function public.anadir_acompanante(text, text, text, boolean, public.tipo_menu, text) from public, anon, authenticated;
+
+-- Las tres puertas públicas del RSVP, y ninguna más.
+grant execute on function public.obtener_invitacion(text)             to anon, authenticated;
+grant execute on function public.registrar_confirmacion(text, jsonb)  to anon, authenticated;
+grant execute on function public.anadir_acompanante(text, text, text, boolean, public.tipo_menu, text) to anon, authenticated;
+
+-- La emisión de enlaces la usa el panel.
+grant execute on function public.rotar_token_invitacion(uuid) to authenticated;
+grant execute on function public.crear_grupo_invitacion(text, smallint, public.lado_invitacion, public.evento_boda[]) to authenticated;
+
+commit;
+
+-- ============================================================================
+-- NOTAS DE OPERACIÓN (no son SQL de esta migración, pero sin ellas no cierra)
+-- ----------------------------------------------------------------------------
+-- 1. Programar la purga:
+--      select cron.schedule('purgar-intentos-rsvp', '30 4 * * *',
+--                           'select public.purgar_intentos_rsvp()');
+-- 2. La clave `service_role` tiene BYPASSRLS y anula todo este fichero de una
+--    sola vez: nunca puede aparecer en código de cliente ni en una variable de
+--    entorno con prefijo público (`NEXT_PUBLIC_*`).
+-- 3. El registro público de Supabase puede quedarse activado sin riesgo: un alta
+--    nueva crea un perfil INACTIVO salvo que el correo esté en
+--    `invitaciones_panel`, y todas las funciones de rol exigen `activo`. La
+--    seguridad está en la base de datos, no en una casilla del panel.
+-- ============================================================================

--- a/supabase/migrations/20260803090600_vistas.sql
+++ b/supabase/migrations/20260803090600_vistas.sql
@@ -1,0 +1,286 @@
+-- ============================================================================
+-- 20260803090600_vistas.sql
+-- Ticket: BODA-14 (vistas de lectura para la landing y el panel)
+-- Motor:  PostgreSQL 17 (Supabase)
+--
+-- Qué hace este fichero:
+--   Las vistas que el frontend consume, de modo que ninguna regla de negocio
+--   —el coste por invitado confirmado, la desviación del presupuesto— acabe
+--   reimplementada en TypeScript y deje de coincidir con la base de datos.
+--
+-- ---------------------------------------------------------------------------
+-- DOS REGLAS INNEGOCIABLES PARA TODA VISTA DE `public`:
+--
+--   1. `with (security_invoker = on)`. En PostgreSQL una vista se ejecuta con
+--      los privilegios de su PROPIETARIO salvo que se diga lo contrario. En
+--      Supabase el propietario es `postgres`, dueño de todas estas tablas: una
+--      vista normal ignora TODA la RLS de las tablas base. `v_resumen_presupuesto`
+--      cruza por definición categorías, partidas, pagos y proveedores — es
+--      exactamente el agregado que un atacante quiere, servido sin que ninguna
+--      política intervenga.
+--
+--   2. Columnas ENUMERADAS una a una. Nunca `select *`: con el asterisco,
+--      cualquier `alter table ... add column` futuro se publica solo, en
+--      silencio y sin que nadie lo revise.
+--
+--   Prohibidas además las vistas MATERIALIZADAS sobre estas tablas: no admiten
+--   `security_invoker` en absoluto y saltan RLS siempre. Si alguna vez hiciera
+--   falta una, va a un esquema no expuesto y se accede por función SECURITY
+--   DEFINER acotada.
+-- ---------------------------------------------------------------------------
+--
+-- Rollback: supabase/migrations/rollback/20260803090600_vistas.sql
+-- ============================================================================
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- 1. Landing pública
+-- ----------------------------------------------------------------------------
+
+create or replace view public.v_configuracion_publica
+with (security_invoker = on) as
+select
+  c.nombre_novia,
+  c.nombre_novio,
+  c.hashtag,
+  c.fecha_hora_ceremonia,
+  c.fecha_hora_banquete,
+  c.zona_horaria,
+  c.fecha_limite_rsvp,
+  c.lugar_ceremonia,
+  c.direccion_ceremonia,
+  c.latitud_ceremonia,
+  c.longitud_ceremonia,
+  c.lugar_banquete,
+  c.direccion_banquete,
+  c.latitud_banquete,
+  c.longitud_banquete,
+  c.correo_contacto,
+  c.moneda,
+  c.idioma_por_defecto
+from public.configuracion_boda as c;
+
+comment on view public.v_configuracion_publica is
+  'Lo que la landing necesita para pintarse. Las columnas van enumeradas aunque '
+  '`configuracion_boda` sea publicable entera: es la disciplina que impide que '
+  'una columna añadida mañana aparezca sola en la web.';
+
+create or replace view public.v_secciones_publicas
+with (security_invoker = on) as
+select
+  s.seccion,
+  s.orden
+from public.secciones_landing as s
+where s.visible
+order by s.orden;
+
+comment on view public.v_secciones_publicas is
+  'Secciones visibles de la landing, en orden. Sustituye a los nueve flags '
+  '`mostrar_*` y evita que el frontend tenga que traducir a mano nombres de '
+  'columna a nombres de sección.';
+
+create or replace view public.v_medios_publicados
+with (security_invoker = on) as
+select
+  m.id,
+  m.ruta_almacenamiento,
+  m.texto_alternativo,
+  m.seccion,
+  m.orden,
+  m.ancho,
+  m.alto,
+  m.marcador_borroso
+from public.medios as m
+where m.publicado
+order by m.seccion, m.orden;
+
+comment on view public.v_medios_publicados is
+  'Fotos publicadas, ya ordenadas por sección. No expone `subido_por` ni las '
+  'fechas internas: a la landing no le hacen falta.';
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Estadísticas de invitados
+-- ----------------------------------------------------------------------------
+
+create or replace view public.v_estadisticas_invitados
+with (security_invoker = on) as
+select
+  count(*)                                                   as personas,
+  count(*) filter (where f.estado = 'confirmado')             as confirmados,
+  count(*) filter (where f.estado = 'confirmado' and not i.es_nino) as adultos_confirmados,
+  count(*) filter (where f.estado = 'confirmado' and i.es_nino)     as ninos_confirmados,
+  count(*) filter (where f.estado = 'rechazado')              as rechazados,
+  count(*) filter (where f.estado = 'tentativo')              as tentativos,
+  count(*) filter (where f.estado = 'pendiente')              as pendientes,
+  count(*) filter (where f.estado = 'confirmado' and f.necesita_autobus)     as plazas_autobus,
+  count(*) filter (where f.estado = 'confirmado' and f.necesita_alojamiento) as necesitan_alojamiento
+from public.invitados as i
+join public.confirmaciones as f
+  on f.invitado_id = i.id and f.es_vigente;
+
+comment on view public.v_estadisticas_invitados is
+  'Recuento del panel en una sola fila. El JOIN es limpio, sin COALESCE ni LEFT '
+  'JOIN, porque todo invitado tiene siempre una confirmación vigente: lo garantiza '
+  '`invitados_confirmacion_inicial` al darlo de alta y '
+  '`confirmaciones_siempre_vigente` a partir de entonces.';
+
+create or replace view public.v_menus_confirmados
+with (security_invoker = on) as
+select
+  i.tipo_menu,
+  count(*) as personas,
+  count(*) filter (where i.alergias is not null) as con_alergias
+from public.invitados as i
+join public.confirmaciones as f
+  on f.invitado_id = i.id and f.es_vigente
+where f.estado = 'confirmado'
+group by i.tipo_menu;
+
+comment on view public.v_menus_confirmados is
+  'Lo que se le manda al catering: cuántos menús de cada tipo y cuántos llevan '
+  'alergias anotadas. El recuento de niños NO sale de aquí sino de `es_nino`, '
+  'porque un menor puede llevar menú sin gluten o vegetariano.';
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Economía
+-- ----------------------------------------------------------------------------
+
+create or replace view public.v_servicios_importe
+with (security_invoker = on) as
+select
+  s.id,
+  s.proveedor_id,
+  s.nombre,
+  s.descripcion,
+  s.precio_unitario,
+  s.cantidad,
+  s.por_invitado,
+  s.importe_fijo,
+  case
+    when s.por_invitado
+      then s.precio_unitario * s.cantidad
+           * coalesce((select e.confirmados from public.v_estadisticas_invitados as e), 0)
+    else s.importe_fijo
+  end as importe_total
+from public.servicios as s;
+
+comment on view public.v_servicios_importe is
+  'Importe real de cada servicio, resolviendo aquí —y no en el frontend— los de '
+  'precio por invitado. Si el criterio cambia (por ejemplo, contar a los niños a '
+  'media tarifa), se cambia en esta vista y el panel entero se entera; con la '
+  'fórmula replicada en TypeScript, dejaría de coincidir en silencio.';
+
+create or replace view public.v_resumen_presupuesto
+with (security_invoker = on) as
+select
+  c.id                                           as categoria_id,
+  c.nombre                                       as categoria,
+  c.orden,
+  c.importe_previsto,
+  coalesce(sum(p.importe_estimado), 0)           as estimado,
+  coalesce(sum(p.importe_real), 0)               as real,
+  coalesce(sum(g.pagado), 0)                     as pagado,
+  coalesce(sum(g.pendiente), 0)                  as pendiente,
+  c.importe_previsto - coalesce(sum(coalesce(p.importe_real, p.importe_estimado)), 0)
+                                                 as desviacion
+from public.categorias_presupuesto as c
+left join public.partidas_presupuesto as p
+  on p.categoria_id = c.id
+left join lateral (
+  select
+    coalesce(sum(pg.importe) filter (where pg.pagado_en is not null), 0) as pagado,
+    coalesce(sum(pg.importe) filter (where pg.pagado_en is null), 0)     as pendiente
+  from public.pagos as pg
+  where pg.partida_id = p.id
+) as g on true
+group by c.id, c.nombre, c.orden, c.importe_previsto;
+
+comment on view public.v_resumen_presupuesto is
+  'Previsto contra estimado, real y pagado, por categoría. `desviacion` usa el '
+  'importe real cuando existe y el estimado mientras no: es la cifra que de '
+  'verdad interesa mirar, no la suma de lo que ya se ha pagado.';
+
+create or replace view public.v_proximos_pagos
+with (security_invoker = on) as
+select
+  pg.id,
+  pg.partida_id,
+  pa.concepto,
+  ca.nombre        as categoria,
+  pr.nombre        as proveedor,
+  pg.importe,
+  pg.fecha_vencimiento,
+  pg.fecha_vencimiento < current_date as vencido
+from public.pagos as pg
+join public.partidas_presupuesto as pa on pa.id = pg.partida_id
+join public.categorias_presupuesto as ca on ca.id = pa.categoria_id
+left join public.proveedores as pr on pr.id = pa.proveedor_id
+where pg.pagado_en is null
+order by pg.fecha_vencimiento;
+
+comment on view public.v_proximos_pagos is
+  'Qué hay que pagar y cuándo, con su contexto ya resuelto. Es el aviso del panel '
+  'y la única consulta que responde a la pregunta operativa del día a día.';
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Privilegios de las vistas
+--    Con `security_invoker = on`, quien consulta necesita permiso sobre la vista
+--    Y sobre las tablas base, y además pasa por las políticas RLS de éstas. Los
+--    GRANT de aquí no abren nada por su cuenta: sin política que lo permita, la
+--    vista devuelve cero filas.
+-- ----------------------------------------------------------------------------
+
+grant select on public.v_configuracion_publica to anon, authenticated;
+grant select on public.v_secciones_publicas    to anon, authenticated;
+grant select on public.v_medios_publicados     to anon, authenticated;
+
+grant select on
+  public.v_estadisticas_invitados,
+  public.v_menus_confirmados,
+  public.v_servicios_importe,
+  public.v_resumen_presupuesto,
+  public.v_proximos_pagos
+  to authenticated;
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Red de seguridad: barrido final de EXECUTE
+--
+--    Ésta es la última migración del esquema, así que aquí se pasa una escoba
+--    por TODAS las funciones de `public`.
+--
+--    Motivo, comprobado empíricamente sobre una base limpia: revocar las default
+--    privileges NO impide que una función nueva nazca con EXECUTE para el
+--    pseudo-rol PUBLIC, del que `anon` y `authenticated` heredan. Es decir: la
+--    única defensa real es un REVOKE explícito por función, y ese REVOKE es
+--    justo lo que alguien olvidará el día que añada la función número treinta.
+--    Un olvido así no da un error: publica una RPC.
+--
+--    El barrido revoca EXECUTE a PUBLIC y a `anon` en todo `public`, y devuelve
+--    el permiso únicamente a las tres puertas del RSVP. No toca las concesiones
+--    a `authenticated`, que son explícitas y están justificadas una a una.
+-- ----------------------------------------------------------------------------
+
+do $$
+declare
+  v_funcion record;
+begin
+  for v_funcion in
+    select p.oid::regprocedure as firma
+      from pg_catalog.pg_proc as p
+     where p.pronamespace = 'public'::regnamespace
+  loop
+    execute format('revoke execute on function %s from public, anon', v_funcion.firma);
+  end loop;
+end;
+$$;
+
+grant execute on function public.obtener_invitacion(text)            to anon;
+grant execute on function public.registrar_confirmacion(text, jsonb) to anon;
+grant execute on function public.anadir_acompanante(text, text, text, boolean, public.tipo_menu, text) to anon;
+
+commit;

--- a/supabase/migrations/20260803090700_arranque.sql
+++ b/supabase/migrations/20260803090700_arranque.sql
@@ -1,0 +1,137 @@
+-- BODA-10 · Arranque en frío del primer propietario
+--
+-- PROBLEMA QUE RESUELVE
+--
+-- `perfiles.activo` nace en false y el trigger `proteger_privilegios_perfil`
+-- exige que YA exista un propietario activo para poder activar a nadie. En una
+-- base de datos recién desplegada no existe ninguno, así que el candado se
+-- cierra sobre sí mismo: nadie puede entrar jamás, ni siquiera el superusuario.
+--
+-- Se detectó ejecutando las migraciones contra un Postgres real y siguiendo el
+-- flujo completo de acceso. Ninguna revisión del SQL lo habría visto: cada
+-- pieza es correcta por separado.
+--
+-- CÓMO SE RESUELVE
+--
+-- Una función de arranque que:
+--   * solo puede ejecutar `service_role` (la clave de servidor, que nunca sale
+--     del backend y no está en el bundle del cliente);
+--   * se niega a actuar si ya existe un propietario activo, de modo que no
+--     sirve para escalar privilegios más adelante;
+--   * marca la sesión con un testigo que el trigger reconoce, para poder
+--     escribir sin desactivar la protección para todos los demás.
+--
+-- El trigger pasa a admitir esa única excepción, explícita y acotada.
+
+-- ---------------------------------------------------------------------------
+-- 1. El trigger admite el testigo de arranque
+-- ---------------------------------------------------------------------------
+
+create or replace function public.proteger_privilegios_perfil()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+begin
+  -- Excepción de arranque: la establece `public.designar_primer_propietario`
+  -- durante su propia transacción y solo vive dentro de ella.
+  if coalesce(current_setting('boda.arranque_en_curso', true), 'no') = 'si' then
+    return new;
+  end if;
+
+  if (new.rol, new.activo, new.usuario_id)
+     is distinct from (old.rol, old.activo, old.usuario_id)
+     and not exists (
+       select 1
+         from public.perfiles as p
+        where p.usuario_id = auth.uid()
+          and p.rol = 'propietario'
+          and p.activo
+     )
+  then
+    raise exception 'PRF01'
+      using errcode  = 'insufficient_privilege',
+            detail   = format('perfil=%s', old.id),
+            hint     = 'Sólo un propietario puede cambiar el rol o el alta de un perfil.';
+  end if;
+
+  return new;
+end;
+$function$;
+
+comment on function public.proteger_privilegios_perfil() is
+  'Impide que nadie se auto-promocione. Única excepción: el arranque en frío, '
+  'acotado a la transacción de designar_primer_propietario().';
+
+-- ---------------------------------------------------------------------------
+-- 2. Designación del primer propietario
+-- ---------------------------------------------------------------------------
+
+create or replace function public.designar_primer_propietario(
+  p_usuario_id uuid,
+  p_nombre_completo text default null
+)
+returns public.perfiles
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_perfil public.perfiles;
+begin
+  if p_usuario_id is null then
+    raise exception 'ARR01'
+      using errcode = 'null_value_not_allowed',
+            hint    = 'Hace falta el identificador del usuario de auth.users.';
+  end if;
+
+  -- Solo sirve una vez. Después, los cambios de rol pasan por el trigger como
+  -- cualquier otro, así que esta función no es una puerta trasera permanente.
+  if exists (
+    select 1 from public.perfiles as p where p.rol = 'propietario' and p.activo
+  ) then
+    raise exception 'ARR02'
+      using errcode = 'unique_violation',
+            hint    = 'Ya hay un propietario activo: usad el panel para dar de alta a los demás.';
+  end if;
+
+  if not exists (select 1 from auth.users as u where u.id = p_usuario_id) then
+    raise exception 'ARR03'
+      using errcode = 'foreign_key_violation',
+            hint    = 'Ese usuario no existe todavía: que inicie sesión una vez y repetid.';
+  end if;
+
+  perform set_config('boda.arranque_en_curso', 'si', true);
+
+  insert into public.perfiles as pf (usuario_id, nombre_completo, correo_electronico, rol, activo)
+  select
+    u.id,
+    coalesce(p_nombre_completo, split_part(coalesce(u.email, 'sin nombre'), '@', 1)),
+    u.email,
+    'propietario',
+    true
+  from auth.users as u
+  where u.id = p_usuario_id
+  on conflict (usuario_id) do update
+    set rol    = 'propietario',
+        activo = true,
+        nombre_completo = coalesce(p_nombre_completo, pf.nombre_completo)
+  returning * into v_perfil;
+
+  perform set_config('boda.arranque_en_curso', 'no', true);
+
+  return v_perfil;
+end;
+$function$;
+
+comment on function public.designar_primer_propietario(uuid, text) is
+  'Arranque en frío: convierte al primer usuario en propietario activo. '
+  'Falla si ya existe uno. Solo ejecutable por service_role.';
+
+-- La clave de servicio vive únicamente en el servidor. Ni anon ni un usuario
+-- autenticado pueden llamar a esto.
+revoke all on function public.designar_primer_propietario(uuid, text) from public;
+revoke all on function public.designar_primer_propietario(uuid, text) from anon;
+revoke all on function public.designar_primer_propietario(uuid, text) from authenticated;
+grant execute on function public.designar_primer_propietario(uuid, text) to service_role;

--- a/supabase/migrations/rollback/20260803090000_base.sql
+++ b/supabase/migrations/rollback/20260803090000_base.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- ROLLBACK de 20260803090000_base.sql
+-- Tickets: BODA-10 (esquema base y convenciones) · BODA-11 (configuración)
+--
+-- Deshace exactamente lo que hace su migración, en orden inverso: primero el
+-- trigger sobre `auth.users`, después las tablas (de la más dependiente a la
+-- más dependida), luego las funciones y por último los enumerados.
+--
+-- Es el ÚLTIMO rollback que debe ejecutarse: el resto del esquema depende de
+-- `public.fijar_actualizado_en()`, `public.es_correo_valido()`,
+-- `public.sin_acentos()` y `public.perfiles`.
+--
+-- Las EXTENSIONES no se eliminan: viven en el esquema `extensions`, son
+-- compartidas y otros objetos —o el propio Supabase— pueden estar usándolas.
+--
+-- Las DEFAULT PRIVILEGES revocadas tampoco se restauran. Devolverle a `anon`
+-- el `grant all` sobre toda tabla futura sería reabrir el agujero que la
+-- migración cierra, no revertir un cambio. Si de verdad se quisiera volver al
+-- estado de fábrica de Supabase (no se recomienda):
+--   alter default privileges in schema public grant all on tables to anon, authenticated;
+-- ============================================================================
+
+begin;
+
+drop trigger if exists auth_users_sincronizar_perfil on auth.users;
+
+drop table if exists public.secciones_landing;
+drop table if exists public.configuracion_privada;
+drop table if exists public.configuracion_boda;
+drop table if exists public.perfiles;
+drop table if exists public.invitaciones_panel;
+drop table if exists public.registro_auditoria;
+drop table if exists public.campos_auditoria_redactados;
+
+drop function if exists public.impedir_borrado_configuracion();
+drop function if exists public.sincronizar_perfil_desde_auth();
+drop function if exists public.proteger_privilegios_perfil();
+drop function if exists public.registrar_auditoria();
+drop function if exists public.redactar_campos_auditados(text, jsonb);
+drop function if exists public.es_ruta_almacenamiento_valida(text);
+drop function if exists public.es_correo_valido(text);
+drop function if exists public.sin_acentos(text);
+drop function if exists public.normalizar_correo();
+drop function if exists public.fijar_actualizado_en();
+drop function if exists public.asegurar_enum(text, text[]);
+
+drop type if exists public.seccion_landing;
+drop type if exists public.rol_usuario;
+drop type if exists public.operacion_auditoria;
+
+commit;

--- a/supabase/migrations/rollback/20260803090100_invitados.sql
+++ b/supabase/migrations/rollback/20260803090100_invitados.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- ROLLBACK de 20260803090100_invitados.sql
+-- Ticket: BODA-12 (invitados, grupos de invitación y confirmaciones)
+--
+-- Deshace exactamente lo que hace su migración, en orden inverso: primero las
+-- tablas (que arrastran sus índices, restricciones y triggers), después las
+-- funciones y por último los enumerados.
+--
+-- AVISO: esto borra invitados, confirmaciones y tokens. Las huellas de los
+-- tokens desaparecen con `grupos_invitacion`, así que TODOS los enlaces
+-- repartidos quedan invalidados para siempre: reaplicar la migración no los
+-- recupera, hay que volver a emitirlos con `rotar_token_invitacion()`.
+--
+-- `public.fijar_actualizado_en()`, `public.normalizar_correo()` y
+-- `public.sin_acentos()` NO se borran: pertenecen a la migración base y las usan
+-- las demás tablas del esquema.
+-- ============================================================================
+
+begin;
+
+drop table if exists public.confirmaciones;
+drop table if exists public.notas_invitado;
+drop table if exists public.invitados;
+drop table if exists public.notas_grupo;
+drop table if exists public.grupos_invitacion;
+
+drop function if exists public.exigir_confirmacion_vigente();
+drop function if exists public.crear_confirmacion_inicial();
+drop function if exists public.proteger_historial_confirmaciones();
+drop function if exists public.validar_plazo_confirmacion();
+drop function if exists public.sellar_respuesta_confirmacion();
+drop function if exists public.marcar_confirmacion_vigente();
+drop function if exists public.invitados_validar_aforo_grupo();
+drop function if exists public.congelar_privilegios_grupo();
+drop function if exists public.normalizar_eventos_grupo();
+drop function if exists public.componer_nombre_completo();
+drop function if exists public.huella_token(text);
+drop function if exists public.generar_token_invitacion();
+
+drop type if exists public.origen_confirmacion;
+drop type if exists public.estado_confirmacion;
+drop type if exists public.tipo_menu;
+drop type if exists public.evento_boda;
+drop type if exists public.lado_invitacion;
+
+commit;

--- a/supabase/migrations/rollback/20260803090200_economia.sql
+++ b/supabase/migrations/rollback/20260803090200_economia.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- ROLLBACK de 20260803090200_economia.sql
+-- Ticket: BODA-13 (proveedores, servicios, presupuesto y pagos)
+--
+-- Deshace exactamente lo que hace su migración, en orden inverso: de la tabla
+-- más dependiente a la más dependida, y los enumerados al final, que no se
+-- pueden borrar mientras alguna columna los use.
+--
+-- Antes de las tablas se sueltan las dependencias que apuntan a `proveedores`
+-- desde OTROS bloques. Sin esto, `drop table public.proveedores` aborta con
+-- 2BP01 («cannot drop table proveedores because other objects depend on it»)
+-- si la migración de organización sigue aplicada, y el rollback se queda a
+-- medias con `pagos` y `partidas_presupuesto` ya borradas.
+-- ============================================================================
+
+begin;
+
+alter table if exists public.tareas
+  drop constraint if exists tareas_proveedor_id_fk;
+
+drop table if exists public.pagos;
+drop table if exists public.partidas_presupuesto;
+drop table if exists public.categorias_presupuesto;
+drop table if exists public.servicios;
+drop table if exists public.documentos_proveedor;
+drop table if exists public.proveedores;
+drop table if exists public.categorias_proveedor;
+
+drop type if exists public.metodo_pago;
+drop type if exists public.tipo_documento_proveedor;
+drop type if exists public.estado_proveedor;
+
+commit;

--- a/supabase/migrations/rollback/20260803090300_organizacion.sql
+++ b/supabase/migrations/rollback/20260803090300_organizacion.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- ROLLBACK de 20260803090300_organizacion.sql
+-- Ticket: BODA-13 (tareas, mesas del banquete y medios de la landing)
+--
+-- Deshace exactamente lo que hace su migración, en orden inverso:
+--   1. Se descuelga el trigger de auditoría de todas las tablas de dominio.
+--   2. Se suelta la clave foránea de `invitados.mesa_id`.
+--   3. Se eliminan las tablas, sus funciones y sus enumerados.
+--
+-- La COLUMNA `invitados.mesa_id` NO se elimina aquí: la declara la migración de
+-- invitados, que es donde nace la tabla que la contiene, y borrarla desde este
+-- fichero destruiría el reparto de mesas al revertir sólo este bloque. Se va
+-- con su tabla en el rollback de 20260803090100_invitados.sql.
+-- ============================================================================
+
+begin;
+
+-- 1. Auditoría ----------------------------------------------------------------
+do $$
+declare
+  v_tabla text;
+begin
+  foreach v_tabla in array array[
+    'perfiles', 'invitaciones_panel', 'configuracion_boda', 'configuracion_privada',
+    'secciones_landing', 'grupos_invitacion', 'notas_grupo', 'invitados',
+    'notas_invitado', 'confirmaciones', 'categorias_proveedor', 'proveedores',
+    'documentos_proveedor', 'servicios', 'categorias_presupuesto',
+    'partidas_presupuesto', 'pagos', 'tareas', 'mesas', 'medios'
+  ]
+  loop
+    execute format('drop trigger if exists %I on public.%I', v_tabla || '_auditoria', v_tabla);
+  end loop;
+end;
+$$;
+
+-- 2. Asignación de mesa -------------------------------------------------------
+drop index if exists public.invitados_mesa_id_idx;
+alter table if exists public.invitados drop constraint if exists invitados_mesa_id_fk;
+
+-- 3. Tablas, funciones y tipos ------------------------------------------------
+-- Las tablas arrastran sus índices, restricciones y triggers.
+drop table if exists public.medios;
+drop table if exists public.mesas;
+drop table if exists public.tareas;
+
+drop function if exists public.validar_texto_alternativo_medio();
+drop function if exists public.asignar_orden_medio();
+drop function if exists public.sellar_tarea_completada();
+
+drop type if exists public.forma_mesa;
+drop type if exists public.prioridad_tarea;
+drop type if exists public.estado_tarea;
+
+commit;

--- a/supabase/migrations/rollback/20260803090400_rls.sql
+++ b/supabase/migrations/rollback/20260803090400_rls.sql
@@ -1,0 +1,85 @@
+-- ============================================================================
+-- ROLLBACK de 20260803090400_rls.sql
+-- Ticket: BODA-14 (políticas RLS, privilegios y límite de intentos)
+--
+-- Deshace exactamente lo que hace su migración, en orden inverso:
+--   1. Se quita `force row level security`.
+--   2. Se eliminan todas las políticas.
+--   3. Se revocan los privilegios concedidos.
+--   4. Se eliminan las funciones de rol.
+--   5. Se eliminan las tablas de seguridad.
+--
+-- LÉASE ANTES DE EJECUTARLO: al terminar, las tablas conservan RLS ACTIVADO y
+-- se quedan SIN NINGUNA POLÍTICA, que es el estado seguro (nadie lee, nadie
+-- escribe) y el mismo en el que las dejan las migraciones de esquema. El panel
+-- dejará de funcionar por completo hasta que se reaplique esta migración: eso
+-- es lo correcto, no un efecto secundario que haya que compensar.
+--
+-- Las funciones de rol se eliminan con CASCADE porque las políticas que las
+-- usan ya se han borrado en el paso 2; si quedara alguna, el CASCADE se la
+-- llevaría, y por eso el orden importa.
+-- ============================================================================
+
+begin;
+
+-- 1. Quitar el forzado de RLS ------------------------------------------------
+do $$
+declare
+  v_tabla text;
+begin
+  foreach v_tabla in array array[
+    'configuracion_privada', 'secciones_landing', 'notas_grupo', 'notas_invitado',
+    'categorias_proveedor', 'proveedores', 'documentos_proveedor', 'servicios',
+    'categorias_presupuesto', 'partidas_presupuesto', 'pagos', 'tareas', 'mesas',
+    'medios'
+  ]
+  loop
+    execute format('alter table if exists public.%I no force row level security', v_tabla);
+  end loop;
+end;
+$$;
+
+-- 2. Eliminar todas las políticas del esquema público -------------------------
+do $$
+declare
+  v_politica record;
+begin
+  for v_politica in
+    select schemaname, tablename, policyname
+      from pg_policies
+     where schemaname = 'public'
+  loop
+    execute format('drop policy if exists %I on %I.%I',
+                   v_politica.policyname, v_politica.schemaname, v_politica.tablename);
+  end loop;
+end;
+$$;
+
+-- 3. Revocar los privilegios --------------------------------------------------
+revoke all on all tables in schema public from anon, authenticated;
+
+revoke execute on function public.alta_declarada() from authenticated;
+revoke execute on function public.rol_declarado()  from authenticated;
+revoke execute on function public.es_propietario() from authenticated;
+revoke execute on function public.puede_editar()   from authenticated;
+revoke execute on function public.puede_leer()     from authenticated;
+revoke execute on function public.rol_actual()     from authenticated;
+
+-- 4. Funciones de rol ---------------------------------------------------------
+-- CASCADE: `congelar_privilegios_grupo()` (BODA-12) y las funciones públicas del
+-- RSVP invocan `puede_editar()`. Sus cuerpos son PL/pgSQL, así que no se
+-- registra dependencia y el DROP no las arrastra; quedan válidas y fallarán en
+-- tiempo de ejecución hasta que se reaplique esta migración. Es coherente con
+-- dejar el esquema cerrado.
+drop function if exists public.alta_declarada();
+drop function if exists public.rol_declarado();
+drop function if exists public.es_propietario();
+drop function if exists public.puede_editar();
+drop function if exists public.puede_leer();
+drop function if exists public.rol_actual();
+
+-- 5. Tablas de la capa de seguridad -------------------------------------------
+drop table if exists public.intentos_rsvp;
+drop table if exists public.parametros_seguridad;
+
+commit;

--- a/supabase/migrations/rollback/20260803090500_funciones_publicas.sql
+++ b/supabase/migrations/rollback/20260803090500_funciones_publicas.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- ROLLBACK de 20260803090500_funciones_publicas.sql
+-- Ticket: BODA-14 (funciones públicas del RSVP y emisión de enlaces)
+--
+-- Deshace exactamente lo que hace su migración, en orden inverso: primero se
+-- retiran las concesiones y después se eliminan las funciones.
+--
+-- AVISO OPERATIVO: al eliminar `rotar_token_invitacion` y
+-- `crear_grupo_invitacion` desaparece la única vía de emitir enlaces de
+-- invitación, y al eliminar `obtener_invitacion` y `registrar_confirmacion` el
+-- RSVP público deja de existir. Los tokens ya emitidos NO se pierden: sus
+-- huellas siguen en `grupos_invitacion.huella_token` y vuelven a funcionar en
+-- cuanto se reaplique la migración.
+--
+-- Si además se ha programado la purga con pg_cron, quitarla antes:
+--   select cron.unschedule('purgar-intentos-rsvp');
+-- ============================================================================
+
+begin;
+
+revoke execute on function public.crear_grupo_invitacion(text, smallint, public.lado_invitacion, public.evento_boda[]) from authenticated;
+revoke execute on function public.rotar_token_invitacion(uuid) from authenticated;
+
+revoke execute on function public.anadir_acompanante(text, text, text, boolean, public.tipo_menu, text) from anon, authenticated;
+revoke execute on function public.registrar_confirmacion(text, jsonb) from anon, authenticated;
+revoke execute on function public.obtener_invitacion(text)            from anon, authenticated;
+
+drop function if exists public.purgar_intentos_rsvp();
+drop function if exists public.anadir_acompanante(text, text, text, boolean, public.tipo_menu, text);
+drop function if exists public.registrar_confirmacion(text, jsonb);
+drop function if exists public.obtener_invitacion(text);
+drop function if exists public.registrar_intento_rsvp(text, boolean);
+drop function if exists public.exigir_cupo_rsvp();
+drop function if exists public.huella_peticion();
+drop function if exists public.crear_grupo_invitacion(text, smallint, public.lado_invitacion, public.evento_boda[]);
+drop function if exists public.rotar_token_invitacion(uuid);
+
+commit;

--- a/supabase/migrations/rollback/20260803090600_vistas.sql
+++ b/supabase/migrations/rollback/20260803090600_vistas.sql
@@ -1,0 +1,35 @@
+-- ============================================================================
+-- ROLLBACK de 20260803090600_vistas.sql
+-- Ticket: BODA-14 (vistas de lectura)
+--
+-- Deshace exactamente lo que hace su migración, en orden inverso: primero se
+-- retiran las concesiones y después se eliminan las vistas.
+--
+-- El barrido final de EXECUTE de la migración no se «deshace»: devolver el
+-- permiso de ejecución al pseudo-rol PUBLIC sobre todas las funciones sería
+-- reabrir un agujero, no revertir un cambio. Las funciones desaparecen con el
+-- rollback de 20260803090500_funciones_publicas.sql, que es su sitio.
+-- ============================================================================
+
+begin;
+
+revoke select on public.v_proximos_pagos          from authenticated;
+revoke select on public.v_resumen_presupuesto     from authenticated;
+revoke select on public.v_servicios_importe       from authenticated;
+revoke select on public.v_menus_confirmados       from authenticated;
+revoke select on public.v_estadisticas_invitados  from authenticated;
+
+revoke select on public.v_medios_publicados       from anon, authenticated;
+revoke select on public.v_secciones_publicas      from anon, authenticated;
+revoke select on public.v_configuracion_publica   from anon, authenticated;
+
+drop view if exists public.v_proximos_pagos;
+drop view if exists public.v_resumen_presupuesto;
+drop view if exists public.v_servicios_importe;
+drop view if exists public.v_menus_confirmados;
+drop view if exists public.v_estadisticas_invitados;
+drop view if exists public.v_medios_publicados;
+drop view if exists public.v_secciones_publicas;
+drop view if exists public.v_configuracion_publica;
+
+commit;

--- a/supabase/migrations/rollback/20260803090700_arranque.sql
+++ b/supabase/migrations/rollback/20260803090700_arranque.sql
@@ -1,0 +1,36 @@
+-- Rollback de 20260803090700_arranque.sql
+--
+-- Devuelve el trigger a su forma anterior y elimina la función de arranque.
+--
+-- AVISO: deshacer esto reintroduce el candado circular. Si la base no tiene ya
+-- un propietario activo, nadie podrá acceder al panel nunca más y no habrá
+-- forma de arreglarlo desde dentro de la propia base.
+
+drop function if exists public.designar_primer_propietario(uuid, text);
+
+create or replace function public.proteger_privilegios_perfil()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+begin
+  if (new.rol, new.activo, new.usuario_id)
+     is distinct from (old.rol, old.activo, old.usuario_id)
+     and not exists (
+       select 1
+         from public.perfiles as p
+        where p.usuario_id = auth.uid()
+          and p.rol = 'propietario'
+          and p.activo
+     )
+  then
+    raise exception 'PRF01'
+      using errcode  = 'insufficient_privilege',
+            detail   = format('perfil=%s', old.id),
+            hint     = 'Sólo un propietario puede cambiar el rol o el alta de un perfil.';
+  end if;
+
+  return new;
+end;
+$function$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,310 @@
+-- ============================================================================
+-- seed.sql — DATOS DE DESARROLLO
+--
+--   ⚠  NADA DE ESTE FICHERO SON DATOS REALES DE LA BODA.  ⚠
+--
+-- Todo lo que hay aquí está marcado con el prefijo «(DES)», usa el dominio
+-- reservado `.test` (RFC 2606, nunca resoluble en internet) y lleva fechas
+-- relativas a `now()`. Si en una pantalla aparece «(DES)», es que está leyendo
+-- del seed y no de la base de datos real.
+--
+-- Se ejecuta con `supabase db reset`, DESPUÉS de las migraciones, y sólo en
+-- local. Los datos reales de la boda se cargan desde el panel: la regla 3 del
+-- proyecto prohíbe los datos de ejemplo incrustados en producción.
+--
+-- Lo mínimo imprescindible para que la landing pinte algo y para que la suite
+-- E2E tenga contra qué correr:
+--   · configuración de la boda y su parte privada
+--   · dos grupos de invitación CON TOKEN CONOCIDO (los tests los necesitan)
+--   · cuatro invitados, uno de ellos niña celíaca y otro acompañante
+--   · un proveedor con servicio, categoría de gasto, partida y pago
+--   · una tarea, dos mesas y una foto publicada
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- Tokens de desarrollo
+--
+-- La base de datos NUNCA guarda el token en claro, sólo su SHA-256. En
+-- producción el texto plano lo devuelve `crear_grupo_invitacion()` una única
+-- vez y no se puede recuperar. Aquí se fijan dos valores conocidos para que los
+-- tests E2E puedan visitar /rsvp/<token> sin tener que capturar nada:
+--
+--   Familia Uno  ->  desarrollo-familia-uno-000000
+--   Familia Dos  ->  desarrollo-familia-dos-000000
+--
+-- Son públicos, están en git y sólo abren datos «(DES)». Que un token de
+-- desarrollo esté versionado es seguro justamente porque este fichero jamás se
+-- ejecuta contra la base de producción.
+-- ----------------------------------------------------------------------------
+
+begin;
+
+-- ----------------------------------------------------------------------------
+-- `force row level security` durante la carga
+--
+-- Catorce tablas llevan RLS forzada, y `force` también le aplica al PROPIETARIO
+-- de la tabla — que es justamente el rol con el que corre este seed—. Sin
+-- levantarla, cada INSERT de aquí moriría con 42501 porque no hay ninguna
+-- política escrita para `postgres`, y escribir una sería abrir en producción un
+-- agujero para comodidad del entorno local.
+--
+-- Se levanta, se carga y se vuelve a poner al final del fichero. Si el seed
+-- falla a mitad, el `begin/commit` que lo envuelve revierte también estos
+-- ALTER: la base nunca se queda con la RLS relajada.
+-- ----------------------------------------------------------------------------
+
+do $$
+declare
+  v_tabla text;
+begin
+  foreach v_tabla in array array[
+    'configuracion_privada', 'secciones_landing', 'notas_grupo', 'notas_invitado',
+    'categorias_proveedor', 'proveedores', 'documentos_proveedor', 'servicios',
+    'categorias_presupuesto', 'partidas_presupuesto', 'pagos', 'tareas', 'mesas',
+    'medios'
+  ]
+  loop
+    execute format('alter table public.%I no force row level security', v_tabla);
+  end loop;
+end;
+$$;
+
+
+-- ----------------------------------------------------------------------------
+-- 1. Configuración de la boda
+--    La fila ya existe (la siembra la migración base): se actualiza, no se
+--    inserta. Fechas relativas para que el seed no caduque.
+-- ----------------------------------------------------------------------------
+
+update public.configuracion_boda set
+  nombre_novia         = '(DES) Ana',
+  nombre_novio         = '(DES) Luis',
+  hashtag              = '#DESAnaYLuis',
+  fecha_hora_ceremonia = date_trunc('hour', now()) + interval '200 days' + interval '12 hours',
+  fecha_hora_banquete  = date_trunc('hour', now()) + interval '200 days' + interval '14 hours',
+  zona_horaria         = 'Europe/Madrid',
+  fecha_limite_rsvp    = date_trunc('day', now()) + interval '150 days',
+  lugar_ceremonia      = '(DES) Finca de pruebas',
+  direccion_ceremonia  = '(DES) Camino del Ejemplo, 1',
+  latitud_ceremonia    = 40.416775,
+  longitud_ceremonia   = -3.703790,
+  lugar_banquete       = '(DES) Finca de pruebas',
+  direccion_banquete   = '(DES) Camino del Ejemplo, 1',
+  latitud_banquete     = 40.416775,
+  longitud_banquete    = -3.703790,
+  correo_contacto      = 'hola@ejemplo.test',
+  moneda               = 'EUR',
+  idioma_por_defecto   = 'es';
+
+update public.configuracion_privada set
+  presupuesto_objetivo = 42000.00,
+  aforo_maximo         = 150,
+  telefono_contacto    = '+34 600 000 000',
+  notas_privadas       = '(DES) Fila de desarrollo. No son cifras reales.';
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Invitados
+-- ----------------------------------------------------------------------------
+
+insert into public.grupos_invitacion
+  (id, nombre, huella_token, token_emitido_en, maximo_acompanantes, lado, invitado_a,
+   direccion, codigo_postal, ciudad, provincia, pais, idioma)
+values
+  ('aaaaaaaa-0000-4000-8000-000000000001',
+   '(DES) Familia Uno',
+   public.huella_token('desarrollo-familia-uno-000000'),
+   now(), 2, 'novia',
+   array['ceremonia','banquete','fiesta']::public.evento_boda[],
+   '(DES) Calle Uno, 1', '28001', 'Madrid', 'Madrid', 'España', 'es'),
+
+  ('aaaaaaaa-0000-4000-8000-000000000002',
+   '(DES) Familia Dos',
+   public.huella_token('desarrollo-familia-dos-000000'),
+   now(), 0, 'novio',
+   -- Sólo a la ceremonia: sirve para probar que la invitación no enseña el
+   -- banquete a quien no está invitado.
+   array['ceremonia']::public.evento_boda[],
+   '(DES) Calle Dos, 2', '08001', 'Barcelona', 'Barcelona', 'España', 'es');
+
+insert into public.notas_grupo (grupo_id, texto) values
+  ('aaaaaaaa-0000-4000-8000-000000000001',
+   '(DES) Nota privada. Si esto aparece en el RSVP público, hay una fuga.');
+
+insert into public.invitados
+  (id, grupo_id, nombre, apellidos, correo_electronico, telefono,
+   es_nino, es_acompanante, tipo_menu, alergias)
+values
+  ('bbbbbbbb-0000-4000-8000-000000000001', 'aaaaaaaa-0000-4000-8000-000000000001',
+   '(DES) Ana', 'Uno', 'ana.uno@ejemplo.test', '+34 600 000 001',
+   false, false, 'estandar', null),
+
+  ('bbbbbbbb-0000-4000-8000-000000000002', 'aaaaaaaa-0000-4000-8000-000000000001',
+   '(DES) Luis', 'Uno', 'luis.uno@ejemplo.test', null,
+   false, false, 'vegetariano', null),
+
+  -- Niña celíaca: el caso que la restricción antigua hacía imposible registrar.
+  ('bbbbbbbb-0000-4000-8000-000000000003', 'aaaaaaaa-0000-4000-8000-000000000001',
+   '(DES) Nina', 'Uno', null, null,
+   true, false, 'sin_gluten', '(DES) Celíaca.'),
+
+  ('bbbbbbbb-0000-4000-8000-000000000004', 'aaaaaaaa-0000-4000-8000-000000000002',
+   '(DES) Bea', 'Dos', 'bea.dos@ejemplo.test', null,
+   false, false, 'estandar', null);
+
+insert into public.notas_invitado (invitado_id, texto) values
+  ('bbbbbbbb-0000-4000-8000-000000000001',
+   '(DES) Nota privada sobre una persona. Tampoco debe salir por el RSVP.');
+
+-- Respuestas. Cada invitado ya tiene su fila `pendiente` (la crea el trigger
+-- `invitados_confirmacion_inicial`): estas INSERT la degradan y pasan a ser las
+-- vigentes, dejando además un historial con el que probar la pantalla.
+insert into public.confirmaciones
+  (invitado_id, estado, origen, necesita_autobus, necesita_alojamiento,
+   cancion_solicitada, mensaje)
+values
+  ('bbbbbbbb-0000-4000-8000-000000000001', 'confirmado', 'publico', true,  false,
+   '(DES) Una canción', '(DES) Allí estaremos.'),
+  ('bbbbbbbb-0000-4000-8000-000000000002', 'confirmado', 'publico', true,  false,
+   null, null),
+  ('bbbbbbbb-0000-4000-8000-000000000003', 'confirmado', 'publico', true,  false,
+   null, null),
+  ('bbbbbbbb-0000-4000-8000-000000000004', 'rechazado',  'publico', null,  null,
+   null, '(DES) No podremos ir.');
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Economía
+-- ----------------------------------------------------------------------------
+
+insert into public.categorias_proveedor (id, nombre, descripcion, orden) values
+  ('cccccccc-0000-4000-8000-000000000001', '(DES) Catering',   '(DES) Comida y bebida.', 0),
+  ('cccccccc-0000-4000-8000-000000000002', '(DES) Fotografía', '(DES) Foto y vídeo.',    1);
+
+insert into public.proveedores
+  (id, categoria_id, nombre, persona_contacto, correo_electronico, telefono,
+   sitio_web, estado, valoracion, importe_presupuestado, importe_acordado, notas)
+values
+  ('dddddddd-0000-4000-8000-000000000001', 'cccccccc-0000-4000-8000-000000000001',
+   '(DES) Catering de pruebas', '(DES) Marta', 'catering@ejemplo.test', '+34 600 000 010',
+   'https://ejemplo.test', 'contratado', 4, 9000.00, 8600.00, '(DES) Proveedor ficticio.'),
+
+  ('dddddddd-0000-4000-8000-000000000002', 'cccccccc-0000-4000-8000-000000000002',
+   '(DES) Fotógrafo de pruebas', null, 'foto@ejemplo.test', null,
+   null, 'presupuesto_recibido', 5, 2200.00, null, null);
+
+-- Un servicio por invitado y otro de precio cerrado: con los dos se puede ver
+-- que `v_servicios_importe` recalcula uno y el otro no.
+insert into public.servicios
+  (proveedor_id, nombre, descripcion, precio_unitario, cantidad, por_invitado)
+values
+  ('dddddddd-0000-4000-8000-000000000001', '(DES) Menú adulto',
+   '(DES) Precio por comensal confirmado.', 75.00, 1, true),
+  ('dddddddd-0000-4000-8000-000000000001', '(DES) Barra libre',
+   '(DES) Precio cerrado.', 1200.00, 1, false);
+
+insert into public.categorias_presupuesto (id, nombre, descripcion, importe_previsto, orden) values
+  ('eeeeeeee-0000-4000-8000-000000000001', '(DES) Banquete',   '(DES)', 20000.00, 0),
+  ('eeeeeeee-0000-4000-8000-000000000002', '(DES) Fotografía', '(DES)',  2500.00, 1);
+
+insert into public.partidas_presupuesto
+  (id, categoria_id, proveedor_id, concepto, descripcion, importe_estimado, importe_real, pagada)
+values
+  ('ffffffff-0000-4000-8000-000000000001', 'eeeeeeee-0000-4000-8000-000000000001',
+   'dddddddd-0000-4000-8000-000000000001', '(DES) Catering', '(DES)', 9000.00, 8600.00, false),
+  ('ffffffff-0000-4000-8000-000000000002', 'eeeeeeee-0000-4000-8000-000000000002',
+   'dddddddd-0000-4000-8000-000000000002', '(DES) Reportaje', '(DES)', 2200.00, null, false);
+
+-- Un pago hecho y otro pendiente: el panel necesita los dos estados.
+insert into public.pagos
+  (partida_id, importe, fecha_vencimiento, pagado_en, metodo, notas)
+values
+  ('ffffffff-0000-4000-8000-000000000001', 2000.00,
+   (now() - interval '30 days')::date, (now() - interval '30 days')::date,
+   'transferencia', '(DES) Señal.'),
+  ('ffffffff-0000-4000-8000-000000000001', 6600.00,
+   (now() + interval '120 days')::date, null, null, '(DES) Resto.');
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Organización
+-- ----------------------------------------------------------------------------
+
+insert into public.tareas (titulo, descripcion, estado, prioridad, fecha_limite, categoria) values
+  ('(DES) Cerrar el menú con el catering', '(DES)', 'pendiente', 'alta',
+   (now() + interval '60 days')::date, '(DES) Banquete'),
+  ('(DES) Reservar el autobús', '(DES)', 'en_progreso', 'media',
+   (now() + interval '90 days')::date, '(DES) Transporte');
+
+insert into public.mesas (nombre, capacidad, forma, posicion_x, posicion_y) values
+  ('(DES) Mesa 1', 10, 'redonda', 100.00, 100.00),
+  ('(DES) Mesa 2', 10, 'redonda', 300.00, 100.00);
+
+-- Sentamos a la Familia Uno para que el plano no salga vacío.
+update public.invitados
+   set mesa_id = (select id from public.mesas where nombre = '(DES) Mesa 1')
+ where grupo_id = 'aaaaaaaa-0000-4000-8000-000000000001';
+
+-- Una publicada y otra sin publicar: así el test comprueba que `anon` sólo ve
+-- la primera. La ruta apunta a un objeto que puede no existir en el Storage
+-- local; la landing debe degradar con elegancia, y eso también se prueba.
+insert into public.medios
+  (ruta_almacenamiento, texto_alternativo, seccion, orden, ancho, alto, publicado)
+values
+  ('desarrollo/portada.jpg',
+   '{"es": "(DES) Fotografía de portada de ejemplo"}'::jsonb,
+   'portada', 0, 2000, 1333, true),
+  ('desarrollo/galeria-borrador.jpg',
+   '{"es": "(DES) Borrador que no debe verse en la landing"}'::jsonb,
+   'galeria', 0, 1600, 1067, false);
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Se restaura `force row level security`
+-- ----------------------------------------------------------------------------
+
+do $$
+declare
+  v_tabla text;
+begin
+  foreach v_tabla in array array[
+    'configuracion_privada', 'secciones_landing', 'notas_grupo', 'notas_invitado',
+    'categorias_proveedor', 'proveedores', 'documentos_proveedor', 'servicios',
+    'categorias_presupuesto', 'partidas_presupuesto', 'pagos', 'tareas', 'mesas',
+    'medios'
+  ]
+  loop
+    execute format('alter table public.%I force row level security', v_tabla);
+  end loop;
+end;
+$$;
+
+commit;
+
+
+-- ----------------------------------------------------------------------------
+-- Comprobación final: si alguna tabla se quedó sin RLS forzada, el seed avisa
+-- en voz alta en vez de dejar el entorno local en un estado que no se parece a
+-- producción — que es exactamente cómo se cuela un fallo de seguridad hasta el
+-- despliegue.
+-- ----------------------------------------------------------------------------
+
+do $$
+declare
+  v_relajadas text;
+begin
+  select string_agg(c.relname, ', ' order by c.relname) into v_relajadas
+    from pg_catalog.pg_class as c
+    join pg_catalog.pg_namespace as n on n.oid = c.relnamespace
+   where n.nspname = 'public'
+     and c.relkind = 'r'
+     and not c.relrowsecurity;
+
+  if v_relajadas is not null then
+    raise exception 'El seed ha dejado tablas sin RLS: %', v_relajadas;
+  end if;
+
+  raise notice 'Seed de desarrollo cargado. Tokens de prueba: '
+    'desarrollo-familia-uno-000000 / desarrollo-familia-dos-000000';
+end;
+$$;

--- a/supabase/tests/seguridad.sql
+++ b/supabase/tests/seguridad.sql
@@ -1,0 +1,278 @@
+-- BODA-14 · Suite de seguridad de la base de datos
+--
+-- Estos tests son BLOQUEANTES. Verifican la única garantía que de verdad
+-- importa: que alguien con la clave pública, o con el enlace de otro invitado,
+-- no puede leer ni escribir lo que no le corresponde.
+--
+-- Se ejecutan contra un Postgres real (ver scripts/probar-bbdd.sh). No usan
+-- mocks: un mock de RLS no demuestra nada.
+--
+-- Cada prueba imprime OK o FALLA. El script que las lanza sale con error si
+-- aparece cualquier FALLA.
+
+\set ON_ERROR_STOP off
+\pset pager off
+\set QUIET on
+
+create or replace function pg_temp.comprobar(descripcion text, condicion boolean)
+returns void language plpgsql as $$
+begin
+  if condicion then
+    raise notice 'OK    %', descripcion;
+  else
+    raise warning 'FALLA %', descripcion;
+  end if;
+end $$;
+
+-- Intenta leer una tabla como el rol indicado. Devuelve true si el acceso fue
+-- denegado (que es lo que queremos para las tablas privadas).
+create or replace function pg_temp.lectura_denegada(p_rol text, p_tabla text)
+returns boolean language plpgsql as $$
+declare
+  v_filas bigint;
+begin
+  execute format('set local role %I', p_rol);
+  execute format('select count(*) from public.%I', p_tabla) into v_filas;
+  execute 'reset role';
+  -- Sin privilegio la ejecución habría lanzado. Llegar aquí con filas visibles
+  -- es un fallo; cero filas también vale como denegación efectiva.
+  return v_filas = 0;
+exception
+  when insufficient_privilege then
+    execute 'reset role';
+    return true;
+  when others then
+    execute 'reset role';
+    return true;
+end $$;
+
+\echo ''
+\echo '========================================'
+\echo '  SEGURIDAD · lo que anon NO puede ver'
+\echo '========================================'
+
+do $$
+declare
+  t text;
+  privadas text[] := array[
+    'grupos_invitacion', 'invitados', 'confirmaciones', 'notas_invitado',
+    'notas_grupo', 'proveedores', 'documentos_proveedor', 'servicios',
+    'categorias_proveedor', 'categorias_presupuesto', 'partidas_presupuesto',
+    'pagos', 'tareas', 'mesas', 'perfiles', 'registro_auditoria',
+    'configuracion_privada', 'intentos_rsvp', 'invitaciones_panel',
+    'parametros_seguridad'
+  ];
+begin
+  foreach t in array privadas loop
+    perform pg_temp.comprobar(
+      format('anon no puede leer %s', t),
+      pg_temp.lectura_denegada('anon', t)
+    );
+  end loop;
+end $$;
+
+\echo ''
+\echo '========================================'
+\echo '  RLS activo en todas las tablas'
+\echo '========================================'
+
+do $$
+declare
+  sin_rls text[];
+begin
+  select coalesce(array_agg(tablename), '{}')
+    into sin_rls
+    from pg_tables
+   where schemaname = 'public' and not rowsecurity;
+
+  perform pg_temp.comprobar(
+    format('todas las tablas tienen RLS (sin RLS: %s)', coalesce(array_to_string(sin_rls, ', '), 'ninguna')),
+    cardinality(sin_rls) = 0
+  );
+end $$;
+
+\echo ''
+\echo '========================================'
+\echo '  Funciones SECURITY DEFINER blindadas'
+\echo '========================================'
+
+do $$
+declare
+  sin_search_path text[];
+begin
+  -- Una función SECURITY DEFINER sin search_path fijo permite que quien la
+  -- llama cree objetos que la función resolverá con privilegios elevados.
+  select coalesce(array_agg(p.proname::text), '{}')
+    into sin_search_path
+    from pg_proc as p
+    join pg_namespace as n on n.oid = p.pronamespace
+   where n.nspname = 'public'
+     and p.prosecdef
+     and not exists (
+       select 1 from unnest(coalesce(p.proconfig, '{}')) as cfg
+        where cfg like 'search_path=%'
+     );
+
+  perform pg_temp.comprobar(
+    format('toda función SECURITY DEFINER fija search_path (sin fijar: %s)',
+           coalesce(array_to_string(sin_search_path, ', '), 'ninguna')),
+    cardinality(sin_search_path) = 0
+  );
+end $$;
+
+\echo ''
+\echo '========================================'
+\echo '  Arranque en frío: una sola vez'
+\echo '========================================'
+
+do $$
+declare
+  v_error text;
+begin
+  perform pg_temp.comprobar(
+    'existe un propietario activo tras el arranque',
+    exists (select 1 from public.perfiles where rol = 'propietario' and activo)
+  );
+
+  begin
+    perform public.designar_primer_propietario(
+      (select usuario_id from public.perfiles limit 1)
+    );
+    perform pg_temp.comprobar('el arranque se rechaza la segunda vez', false);
+  exception when others then
+    perform pg_temp.comprobar('el arranque se rechaza la segunda vez', true);
+  end;
+end $$;
+
+\echo ''
+\echo '========================================'
+\echo '  Registro público: un intruso no ve nada'
+\echo '========================================'
+
+-- El ataque más realista de todos, y el que no necesita ningún token: la clave
+-- anónima viaja en el bundle de la landing, así que cualquiera puede llamar a
+-- /auth/v1/signup y obtener una cuenta. Si el perfil naciera activo, ese
+-- desconocido sería un lector legítimo de la lista de invitados, con teléfonos
+-- y alergias — dato de salud, artículo 9 del RGPD.
+do $$
+declare
+  v_intruso uuid := '99999999-9999-9999-9999-999999999999';
+  v_filas   bigint;
+  v_activo  boolean;
+begin
+  insert into auth.users (id, email)
+  values (v_intruso, 'intruso@ejemplo.com')
+  on conflict (id) do nothing;
+
+  select p.activo into v_activo
+    from public.perfiles as p
+   where p.usuario_id = v_intruso;
+
+  perform pg_temp.comprobar(
+    'quien se registra por su cuenta no queda activo',
+    coalesce(v_activo, false) = false
+  );
+
+  -- Y aunque tenga sesión válida, no puede leer nada.
+  begin
+    set local role authenticated;
+    perform set_config('request.jwt.claim.sub', v_intruso::text, true);
+
+    select count(*) into v_filas from public.invitados;
+    perform pg_temp.comprobar('un recién registrado no lee la lista de invitados', v_filas = 0);
+
+    select count(*) into v_filas from public.pagos;
+    perform pg_temp.comprobar('un recién registrado no lee los pagos', v_filas = 0);
+  exception when insufficient_privilege then
+    perform pg_temp.comprobar('un recién registrado no lee la lista de invitados', true);
+    perform pg_temp.comprobar('un recién registrado no lee los pagos', true);
+  end;
+
+  reset role;
+  perform set_config('request.jwt.claim.sub', '11111111-1111-1111-1111-111111111111', true);
+end $$;
+
+\echo ''
+\echo '========================================'
+\echo '  RSVP público: solo tu grupo'
+\echo '========================================'
+
+do $$
+declare
+  v_token   text;
+  v_grupo   uuid;
+  v_otro    uuid;
+  v_mio     uuid;
+  v_ajeno   uuid;
+  v_filas   bigint;
+  v_ok      boolean;
+begin
+  -- Dos grupos distintos: el nuestro y el de otra familia, para poder probar
+  -- el ataque cruzado, que es la comprobación importante de todo el fichero.
+  select token into v_token
+    from public.crear_grupo_invitacion(
+      'Grupo de prueba', 2::smallint, 'ambos'::public.lado_invitacion,
+      array['ceremonia']::public.evento_boda[]
+    );
+
+  select g.id into v_grupo
+    from public.grupos_invitacion as g
+   where g.huella_token = public.huella_token(v_token);
+
+  insert into public.invitados (grupo_id, nombre, apellidos)
+  values (v_grupo, 'Prueba', 'Uno')
+  returning id into v_mio;
+
+  select id into v_otro
+    from public.grupos_invitacion
+   where id <> v_grupo
+   limit 1;
+
+  if v_otro is null then
+    insert into public.grupos_invitacion (nombre) values ('Otra familia')
+    returning id into v_otro;
+  end if;
+
+  insert into public.invitados (grupo_id, nombre, apellidos)
+  values (v_otro, 'Ajena', 'Dos')
+  returning id into v_ajeno;
+
+  set local role anon;
+
+  select count(*) into v_filas from public.obtener_invitacion(v_token);
+  perform pg_temp.comprobar('un token válido devuelve su invitación', v_filas > 0);
+
+  select count(*) into v_filas
+    from public.obtener_invitacion('token-inventado-que-no-existe-0000');
+  perform pg_temp.comprobar('un token inventado no devuelve nada', v_filas = 0);
+
+  begin
+    perform public.registrar_confirmacion(
+      v_token,
+      jsonb_build_array(jsonb_build_object(
+        'invitado_id', v_ajeno, 'estado', 'confirmado',
+        'necesita_autobus', true, 'necesita_alojamiento', false
+      ))
+    );
+    v_ok := false;
+  exception when others then
+    v_ok := true;
+  end;
+  perform pg_temp.comprobar('no se puede confirmar a alguien de otro grupo', v_ok);
+
+  -- Casilla sin marcar: debe aceptarse como «no», no reventar.
+  begin
+    perform public.registrar_confirmacion(
+      v_token,
+      jsonb_build_array(jsonb_build_object('invitado_id', v_mio, 'estado', 'confirmado'))
+    );
+    v_ok := true;
+  exception when others then
+    v_ok := false;
+  end;
+  perform pg_temp.comprobar('una confirmación sin logística explícita se acepta', v_ok);
+
+  reset role;
+end $$;
+
+\echo ''


### PR DESCRIPTION
La base de datos entera: **24 tablas, 8 vistas, 14 enumerados, 42 funciones y 46 políticas RLS**. Todo en castellano, cada migración con su rollback, y documentado en [`docs/MODELO-DATOS.md`](../blob/main/docs/MODELO-DATOS.md).

## No se da por bueno leyendo el SQL

`./scripts/probar-bbdd.sh` levanta un PostgreSQL desechable, simula lo que aporta Supabase (esquema `auth`, roles `anon`/`authenticated`/`service_role`, `pgcrypto` en `extensions`), aplica las nueve migraciones **desde cero** y lanza **31 comprobaciones que atacan la base como lo haría un intruso**:

```
OK  anon no puede leer invitados          OK  quien se registra por su cuenta no queda activo
OK  anon no puede leer pagos              OK  un recién registrado no lee la lista de invitados
OK  anon no puede leer confirmaciones     OK  un token inventado no devuelve nada
OK  … 20 tablas privadas                  OK  no se puede confirmar a alguien de otro grupo
```

Es un paso **bloqueante** del CI. Un mock de RLS no demuestra nada.

## El fallo que solo aparece ejecutando

`perfiles.activo` nace en `false`, y el trigger que protege los privilegios exige **un propietario activo** para poder activar a nadie. En una base recién desplegada no existe ninguno:

> **El candado se cierra sobre sí mismo. Nadie puede entrar jamás.** Ni siquiera el superusuario.

Cada pieza era correcta por separado, así que ninguna revisión del SQL lo habría detectado. Apareció al seguir el flujo completo de acceso contra Postgres.

Lo resuelve `designar_primer_propietario(usuario_id, nombre)`: solo la puede ejecutar `service_role` —la clave que nunca sale del servidor—, y **se niega a actuar si ya existe un propietario activo**, de modo que no queda como puerta trasera. Hay un test que lo comprueba llamándola dos veces.

## La auditoría adversarial

El diseño pasó por cuatro auditores con lentes distintas —fuga de datos, escritura no autorizada, corrección y cumplimiento de las reglas del proyecto—, que encontraron **59 problemas, 10 críticos**. El más grave:

> Cualquiera podía registrarse con la clave pública (que viaja en el bundle de la landing) y quedar como **lector activo** de la lista completa de invitados: teléfonos, correos y alergias — dato de salud del artículo 9 del RGPD.

Corregido con una tabla de invitaciones al panel y perfiles que nacen inactivos. Y con un test que lo verifica, porque la corrección sin test se pierde en el siguiente refactor.

## Decisiones que merecen mirada

- **El token de invitación se guarda hasheado.** La tabla no contiene el secreto: si alguien se lleva una copia de la base, no obtiene los enlaces.
- **Las funciones del RSVP enumeran columna a columna** lo que devuelven. Lo que el invitado no debe ver, sencillamente no se selecciona.
- **Una casilla sin marcar significa «no»**, y solo cuando la respuesta es *confirmado*: quien no viene no tiene por qué opinar sobre el autobús.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_