### PR TITLE
Roadmap del panel completo y guía de variables de entorno

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10,20 +10,22 @@ Board de trabajo. Cada ticket es una rama y una PR. Ver [PLAN-MAESTRO.md](./PLAN
 
 ## Resumen
 
-| Épica                 | Tickets      | Estado                        |
-| --------------------- | ------------ | ----------------------------- |
-| E1 · Cimientos        | BODA-01 → 06 | ✅ 6 hechos                   |
-| E2 · Base de datos    | BODA-10 → 14 | ✅ 5 hechos                   |
-| E3 · Landing          | BODA-20 → 28 | ✅ 2 hechos · 📋 7 pendientes |
-| E4 · Save the Date    | BODA-30 → 32 | 📋 3 pendientes               |
-| E5 · Auth y panel     | BODA-40 → 43 | 📋 4 pendientes               |
-| E6 · Invitados y RSVP | BODA-50 → 58 | 📋 9 pendientes               |
-| E7 · Presupuesto      | BODA-60 → 64 | 📋 5 pendientes               |
-| E8 · Proveedores      | BODA-70 → 74 | 📋 5 pendientes               |
-| E9 · Tareas y seating | BODA-80 → 84 | 📋 5 pendientes               |
-| E10 · Producción      | BODA-90 → 95 | 📋 6 pendientes               |
+| Épica                 | Tickets        | Estado                        |
+| --------------------- | -------------- | ----------------------------- |
+| E1 · Cimientos        | BODA-01 → 06   | ✅ 6 hechos                   |
+| E2 · Base de datos    | BODA-10 → 14   | ✅ 5 hechos                   |
+| E3 · Landing          | BODA-20 → 28   | ✅ 2 hechos · 📋 7 pendientes |
+| E4 · Save the Date    | BODA-30 → 32   | 📋 3 pendientes               |
+| E5 · Auth y panel     | BODA-40 → 43   | 📋 4 pendientes               |
+| E6 · Invitados y RSVP | BODA-50 → 58   | 📋 9 pendientes               |
+| E7 · Presupuesto      | BODA-60 → 64   | 📋 5 pendientes               |
+| E8 · Proveedores      | BODA-70 → 74   | 📋 5 pendientes               |
+| E9 · Tareas y seating | BODA-80 → 84   | 📋 5 pendientes               |
+| E10 · Producción      | BODA-90 → 95   | 📋 6 pendientes               |
+| E11 · Día de la boda  | BODA-100 → 104 | 📋 5 pendientes               |
+| E12 · Comunicación    | BODA-110 → 113 | 📋 4 pendientes               |
 
-**Total: 57 tickets · 13 hechos.**
+**Total: 66 tickets · 13 hechos.**
 
 ---
 
@@ -238,6 +240,33 @@ Políticas RLS de todas las tablas + `get_invitation(token)` y `submit_rsvp(toke
 | **BODA-93** | Sentry y PostHog                       | `M`  | Errores y eventos llegan a los paneles       |
 | **BODA-94** | Backup diario automatizado             | `M`  | GitHub Action que exporta a repo privado     |
 | **BODA-95** | Ping semanal anti-pausa de Supabase    | `S`  | Evita la pausa por inactividad del free tier |
+
+---
+
+## E11 · Panel: día de la boda y cierre
+
+> Lo que hace falta cuando ya no se planifica, sino que se ejecuta. Casi todo
+> se usa **desde el móvil y con prisa**, así que prima la lectura rápida sobre
+> la densidad de datos.
+
+| ID           | Ticket                                    | Est. | E2E                                                           |
+| ------------ | ----------------------------------------- | ---- | ------------------------------------------------------------- |
+| **BODA-100** | Lista de control del día                  | `M`  | Marcar hecho persiste y sobrevive a recargar                  |
+| **BODA-101** | Agenda de contactos de proveedores        | `S`  | Los teléfonos son enlaces `tel:` pulsables desde el móvil     |
+| **BODA-102** | Buscador de invitados a pantalla completa | `M`  | Buscar un apellido devuelve su mesa y su menú en un toque     |
+| **BODA-103** | Recuento en vivo para el catering         | `M`  | Confirmados por tipo de menú, con niños aparte                |
+| **BODA-104** | Exportar todo (invitados, mesas, menús)   | `S`  | El fichero descargado abre en Excel con los acentos correctos |
+
+---
+
+## E12 · Panel: comunicación con invitados
+
+| ID           | Ticket                                | Est. | E2E                                                           |
+| ------------ | ------------------------------------- | ---- | ------------------------------------------------------------- |
+| **BODA-110** | Envío de invitaciones por WhatsApp    | `M`  | Genera el enlace con el token del grupo y el texto ya escrito |
+| **BODA-111** | Recordatorio a quien no ha contestado | `M`  | Solo alcanza a los pendientes, nunca a quien ya respondió     |
+| **BODA-112** | Bandeja de mensajes del RSVP          | `S`  | Los mensajes que dejan los invitados se leen en el panel      |
+| **BODA-113** | Moderación de la playlist             | `S`  | Ocultar una canción la retira de la landing sin borrarla      |
 
 ---
 

--- a/docs/ENTORNO.md
+++ b/docs/ENTORNO.md
@@ -1,0 +1,100 @@
+# Variables de entorno y secretos
+
+Dónde va cada valor y por qué. Ningún secreto se guarda en el repositorio: aquí
+solo están los **nombres**.
+
+---
+
+## Resumen: qué necesita cada sitio
+
+| Dónde                          | Qué hace falta                          | Por qué                                             |
+| ------------------------------ | --------------------------------------- | --------------------------------------------------- |
+| **Vercel**                     | `DATABASE_URL` y las claves de Supabase | Es quien sirve la web a los invitados               |
+| **Tu portátil** (`.env.local`) | `DATABASE_URL` local                    | Para levantar el proyecto en desarrollo             |
+| **GitHub Actions**             | **nada, de momento**                    | El CI se fabrica su propia base de datos desechable |
+
+---
+
+## Vercel
+
+**Settings → Environment Variables.** Marcar las tres ramas (Production,
+Preview, Development) salvo que se indique otra cosa.
+
+| Variable                        | De dónde se saca                                                                    |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| `DATABASE_URL`                  | Supabase → Project Settings → Database → **Connection pooling**, modo `transaction` |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Supabase → Project Settings → API → Project URL                                     |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase → Project Settings → API → `anon` `public`                                 |
+| `SUPABASE_SERVICE_ROLE_KEY`     | Supabase → Project Settings → API → `service_role` **secret**                       |
+| `NEXT_PUBLIC_SITE_URL`          | El dominio final de la web                                                          |
+
+**El pooler, no la conexión directa.** Cada petición a la web arranca una
+función efímera; con conexión directa se agotan las conexiones del servidor en
+cuanto hay algo de tráfico. El pooler en modo `transaction` está hecho
+exactamente para esto.
+
+**`SUPABASE_SERVICE_ROLE_KEY` se salta todas las políticas RLS.** Nunca puede
+llevar el prefijo `NEXT_PUBLIC_`, porque eso la metería en el JavaScript que
+descarga cualquier visitante y le daría acceso completo a la lista de invitados
+y al presupuesto.
+
+Si falta `DATABASE_URL`, **la web despliega igual** y muestra que está en
+preparación, dejando el error en el log del servidor. Se decidió así tras un
+despliegue fallido: reventar el build entero por una variable ausente también
+tumbaba el 404 y la página de sistema de diseño, que ni siquiera tocan la base.
+
+---
+
+## En local
+
+```bash
+# Levanta un PostgreSQL desechable con las migraciones y el seed
+export DATABASE_URL="$(./scripts/preparar-bbdd.sh)"
+npm run dev
+```
+
+O se copia `.env.example` a `.env.local` y se rellena. `.env*` está en
+`.gitignore`: esos ficheros no se suben nunca.
+
+---
+
+## GitHub Actions: por qué no hay secretos
+
+El CI **no necesita ninguno**, y es a propósito.
+
+`scripts/preparar-bbdd.sh` levanta un PostgreSQL nuevo en el runner, le aplica
+las migraciones desde cero y carga el seed de desarrollo. Cada ejecución
+empieza de una base vacía.
+
+Un CI conectado a una base de datos compartida tendría tres problemas que esto
+evita:
+
+1. **Los tests se pisarían entre ellos.** Dos PR a la vez escribiendo en la
+   misma base dan fallos intermitentes imposibles de reproducir.
+2. **Datos reales en los logs.** Un test que falla imprime lo que ha leído; si
+   lee de la base de verdad, acaban en el log público de la Action los
+   teléfonos y las alergias de los invitados.
+3. **Un secreto más que rota y que se filtra.** El que no existe no se filtra.
+
+### Si algún día hacen falta
+
+Cuando entren los emails (BODA-57) o la analítica (BODA-93) habrá que añadir
+`RESEND_API_KEY` y similares. Entonces:
+
+**Settings → Secrets and variables → Actions → New repository secret.**
+
+Solo tú puedes crearlos: hacen falta los valores, y esos valores no deben
+viajar por un chat ni quedar registrados en ninguna conversación. Si me pasas
+uno por aquí, dalo por comprometido y rótalo.
+
+---
+
+## Qué hacer si se filtra una clave
+
+1. **Rotarla primero, investigar después.** En Supabase: Project Settings → API
+   → `Reset`. La clave vieja deja de valer al instante.
+2. Actualizarla en Vercel y volver a desplegar.
+3. Revisar los logs de Supabase por si hubo accesos raros.
+
+Rotar una clave cuesta dos minutos. Una lista de invitados filtrada no se
+recupera.


### PR DESCRIPTION
## El panel, completo

El board cubría planificar la boda, pero no **ejecutarla**. Se añaden dos épicas con lo que falta:

**E11 · Día de la boda** — lista de control, agenda de proveedores con teléfonos pulsables (`tel:`), buscador de invitados a pantalla completa que devuelve mesa y menú en un toque, recuento en vivo por tipo de menú para el catering, y exportación completa.

Todo pensado para **usarse desde el móvil y con prisa**, que es como se usa ese día: prima la lectura rápida sobre la densidad de datos.

**E12 · Comunicación** — envío de invitaciones por WhatsApp con el token ya dentro del enlace, recordatorio que alcanza **solo a quien no ha contestado**, bandeja de los mensajes que dejan los invitados, y moderación de la playlist.

Total: **66 tickets**, 13 hechos.

## Variables de entorno

`docs/ENTORNO.md` explica dónde va cada valor. Lo relevante:

**El CI no lleva ningún secreto, y es a propósito.** `scripts/preparar-bbdd.sh` fabrica un PostgreSQL desechable en cada ejecución. Una base compartida daría tres problemas que esto evita:

1. Dos PR simultáneas escribiendo en la misma base → fallos intermitentes imposibles de reproducir.
2. Un test que falla imprime lo que ha leído. Si lee de la base real, **acaban en el log público de la Action los teléfonos y las alergias de los invitados**.
3. Un secreto más que rotar. El que no existe no se filtra.

Lo que **sí** hace falta es `DATABASE_URL` en Vercel, con el pooler en modo `transaction` — con conexión directa se agotan las conexiones en cuanto hay tráfico.

También queda documentado que `SUPABASE_SERVICE_ROLE_KEY` **nunca** puede llevar el prefijo `NEXT_PUBLIC_`: eso la metería en el JavaScript que descarga cualquier visitante, con acceso completo a la lista de invitados y al presupuesto.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_