### PR TITLE
chore: el board pasa a GitHub Issues y el trabajo se dispara desde GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Plan maestro
+    url: https://github.com/Davmunrey/p-d/blob/main/docs/PLAN-MAESTRO.md
+    about: Arquitectura, modelo de datos y decisiones tomadas. Léelo antes de abrir un ticket grande.
+  - name: Reglas del proyecto
+    url: https://github.com/Davmunrey/p-d/blob/main/CLAUDE.md
+    about: Cero hardcode, castellano, todo cableado, E2E en cada entrega. Son innegociables.

--- a/.github/ISSUE_TEMPLATE/error.yml
+++ b/.github/ISSUE_TEMPLATE/error.yml
@@ -1,0 +1,52 @@
+name: Algo no funciona
+description: Una parte que ya estaba entregada se comporta mal.
+title: "Error · "
+labels: ["error"]
+body:
+  - type: textarea
+    id: que-pasa
+    attributes:
+      label: Qué pasa
+      description: Qué esperabas ver y qué ves en su lugar.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducir
+    attributes:
+      label: Cómo reproducirlo
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: input
+    id: donde
+    attributes:
+      label: Dónde
+      description: URL exacta. Si es un preview de una PR, pega el enlace del preview.
+      placeholder: https://…/rsvp/xxxx
+    validations:
+      required: true
+
+  - type: dropdown
+    id: dispositivo
+    attributes:
+      label: Dónde lo has visto
+      multiple: true
+      options:
+        - Móvil
+        - Tablet
+        - Escritorio
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: datos-personales
+    attributes:
+      label: Antes de enviar
+      options:
+        - label: No he pegado teléfonos, correos, tokens de invitación ni claves. Las incidencias son públicas.
+          required: true

--- a/.github/ISSUE_TEMPLATE/ticket.yml
+++ b/.github/ISSUE_TEMPLATE/ticket.yml
@@ -1,0 +1,91 @@
+name: Ticket de trabajo
+description: Una unidad de trabajo que acaba en una rama, una PR y un deploy preview.
+title: "BODA-00 · "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Un ticket es lo que cabe en una PR. Si al describirlo salen dos cosas
+        que se pueden entregar por separado, son dos tickets.
+
+        Sustituye `BODA-00` en el título por el siguiente número libre de su
+        épica (las decenas marcan la épica: 20-29 landing, 50-59 invitados…).
+
+  - type: textarea
+    id: objetivo
+    attributes:
+      label: Qué hay que hacer
+      description: En dos o tres frases, y desde el punto de vista de quien lo va a usar.
+      placeholder: Que los invitados puedan ver el listado de alojamientos con su distancia a la finca.
+    validations:
+      required: true
+
+  - type: textarea
+    id: aceptacion
+    attributes:
+      label: Criterios de aceptación
+      description: Qué tiene que ser cierto para darlo por hecho. Comprobables, no opiniones.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: e2e
+    attributes:
+      label: Test E2E
+      description: |
+        Camino feliz **y al menos un caso de error**. Regla 4 del proyecto: un
+        módulo sin test se considera no entregado.
+      placeholder: |
+        Feliz: la sección lista los alojamientos publicados en la BBDD.
+        Error: un alojamiento en borrador no aparece.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: talla
+    attributes:
+      label: Talla
+      options:
+        - S · medio día
+        - M · un día
+        - L · dos días
+    validations:
+      required: true
+
+  - type: input
+    id: dependencias
+    attributes:
+      label: Depende de
+      description: Tickets que tienen que estar cerrados antes. Referéncialos con `#`.
+      placeholder: "#12, #15"
+
+  - type: textarea
+    id: datos
+    attributes:
+      label: De dónde salen los datos y los textos
+      description: |
+        Regla 1 del proyecto. Ningún valor se escribe en el componente: los
+        colores y espaciados son tokens, los textos van a `content/copy.es.json`,
+        los datos de la boda a la base de datos y los límites a
+        `src/config/constants.ts`. Di aquí qué hace falta crear.
+      placeholder: |
+        Tabla `alojamientos` (ya existe). Copys nuevos: `alojamiento.titulo`,
+        `alojamiento.distancia`. Token nuevo: ninguno.
+
+  - type: checkboxes
+    id: cierre
+    attributes:
+      label: Definition of Done
+      description: Se marca en la PR, no aquí. Está a la vista para que nadie lo dé por supuesto.
+      options:
+        - label: Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
+        - label: Cero hardcode
+        - label: Test E2E incluido, con su caso de error
+        - label: CI verde entero
+        - label: Responsive en móvil, tablet y escritorio
+        - label: Accesible por teclado, con foco visible, contraste AA y `prefers-reduced-motion`
+        - label: Pasado por las skills de diseño
+        - label: Revisado en el deploy preview

--- a/.github/etiquetas.json
+++ b/.github/etiquetas.json
@@ -1,0 +1,102 @@
+[
+  {
+    "nombre": "e1-cimientos",
+    "color": "3c4233",
+    "descripcion": "Épica 1 · Proyecto, tokens, copys, calidad y despliegue"
+  },
+  {
+    "nombre": "e2-base-de-datos",
+    "color": "3c4233",
+    "descripcion": "Épica 2 · Esquema, RLS y funciones públicas"
+  },
+  {
+    "nombre": "e3-landing",
+    "color": "6b7060",
+    "descripcion": "Épica 3 · Web pública para los invitados"
+  },
+  {
+    "nombre": "e4-save-the-date",
+    "color": "6b7060",
+    "descripcion": "Épica 4 · Página de reserva de fecha y calendario"
+  },
+  {
+    "nombre": "e5-auth-y-panel",
+    "color": "8a8f7d",
+    "descripcion": "Épica 5 · Acceso privado y esqueleto del panel"
+  },
+  {
+    "nombre": "e6-invitados-y-rsvp",
+    "color": "8a8f7d",
+    "descripcion": "Épica 6 · Gestión de invitados y confirmaciones"
+  },
+  {
+    "nombre": "e7-presupuesto",
+    "color": "b8a67a",
+    "descripcion": "Épica 7 · Partidas, pagos y desvíos"
+  },
+  {
+    "nombre": "e8-proveedores",
+    "color": "b8a67a",
+    "descripcion": "Épica 8 · Proveedores, contratos y servicios"
+  },
+  {
+    "nombre": "e9-tareas-y-mesas",
+    "color": "b8a67a",
+    "descripcion": "Épica 9 · Tareas y plano de mesas"
+  },
+  {
+    "nombre": "e10-produccion",
+    "color": "9c6b4f",
+    "descripcion": "Épica 10 · Rendimiento, accesibilidad, SEO y respaldos"
+  },
+  {
+    "nombre": "e11-dia-de-la-boda",
+    "color": "9c6b4f",
+    "descripcion": "Épica 11 · Lo que se usa el día D, desde el móvil"
+  },
+  {
+    "nombre": "e12-comunicacion",
+    "color": "9c6b4f",
+    "descripcion": "Épica 12 · Envíos, recordatorios y mensajes"
+  },
+  {
+    "nombre": "talla-s",
+    "color": "e8e4dc",
+    "descripcion": "Medio día de trabajo"
+  },
+  {
+    "nombre": "talla-m",
+    "color": "cfc9bd",
+    "descripcion": "Un día de trabajo"
+  },
+  {
+    "nombre": "talla-l",
+    "color": "a89f8d",
+    "descripcion": "Dos días de trabajo"
+  },
+  {
+    "nombre": "camino-critico",
+    "color": "b03a2e",
+    "descripcion": "Bloquea poder repartir invitaciones y recibir confirmaciones"
+  },
+  {
+    "nombre": "seguridad",
+    "color": "7d1f14",
+    "descripcion": "Toca RLS, tokens o datos personales. La revisión es bloqueante"
+  },
+  {
+    "nombre": "error",
+    "color": "d64545",
+    "descripcion": "Algo que ya existe no funciona como debería"
+  },
+  {
+    "nombre": "bloqueado",
+    "color": "5b5b5b",
+    "descripcion": "Esperando una decisión, un dato o un acceso externo"
+  },
+  {
+    "nombre": "decision-pendiente",
+    "color": "c99700",
+    "descripcion": "Necesita una respuesta de producto antes de poder empezar"
+  }
+]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Qué cambia
+
+<!-- Una frase. Si no cabe en una, probablemente sean dos PR. -->
+
+Closes #
+
+## Cómo probarlo en el preview
+
+<!-- Los pasos exactos. Quien revisa no debería tener que adivinar dónde mirar. -->
+
+1.
+
+## Definition of Done
+
+- [ ] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
+- [ ] Cero hardcode: colores y espaciados son tokens, los textos salen de `content/copy.es.json`, los datos de la boda de la BBDD y los límites de `src/config/constants.ts`
+- [ ] Test E2E incluido: camino feliz **y** al menos un caso de error
+- [ ] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E
+- [ ] Responsive en móvil, tablet y escritorio
+- [ ] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion`
+- [ ] Pasado por las skills de diseño
+- [ ] Revisado en el deploy preview
+
+## Base de datos
+
+- [ ] No la toca
+- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`
+
+## Documentación
+
+- [ ] No hace falta
+- [ ] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,66 @@
+name: Claude
+
+# Permite trabajar desde GitHub sin abrir un terminal: se menciona `@claude` en
+# una incidencia, en una PR o en un comentario de revisión y el trabajo empieza
+# ahí mismo, con el contexto de ese hilo.
+#
+# El flujo NO forma parte del CI: solo se dispara con la mención, así que nunca
+# bloquea ni tiñe de rojo una PR normal.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    name: Atender la mención
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      # Para poder leer por qué ha fallado el CI de una PR.
+      actions: read
+    steps:
+      - name: Comprobar que hay credencial
+        id: credencial
+        env:
+          TOKEN_SUSCRIPCION: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CLAVE_API: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$TOKEN_SUSCRIPCION" ] || [ -n "$CLAVE_API" ]; then
+            echo "hay=si" >> "$GITHUB_OUTPUT"
+          else
+            echo "hay=no" >> "$GITHUB_OUTPUT"
+            echo "::warning::Falta el secreto CLAUDE_CODE_OAUTH_TOKEN (o ANTHROPIC_API_KEY). Ver docs/ENTORNO.md. La mención se ignora."
+          fi
+
+      - name: Descargar el repositorio
+        if: steps.credencial.outputs.hay == 'si'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Trabajar sobre la mención
+        if: steps.credencial.outputs.hay == 'si'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Las órdenes del proyecto se leen de CLAUDE.md, que es donde viven
+          # las reglas. Aquí solo se abren los comandos que hacen falta para
+          # poder verificar el trabajo antes de subirlo.
+          claude_args: |
+            --allowedTools "Bash(npm ci),Bash(npm run verificar),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run lint:css),Bash(npm run format),Bash(npm run format:check),Bash(npm run test),Bash(npm run build)"

--- a/.github/workflows/etiquetas.yml
+++ b/.github/workflows/etiquetas.yml
@@ -1,0 +1,43 @@
+name: Etiquetas
+
+# Las etiquetas del board son configuración, no algo que se cree a mano en la
+# interfaz de GitHub: viven en `.github/etiquetas.json` y este flujo las
+# reconcilia. Así el board se puede reconstruir entero desde el repositorio y
+# un cambio de nombre o de color pasa por PR como cualquier otro cambio.
+
+on:
+  push:
+    branches: [main]
+    paths: [".github/etiquetas.json", ".github/workflows/etiquetas.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: etiquetas
+  cancel-in-progress: false
+
+jobs:
+  sincronizar:
+    name: Sincronizar etiquetas
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Crear o actualizar cada etiqueta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          jq -c '.[]' .github/etiquetas.json | while read -r etiqueta; do
+            nombre=$(jq -r '.nombre' <<<"$etiqueta")
+            color=$(jq -r '.color' <<<"$etiqueta")
+            descripcion=$(jq -r '.descripcion' <<<"$etiqueta")
+            # --force actualiza la etiqueta si ya existe, así que el flujo es
+            # idempotente: se puede relanzar sin miedo.
+            gh label create "$nombre" --color "$color" --description "$descripcion" --force
+            echo "· $nombre"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Reglas del proyecto
 
-Web de boda: landing pública + panel privado de gestión. Documentación en [`docs/PLAN-MAESTRO.md`](./docs/PLAN-MAESTRO.md), board en [`docs/BACKLOG.md`](./docs/BACKLOG.md).
+Web de boda: landing pública + panel privado de gestión. Documentación en [`docs/PLAN-MAESTRO.md`](./docs/PLAN-MAESTRO.md); el board son las [incidencias de GitHub](https://github.com/Davmunrey/p-d/issues), y [`docs/BACKLOG.md`](./docs/BACKLOG.md) explica cómo se leen.
 
 Estas reglas son **innegociables** y aplican a todo cambio, sin excepción.
 
@@ -65,7 +65,8 @@ Precedencia ante conflicto: **estas reglas > skills de diseño > preferencia per
 
 ## Cómo trabajamos
 
-- Se trabaja **por tickets** del backlog. Una rama por ticket: `feat/BODA-12-tabla-invitados`, siempre creada desde `main` actualizado.
+- Se trabaja **por tickets**, que son incidencias de GitHub. Una rama por ticket: `feat/BODA-12-tabla-invitados`, siempre creada desde `main` actualizado.
+- La PR lleva `Closes #NN` en el cuerpo: la incidencia se cierra al mergear, nunca a mano.
 - PR con deploy preview → merge a `main` → producción.
 - **Mergear no requiere pedir permiso: se mergea en cuanto el CI está verde.** Verde significa todo — typecheck, lint, stylelint, formato, unitarios y E2E. Nunca se mergea con un check en rojo, ni se relaja o desactiva un test para conseguirlo: si algo falla, se arregla la causa.
 - Toda migración de BBDD entra por PR con su SQL de rollback.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Web de boda con landing pública y panel privado de gestión.
 
 ## Documentación
 
-| Documento                              | Contenido                                                      |
-| -------------------------------------- | -------------------------------------------------------------- |
-| [Plan maestro](./docs/PLAN-MAESTRO.md) | Visión, arquitectura, stack, modelo de datos, reglas y roadmap |
-| [Backlog](./docs/BACKLOG.md)           | Board de tickets con criterios de aceptación y tests E2E       |
-| [Skills](./.claude/skills/README.md)   | Listón de diseño e interacción del proyecto                    |
+| Documento                                            | Contenido                                                      |
+| ---------------------------------------------------- | -------------------------------------------------------------- |
+| [**Board**](https://github.com/Davmunrey/p-d/issues) | Los tickets. Es donde se mira qué toca hacer                   |
+| [Plan maestro](./docs/PLAN-MAESTRO.md)               | Visión, arquitectura, stack, modelo de datos, reglas y roadmap |
+| [Backlog](./docs/BACKLOG.md)                         | Cómo se lee el board: épicas, tallas y ciclo de un ticket      |
+| [Entorno](./docs/ENTORNO.md)                         | Qué variable va en cada sitio y por qué                        |
+| [Skills](./.claude/skills/README.md)                 | Listón de diseño e interacción del proyecto                    |
 
 ## Reglas del proyecto
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,288 +1,102 @@
-# Backlog — Web de Boda
+# Backlog
 
-Board de trabajo. Cada ticket es una rama y una PR. Ver [PLAN-MAESTRO.md](./PLAN-MAESTRO.md) para arquitectura y reglas.
+**El board vive en [GitHub Issues](https://github.com/Davmunrey/p-d/issues).** Este
+fichero ya no lo duplica: explica cómo está montado y cómo se trabaja con él.
 
-**Estados:** `📋 Pendiente` · `🚧 En curso` · `👀 En revisión` · `✅ Hecho` · `🧊 Congelado`
+Un tablero en Markdown y otro en GitHub acaban discrepando siempre, y cuando
+discrepan nadie sabe cuál manda. Se elige GitHub porque es donde ya están la PR,
+el CI y el deploy preview: cerrar un ticket deja de ser editar un fichero y pasa
+a ser consecuencia de mergear.
 
-**Definition of Done** (todos los tickets): funciona contra BBDD real · cero hardcode · **test E2E incluido** · CI verde · responsive · accesible · revisado en preview.
-
----
-
-## Resumen
-
-| Épica                 | Tickets        | Estado                        |
-| --------------------- | -------------- | ----------------------------- |
-| E1 · Cimientos        | BODA-01 → 06   | ✅ 6 hechos                   |
-| E2 · Base de datos    | BODA-10 → 14   | ✅ 5 hechos                   |
-| E3 · Landing          | BODA-20 → 28   | ✅ 2 hechos · 📋 7 pendientes |
-| E4 · Save the Date    | BODA-30 → 32   | 📋 3 pendientes               |
-| E5 · Auth y panel     | BODA-40 → 43   | 📋 4 pendientes               |
-| E6 · Invitados y RSVP | BODA-50 → 58   | 📋 9 pendientes               |
-| E7 · Presupuesto      | BODA-60 → 64   | 📋 5 pendientes               |
-| E8 · Proveedores      | BODA-70 → 74   | 📋 5 pendientes               |
-| E9 · Tareas y seating | BODA-80 → 84   | 📋 5 pendientes               |
-| E10 · Producción      | BODA-90 → 95   | 📋 6 pendientes               |
-| E11 · Día de la boda  | BODA-100 → 104 | 📋 5 pendientes               |
-| E12 · Comunicación    | BODA-110 → 113 | 📋 4 pendientes               |
-
-**Total: 66 tickets · 13 hechos.**
+| Dónde                                                 | Qué contiene                                             |
+| ----------------------------------------------------- | -------------------------------------------------------- |
+| [Issues](https://github.com/Davmunrey/p-d/issues)     | Los tickets: qué hay que hacer, aceptación y su test E2E |
+| [`docs/PLAN-MAESTRO.md`](./PLAN-MAESTRO.md)           | Arquitectura, modelo de datos y decisiones tomadas       |
+| [`CLAUDE.md`](../CLAUDE.md)                           | Las reglas innegociables                                 |
+| [`.github/etiquetas.json`](../.github/etiquetas.json) | Las etiquetas del board, versionadas                     |
 
 ---
 
-## E1 · Cimientos
+## Cómo se lee el board
 
-> Sin esto, todo lo demás acumula deuda. No se empieza la landing hasta que E1 esté cerrada.
+Cada ticket lleva **una etiqueta de épica**, **una de talla** y, si toca, alguna
+de aviso.
 
-### BODA-01 · Inicializar proyecto Next.js
+**Épicas** — las decenas del código `BODA-XX` coinciden con la épica, así que el
+número ya dice de qué va:
 
-`✅` · `S` · sin dependencias
+| Etiqueta              | Códigos          | Qué agrupa                                   |
+| --------------------- | ---------------- | -------------------------------------------- |
+| `e1-cimientos`        | `BODA-01` → `06` | Proyecto, tokens, copys, calidad, despliegue |
+| `e2-base-de-datos`    | `BODA-10` → `14` | Esquema, RLS y funciones públicas            |
+| `e3-landing`          | `BODA-20` → `28` | La web que ven los invitados                 |
+| `e4-save-the-date`    | `BODA-30` → `32` | Reserva de fecha y calendario                |
+| `e5-auth-y-panel`     | `BODA-40` → `43` | Acceso privado y esqueleto del panel         |
+| `e6-invitados-y-rsvp` | `BODA-50` → `58` | Invitados y confirmaciones                   |
+| `e7-presupuesto`      | `BODA-60` → `64` | Partidas, pagos y desvíos                    |
+| `e8-proveedores`      | `BODA-70` → `74` | Proveedores, contratos y servicios           |
+| `e9-tareas-y-mesas`   | `BODA-80` → `84` | Tareas y plano de mesas                      |
+| `e10-produccion`      | `BODA-90` → `95` | Rendimiento, accesibilidad, SEO y respaldos  |
+| `e11-dia-de-la-boda`  | `BODA-100`→`104` | Lo que se usa el día D, desde el móvil       |
+| `e12-comunicacion`    | `BODA-110`→`113` | Envíos, recordatorios y mensajes             |
 
-Next.js 15 (App Router) + TypeScript estricto + Tailwind v4. Estructura de carpetas del §4 del plan.
+**Tallas** — `talla-s` medio día · `talla-m` un día · `talla-l` dos días.
 
-**Aceptación:** `npm run dev` levanta · `npm run build` pasa · `strict: true` sin errores · árbol de carpetas creado.
-**E2E:** la home responde 200 y renderiza.
+**Avisos** — `camino-critico` es lo que bloquea poder repartir invitaciones;
+`seguridad` marca lo que toca RLS, tokens o datos personales y tiene revisión
+bloqueante; `bloqueado` y `decision-pendiente` señalan lo que no se puede
+empezar todavía.
 
----
-
-### BODA-02 · Sistema de design tokens
-
-`✅` · `M` · ← BODA-01
-
-Las tres capas del §2.2: primitivos → semánticos → componente. Expuestos a Tailwind vía `@theme`. Incluye tokens de movimiento (duraciones, easings) y tema claro/oscuro.
-
-**Aceptación:** `styles/tokens/primitives.css`, `semantic.css`, `motion.css` · `bg-surface` y `var(--color-surface)` resuelven al mismo valor · cambiar un primitivo se propaga sin tocar componentes · página `/kitchen-sink` que muestra la paleta y la escala tipográfica.
-**E2E:** el kitchen sink renderiza todos los tokens · alternar tema cambia los colores computados.
-
----
-
-### BODA-03 · Capa de copys en castellano
-
-`✅` · `S` · ← BODA-01
-
-`content/copy.es.json` + hook `useCopy()` tipado. Autocompletado de claves y error de compilación si falta una.
-
-**Aceptación:** cero textos visibles en componentes · clave inexistente falla en typecheck.
-**E2E:** una clave del JSON aparece renderizada en pantalla.
-
----
-
-### BODA-04 · Calidad automatizada
-
-`✅` · `M` · ← BODA-02, BODA-03
-
-ESLint + Prettier + Stylelint + Husky + lint-staged. **Las reglas del §2 se aplican en CI, no por revisión humana.**
-
-**Aceptación:** stylelint rechaza colores literales en CSS · ESLint rechaza valores arbitrarios de Tailwind (`text-[14px]`) y textos literales en JSX · pre-commit bloquea código que no cumple.
-**E2E:** n/a — se valida con casos de prueba de lint que deben fallar.
+**Estados.** No hay etiquetas de estado: abierto es pendiente, con PR enlazada
+es en curso, cerrado es hecho. Se sabe por la propia incidencia, no por una
+etiqueta que alguien tiene que acordarse de mover.
 
 ---
 
-### BODA-05 · Despliegue y CI
+## Camino crítico
 
-`✅` · `M` · ← BODA-01
+Filtro directo: [`label:camino-critico`](https://github.com/Davmunrey/p-d/issues?q=is%3Aopen+label%3Acamino-critico).
 
-Despliegue en Vercel, nativo para Next.js. GitHub Actions: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E. Deploy preview por PR.
+`E1 → E2 → E3 → E4 → BODA-52 → BODA-55`. Con eso ya se pueden repartir
+invitaciones y recibir confirmaciones, que es lo único con fecha de verdad.
 
-**Aceptación:** push a `main` despliega · cada PR genera preview con URL · CI bloquea el merge si falla.
-**E2E:** la suite corre en CI contra el preview.
-
----
-
-### BODA-06 · Proyecto Supabase y conexión
-
-`✅` · `M` · ← BODA-01
-
-Proyectos de producción y staging. Clientes tipados (browser, servidor, middleware). Supabase CLI para local. Generación automática de tipos.
-
-**Aceptación:** `supabase start` levanta en local · `npm run db:types` genera `types/database.ts` · variables en Vercel · **`service_role` nunca en el bundle de cliente** (verificado en build).
-**E2E:** una página server-side lee un valor de la BBDD y lo pinta.
+E7, E8 y E9 son gestión interna: no bloquean a nadie. E3 (landing) y E5
+(panel) se pueden llevar en paralelo una vez cerrada E2.
 
 ---
 
-## E2 · Base de datos
+## El ciclo de un ticket
 
-### BODA-10 · Esquema base y convenciones
-
-`✅` · `S` · ← BODA-06
-
-Extensiones, `updated_at` por trigger, helpers de auditoría, tabla `profiles` ligada a `auth.users` con roles.
-
-### BODA-11 · Configuración de la boda
-
-`✅` · `S` · ← BODA-10
-
-`wedding_settings` (fila única): fecha, lugar, nombres, coordenadas, flags de secciones, fecha límite de RSVP. **Fuente de verdad de todo dato de la boda.**
-**E2E:** cambiar la fecha en BBDD se refleja en la cuenta atrás de la landing.
-
-### BODA-12 · Invitados
-
-`✅` · `M` · ← BODA-10
-
-`guest_groups`, `guests`, `rsvps` con sus enums. Índice único sobre `invite_token`.
-
-### BODA-13 · Presupuesto, proveedores y organización
-
-`✅` · `M` · ← BODA-10
-
-`vendor_categories`, `vendors`, `vendor_documents`, `services`, `budget_categories`, `budget_items`, `payments`, `tasks`, `tables`, `media`, `activity_log`. Vistas `v_budget_summary` y `v_guest_stats`.
-
-### BODA-14 · RLS y funciones públicas
-
-`✅` · `L` · ← BODA-11, BODA-12, BODA-13 · **🔒 crítico**
-
-Políticas RLS de todas las tablas + `get_invitation(token)` y `submit_rsvp(token, responses)` como `SECURITY DEFINER` con rate limiting.
-
-**Aceptación:** anon no lee `guests`, `vendors`, `payments` ni ninguna tabla privada · las funciones devuelven **solo** el grupo del token · token caducado o fuera de plazo se rechaza.
-**E2E:** suite de tests de seguridad que intenta leer cada tabla privada como anon y **debe fallar en todas**.
+1. **Se abre** con la plantilla de ticket. Sin criterios de aceptación y sin
+   test E2E descrito, no es un ticket: es una idea.
+2. **Rama desde `main` actualizado**, nombrada por el ticket:
+   `feat/BODA-52-enlaces-de-invitacion`.
+3. **PR con `Closes #NN`** en el cuerpo. GitHub cierra la incidencia al mergear;
+   nadie la cierra a mano.
+4. **CI verde y preview revisado.** Verde es todo: typecheck, lint, stylelint,
+   formato, unitarios, migraciones y E2E.
+5. **Merge a `main`** en cuanto esté verde, sin pedir permiso. Nunca con un
+   check en rojo, y nunca relajando un test para conseguirlo.
+6. La rama se borra sola.
 
 ---
 
-## E3 · Landing
+## Trabajar desde GitHub, sin terminal
 
-> Todas las secciones leen su contenido de la BBDD. Ninguna imagen en `/public`.
+Mencionar `@claude` en una incidencia, en una PR o en un comentario de revisión
+lanza el trabajo ahí mismo, con el contexto de ese hilo
+([`.github/workflows/claude.yml`](../.github/workflows/claude.yml)).
 
-| ID          | Ticket                                                           | Est. | E2E                                                                   |
-| ----------- | ---------------------------------------------------------------- | ---- | --------------------------------------------------------------------- |
-| **BODA-20** | Layout público, navegación y footer                              | `M`  | Navegación entre secciones funciona en móvil y escritorio             |
-| **BODA-21** | Motor de animación (Motion + Lenis) con `prefers-reduced-motion` | `M`  | Con motion reducido no hay transforms activos                         |
-| **BODA-22** | Hero: foto, nombres, fecha, parallax                             | `M`  | Muestra los datos de `wedding_settings`                               |
-| **BODA-23** | Cuenta atrás                                                     | `S`  | Calcula desde la fecha en BBDD, no desde una constante                |
-| **BODA-24** | Nuestra historia: timeline con reveals                           | `M`  | Los hitos se cargan de BBDD y aparecen al hacer scroll                |
-| **BODA-25** | Galería con lightbox y lazy loading                              | `L`  | Solo fotos publicadas · el lightbox abre, navega y cierra con teclado |
-| **BODA-26** | Cuándo y dónde + mapa                                            | `M`  | Coordenadas de BBDD · el enlace de mapa abre bien                     |
-| **BODA-27** | FAQ, alojamiento y transporte                                    | `M`  | El acordeón abre y cierra, accesible por teclado                      |
-| **BODA-28** | Sección de regalo + CTA de RSVP sticky                           | `S`  | El CTA lleva al RSVP · el regalo solo se revela al interactuar        |
+Sirve para abrir un ticket y decir «hazlo», para pedir un cambio sobre una
+revisión, o para que arregle su propio CI en rojo. Necesita el secreto
+`CLAUDE_CODE_OAUTH_TOKEN`; mientras no esté, la mención se ignora con un aviso
+en el registro en lugar de fallar. Ver [`ENTORNO.md`](./ENTORNO.md).
 
 ---
 
-## E4 · Save the Date
+## Reconstruir el board
 
-| ID          | Ticket                          | Est. | E2E                                          |
-| ----------- | ------------------------------- | ---- | -------------------------------------------- |
-| **BODA-30** | Página `/save-the-date`         | `M`  | Renderiza con datos de BBDD                  |
-| **BODA-31** | Descarga `.ics` para calendario | `S`  | El `.ics` descargado tiene la fecha correcta |
-| **BODA-32** | Open Graph e imagen dinámica    | `S`  | Las meta tags contienen los datos reales     |
-
----
-
-## E5 · Auth y panel
-
-| ID          | Ticket                                        | Est. | E2E                                        |
-| ----------- | --------------------------------------------- | ---- | ------------------------------------------ |
-| **BODA-40** | Login por magic link                          | `M`  | Login completo hasta el panel              |
-| **BODA-41** | Middleware de protección de rutas             | `S`  | **Anon en `/app/*` → redirigido al login** |
-| **BODA-42** | Layout del panel: navegación, usuario, logout | `M`  | Navegar entre módulos y cerrar sesión      |
-| **BODA-43** | Dashboard con KPIs reales                     | `M`  | Los KPIs cambian al modificar datos        |
-
----
-
-## E6 · Invitados y RSVP
-
-> El corazón de la app. Ningún ticket se cierra sin su E2E.
-
-| ID          | Ticket                                       | Est. | E2E                                                                             |
-| ----------- | -------------------------------------------- | ---- | ------------------------------------------------------------------------------- |
-| **BODA-50** | Tabla de invitados: filtros, búsqueda, orden | `L`  | Filtrar y buscar devuelve resultados correctos                                  |
-| **BODA-51** | Alta y edición de invitados y grupos         | `M`  | Crear invitado → aparece en la tabla → editarlo persiste                        |
-| **BODA-52** | Generación y copia de enlaces de invitación  | `M`  | El enlace generado **funciona** en el flujo público                             |
-| **BODA-53** | Import CSV con validación                    | `M`  | CSV válido da de alta en bloque · CSV con errores los muestra sin importar nada |
-| **BODA-54** | Export CSV y Excel                           | `S`  | El fichero descargado contiene las filas filtradas                              |
-| **BODA-55** | Formulario público de RSVP multipaso         | `L`  | Recorrido completo de confirmación                                              |
-| **BODA-56** | Edición de RSVP hasta la fecha límite        | `M`  | Editar antes del plazo funciona · después, se bloquea                           |
-| **BODA-57** | Emails de confirmación (Resend)              | `M`  | Al confirmar se envía el email (mailbox de test)                                |
-| **BODA-58** | Manejo de tokens inválidos y caducados       | `S`  | Token falso → error claro, **sin filtrar datos de otros**                       |
-
----
-
-## E7 · Presupuesto
-
-| ID          | Ticket                                    | Est. | E2E                                           |
-| ----------- | ----------------------------------------- | ---- | --------------------------------------------- |
-| **BODA-60** | Categorías de presupuesto                 | `M`  | Crear categoría con importe previsto          |
-| **BODA-61** | Partidas de gasto: alta, edición, borrado | `M`  | Alta de gasto → **se refleja en los totales** |
-| **BODA-62** | Pagos y calendario de vencimientos        | `M`  | Marcar pagado actualiza el pendiente          |
-| **BODA-63** | Gráficas previsto vs real                 | `M`  | Las gráficas reflejan los datos reales        |
-| **BODA-64** | Alertas de desvío presupuestario          | `S`  | Superar lo previsto muestra el aviso          |
-
----
-
-## E8 · Proveedores y servicios
-
-| ID          | Ticket                                         | Est. | E2E                                                       |
-| ----------- | ---------------------------------------------- | ---- | --------------------------------------------------------- |
-| **BODA-70** | CRUD de proveedores + categorías               | `M`  | Alta, edición y borrado                                   |
-| **BODA-71** | Pipeline de estado (investigando → contratado) | `M`  | Cambiar estado persiste y se refleja en la vista          |
-| **BODA-72** | Documentos: subida a Storage                   | `M`  | Subir contrato → descargarlo · **anon no puede acceder**  |
-| **BODA-73** | Comparativa de presupuestos                    | `M`  | Compara importes de varios proveedores                    |
-| **BODA-74** | Servicios con precio por invitado              | `M`  | Confirmar invitados **recalcula el importe del servicio** |
-
----
-
-## E9 · Tareas y seating
-
-| ID          | Ticket                                          | Est. | E2E                                               |
-| ----------- | ----------------------------------------------- | ---- | ------------------------------------------------- |
-| **BODA-80** | CRUD de tareas                                  | `M`  | Crear, completar y borrar                         |
-| **BODA-81** | Vista kanban con drag & drop                    | `M`  | Arrastrar cambia el estado y persiste             |
-| **BODA-82** | Plantilla inicial de tareas por meses restantes | `S`  | Genera las tareas según la fecha de boda          |
-| **BODA-83** | Plano de mesas drag & drop                      | `L`  | Mover mesa guarda su posición                     |
-| **BODA-84** | Asignación de invitados a mesas                 | `L`  | Asignar avisa de alergias y de invitados sin mesa |
-
----
-
-## E10 · Producción
-
-| ID          | Ticket                                 | Est. | Nota                                         |
-| ----------- | -------------------------------------- | ---- | -------------------------------------------- |
-| **BODA-90** | Optimización de imágenes y rendimiento | `L`  | Objetivo Lighthouse ≥ 95 · CLS < 0.1         |
-| **BODA-91** | Auditoría de accesibilidad AA          | `M`  | Axe en CI sin violaciones críticas           |
-| **BODA-92** | SEO, sitemap y robots                  | `S`  | Landing indexable · panel **no** indexable   |
-| **BODA-93** | Sentry y PostHog                       | `M`  | Errores y eventos llegan a los paneles       |
-| **BODA-94** | Backup diario automatizado             | `M`  | GitHub Action que exporta a repo privado     |
-| **BODA-95** | Ping semanal anti-pausa de Supabase    | `S`  | Evita la pausa por inactividad del free tier |
-
----
-
-## E11 · Panel: día de la boda y cierre
-
-> Lo que hace falta cuando ya no se planifica, sino que se ejecuta. Casi todo
-> se usa **desde el móvil y con prisa**, así que prima la lectura rápida sobre
-> la densidad de datos.
-
-| ID           | Ticket                                    | Est. | E2E                                                           |
-| ------------ | ----------------------------------------- | ---- | ------------------------------------------------------------- |
-| **BODA-100** | Lista de control del día                  | `M`  | Marcar hecho persiste y sobrevive a recargar                  |
-| **BODA-101** | Agenda de contactos de proveedores        | `S`  | Los teléfonos son enlaces `tel:` pulsables desde el móvil     |
-| **BODA-102** | Buscador de invitados a pantalla completa | `M`  | Buscar un apellido devuelve su mesa y su menú en un toque     |
-| **BODA-103** | Recuento en vivo para el catering         | `M`  | Confirmados por tipo de menú, con niños aparte                |
-| **BODA-104** | Exportar todo (invitados, mesas, menús)   | `S`  | El fichero descargado abre en Excel con los acentos correctos |
-
----
-
-## E12 · Panel: comunicación con invitados
-
-| ID           | Ticket                                | Est. | E2E                                                           |
-| ------------ | ------------------------------------- | ---- | ------------------------------------------------------------- |
-| **BODA-110** | Envío de invitaciones por WhatsApp    | `M`  | Genera el enlace con el token del grupo y el texto ya escrito |
-| **BODA-111** | Recordatorio a quien no ha contestado | `M`  | Solo alcanza a los pendientes, nunca a quien ya respondió     |
-| **BODA-112** | Bandeja de mensajes del RSVP          | `S`  | Los mensajes que dejan los invitados se leen en el panel      |
-| **BODA-113** | Moderación de la playlist             | `S`  | Ocultar una canción la retira de la landing sin borrarla      |
-
----
-
-## Rutas de trabajo
-
-**Camino crítico hacia el primer envío a invitados:**
-`E1 → E2 → E3 → E4 → BODA-52 → BODA-55` — con esto ya se pueden repartir invitaciones y recibir confirmaciones.
-
-**Después, sin prisa:** E7, E8 y E9 son gestión interna y no bloquean a los invitados.
-
-**Paralelizable:** E3 (landing) y E5 (auth/panel) no dependen entre sí una vez cerrada E2.
-
----
-
-## Estimaciones
-
-`S` ≈ medio día · `M` ≈ 1 día · `L` ≈ 2 días
-
-**Total estimado: ~48 días de trabajo efectivo.** Al camino crítico (E1→E4 + RSVP) le corresponden ~22.
+Las etiquetas son configuración versionada, no algo que se cree a mano en la
+interfaz. Se editan en [`.github/etiquetas.json`](../.github/etiquetas.json) y
+al mergear a `main` el flujo `Etiquetas` las reconcilia. También se puede
+lanzar a mano desde la pestaña **Actions**.

--- a/docs/ENTORNO.md
+++ b/docs/ENTORNO.md
@@ -76,10 +76,25 @@ evita:
    teléfonos y las alergias de los invitados.
 3. **Un secreto más que rota y que se filtra.** El que no existe no se filtra.
 
-### Si algún día hacen falta
+### La excepción: trabajar desde GitHub
+
+`.github/workflows/claude.yml` permite mencionar `@claude` en una incidencia o
+en una PR y que el trabajo se haga ahí, sin abrir un terminal. Eso sí necesita
+credencial:
+
+| Secreto                   | De dónde sale                                                     |
+| ------------------------- | ----------------------------------------------------------------- |
+| `CLAUDE_CODE_OAUTH_TOKEN` | `/install-github-app` desde Claude Code, si usas la suscripción   |
+| `ANTHROPIC_API_KEY`       | Alternativa: consola de Anthropic, si prefieres pagar por consumo |
+
+Basta con uno de los dos. **Mientras no exista ninguno, la mención se ignora**
+dejando un aviso en el registro: el flujo no se pone en rojo, porque no forma
+parte del CI y no debe ensuciar el estado de una PR.
+
+### Si algún día hacen falta más
 
 Cuando entren los emails (BODA-57) o la analítica (BODA-93) habrá que añadir
-`RESEND_API_KEY` y similares. Entonces:
+`RESEND_API_KEY` y similares. En todos los casos:
 
 **Settings → Secrets and variables → Actions → New repository secret.**
 

--- a/docs/PLAN-MAESTRO.md
+++ b/docs/PLAN-MAESTRO.md
@@ -357,7 +357,7 @@ _Idioma resuelto: solo castellano._
 
 ## 13. Cómo trabajamos
 
-- **Se trabaja por tickets**, no por fases sueltas. El board está en [`docs/BACKLOG.md`](./BACKLOG.md).
+- **Se trabaja por tickets**, no por fases sueltas. El board está en [GitHub Issues](https://github.com/Davmunrey/p-d/issues); cómo se lee, en [`docs/BACKLOG.md`](./BACKLOG.md).
 - Una rama por ticket (`feat/BODA-12-tabla-invitados`), PR con deploy preview, merge a `main` = deploy a producción.
 - Toda migración de BBDD entra por PR con su SQL de rollback.
 - Este documento se actualiza en la misma PR que introduce el cambio que lo afecta.
@@ -407,4 +407,8 @@ Entorno de test: proyecto Supabase de staging con seed determinista, reseteado a
 
 ## 15. Board
 
-El backlog vive en [`docs/BACKLOG.md`](./BACKLOG.md): tickets con ID, épica, estimación, dependencias, criterios de aceptación y su test E2E asociado. Se mantiene sincronizado con GitHub Issues (mismo ID) para poder enlazarlos desde las PRs.
+El backlog vive en [GitHub Issues](https://github.com/Davmunrey/p-d/issues): un ticket por incidencia, con su código `BODA-XX` en el título, épica y talla como etiquetas, dependencias enlazadas con `#` y sus criterios de aceptación y test E2E en el cuerpo.
+
+Está en GitHub y no en un fichero del repositorio a propósito. Es donde ya están la PR, el CI y el deploy preview, así que un ticket se cierra al mergear (`Closes #NN`) en lugar de editando un Markdown que tarde o temprano discrepa del estado real. Las etiquetas sí son configuración versionada: viven en [`.github/etiquetas.json`](../.github/etiquetas.json) y un flujo de Actions las reconcilia, de modo que el board se puede reconstruir entero desde el repositorio.
+
+[`docs/BACKLOG.md`](./BACKLOG.md) explica cómo leerlo: épicas, tallas, camino crítico y el ciclo de un ticket.


### PR DESCRIPTION
## Qué cambia

El backlog deja de vivir en un Markdown y pasa a ser incidencias de GitHub, con las etiquetas versionadas en el repositorio y la posibilidad de lanzar trabajo mencionando `@claude`.

Un board en `docs/BACKLOG.md` y otro en GitHub acaban discrepando siempre, y cuando discrepan nadie sabe cuál manda. En GitHub ya están la PR, el CI y el deploy preview: cerrar un ticket pasa a ser consecuencia de mergear (`Closes #NN`) en lugar de acordarse de editar un fichero.

| Fichero | Para qué |
| --- | --- |
| `.github/etiquetas.json` + `workflows/etiquetas.yml` | Las etiquetas del board son configuración versionada. Se reconcilian al mergear a `main` o a mano desde **Actions**, y `--force` las hace idempotentes |
| `.github/ISSUE_TEMPLATE/ticket.yml` | Un ticket sin criterios de aceptación y sin test E2E descrito no se puede ni abrir |
| `.github/ISSUE_TEMPLATE/error.yml` | Incidencias de algo roto, con recordatorio de no pegar datos personales: son públicas |
| `.github/pull_request_template.md` | La Definition of Done a la vista, más el recordatorio del SQL de rollback |
| `.github/workflows/claude.yml` | Mencionar `@claude` en una incidencia o en una revisión lanza el trabajo ahí mismo |

`docs/BACKLOG.md` deja de duplicar el board: ahora explica cómo leerlo (épicas, tallas, camino crítico y el ciclo de un ticket).

## Cómo probarlo en el preview

Este cambio no toca la web, así que el preview debería salir idéntico. Lo que se comprueba es en GitHub:

1. **Actions → Etiquetas → Run workflow** sobre esta rama: crea las 20 etiquetas. Relanzarlo no duplica nada.
2. **Issues → New issue**: aparecen las dos plantillas y no la opción de incidencia en blanco.
3. **Esta misma PR**: el cuerpo sale de la plantilla nueva.
4. `@claude` todavía no responde: falta el secreto, y eso es deliberado — se ignora con un aviso en el registro en lugar de dejar el flujo en rojo.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados — no toca datos
- [x] Cero hardcode: los colores de las etiquetas viven en `etiquetas.json`, no en el flujo que las crea
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error — no hay código de aplicación que probar; la validación es que el CI existente sigue verde
- [ ] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E
- [x] Responsive en móvil, tablet y escritorio — sin cambios de interfaz
- [x] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion` — sin cambios de interfaz
- [x] Pasado por las skills de diseño — sin cambios de interfaz
- [ ] Revisado en el deploy preview

## Base de datos

- [x] No la toca

## Documentación

- [x] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR — §13 y §15. También `README.md`, `CLAUDE.md` y `docs/ENTORNO.md` (los dos secretos que habilitan `@claude`)

## Lo que hace falta de tu parte

Ninguna de las dos cosas la puedo hacer yo:

1. **`/install-github-app`** desde Claude Code en un terminal, para que `@claude` funcione. Instala la app y deja el secreto `CLAUDE_CODE_OAUTH_TOKEN`; el valor no debe pasar por un chat.
2. **Un Project** (Projects → New) si además quieres vista de tablero con columnas. Las incidencias y etiquetas ya están; el Project es solo la vista.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_