### PR TITLE
docs: E3 llega hasta BODA-29

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -29,7 +29,7 @@ número ya dice de qué va:
 | --------------------- | ---------------- | -------------------------------------------- |
 | `e1-cimientos`        | `BODA-01` → `06` | Proyecto, tokens, copys, calidad, despliegue |
 | `e2-base-de-datos`    | `BODA-10` → `14` | Esquema, RLS y funciones públicas            |
-| `e3-landing`          | `BODA-20` → `28` | La web que ven los invitados                 |
+| `e3-landing`          | `BODA-20` → `29` | La web que ven los invitados                 |
 | `e4-save-the-date`    | `BODA-30` → `32` | Reserva de fecha y calendario                |
 | `e5-auth-y-panel`     | `BODA-40` → `43` | Acceso privado y esqueleto del panel         |
 | `e6-invitados-y-rsvp` | `BODA-50` → `58` | Invitados y confirmaciones                   |


### PR DESCRIPTION
## Qué cambia

La tabla de épicas decía que E3 acaba en `BODA-28`. Al volcar el board a incidencias apareció un hueco que el Markdown tapaba: la sección de playlist **lista** canciones sugeridas pero no hay forma de sugerir ninguna, y `sugerir_cancion()` lleva desde su migración en la base de datos sin cablear a nada. Eso incumple la regla 3, así que es un ticket: #29.

## Cómo probarlo en el preview

No toca la web. La comprobación es que la tabla de `docs/BACKLOG.md` coincide con lo que hay en el board.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados — solo documentación
- [x] Cero hardcode
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error — el trabajo de verdad está en #29, que trae los suyos
- [ ] CI verde entero
- [x] Responsive en móvil, tablet y escritorio — sin cambios de interfaz
- [x] Accesible — sin cambios de interfaz
- [x] Pasado por las skills de diseño — sin cambios de interfaz
- [ ] Revisado en el deploy preview

## Base de datos

- [x] No la toca

## Documentación

- [x] Es el propio cambio

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_