### PR TITLE
feat(BODA-20): navegación y pie, con las secciones cableadas a la BBDD

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -25,13 +25,26 @@
     "descripcion": "Nos casamos. Aquí tenéis todo lo que necesitáis saber."
   },
   "navegacion": {
-    "inicio": "Inicio",
-    "programa": "Programa",
-    "alojamiento": "Alojamiento",
-    "comoLlegar": "Cómo llegar",
-    "playlist": "Playlist",
-    "confirmar": "Confirmar",
-    "irAlContenido": "Ir al contenido"
+    "etiquetaPrincipal": "Navegación principal",
+    "irAlContenido": "Ir al contenido",
+    "abrirMenu": "Abrir menú",
+    "cerrarMenu": "Cerrar menú",
+    "menu": "Menú",
+    "secciones": {
+      "portada": "Inicio",
+      "reserva_la_fecha": "Reservad la fecha",
+      "cuenta_atras": "Cuenta atrás",
+      "historia": "Nuestra historia",
+      "galeria": "Galería",
+      "programa": "El día",
+      "ubicaciones": "Dónde",
+      "transporte": "Cómo llegar",
+      "alojamiento": "Alojamiento",
+      "regalos": "Regalo",
+      "preguntas_frecuentes": "Preguntas",
+      "playlist": "Playlist",
+      "rsvp": "Confirmar"
+    }
   },
   "portada": {
     "etiquetaFecha": "La fecha",
@@ -108,7 +121,10 @@
     "verLaWeb": "Ver la web"
   },
   "pie": {
-    "escribidnos": "Escribidnos"
+    "escribidnos": "Escribidnos",
+    "etiquetaNavegacion": "Enlaces del pie",
+    "contacto": "Cualquier duda, escribidnos",
+    "volverArriba": "Volver arriba"
   },
   "cocina": {
     "titulo": "Sistema de diseño",

--- a/docs/PLAN-MAESTRO.md
+++ b/docs/PLAN-MAESTRO.md
@@ -28,8 +28,8 @@ Estas reglas aplican a **todo** el código. Una PR que las incumpla no se mergea
 | -------------------------------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------- |
 | Colores, tipografías, espaciados, radios, sombras, duraciones, easings, z-index, breakpoints | Design tokens (CSS custom properties)     | Valores literales en componentes   |
 | Textos visibles (copys, labels, errores, meta)                                               | `content/copy.es.json`, tipado            | Strings literales en JSX           |
-| Datos de la boda (fecha, lugar, nombres, coordenadas, hashtag)                               | Tabla `wedding_settings` en BBDD          | Constantes en código               |
-| Fotos, vídeos, documentos                                                                    | Supabase Storage + tabla `media`          | `/public` con rutas fijas          |
+| Datos de la boda (fecha, lugar, nombres, coordenadas, hashtag)                               | Tabla `configuracion_boda` en BBDD        | Constantes en código               |
+| Fotos, vídeos, documentos                                                                    | Supabase Storage + tabla `medios`         | `/public` con rutas fijas          |
 | URLs de servicios, claves, IDs de proyecto                                                   | Variables de entorno (`.env`, Vercel env) | Código fuente                      |
 | Enums de negocio (estados RSVP, categorías)                                                  | Tipos Postgres + tipos TS generados       | Uniones de strings escritas a mano |
 | Números mágicos (límites, paginación, timeouts)                                              | `src/config/constants.ts`, con nombre     | Literales incrustados              |
@@ -83,25 +83,25 @@ Orden de precedencia si algo entra en conflicto: **estas reglas fundacionales > 
 
 ## 3. Stack
 
-| Capa          | Elección                                                       | Por qué                                                                                                                      |
-| ------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Framework     | **Next.js 15 (App Router)**                                    | SSR/ISR para la landing, Server Actions para el panel, un solo repo para ambas caras                                         |
-| Hosting       | **Vercel**                                                     | Despliegue nativo de Next.js: no hay adaptador que mantener. Deploy previews por PR, CDN global, free tier suficiente        |
-| BBDD          | **Supabase** (PostgreSQL, open source)                         | Postgres puro + Auth + Storage + RLS + Realtime en un free tier. Autoalojable si algún día hace falta                        |
-| Auth          | Supabase Auth (magic link + OAuth Google)                      | Sin gestionar contraseñas. Solo 2-4 usuarios                                                                                 |
-| Ficheros      | Supabase Storage                                               | Fotos de la landing, contratos y facturas de proveedores                                                                     |
-| Estilos       | Tailwind CSS v4 + design tokens en CSS vars                    | Tokens nativos vía `@theme`, sin capa de traducción                                                                          |
-| Componentes   | shadcn/ui (copiado al repo, re-tematizado con nuestros tokens) | Base accesible; el código es nuestro y se adapta a los tokens                                                                |
-| Animación     | Motion (`framer-motion`) + Lenis (scroll suave)                | Scroll-linked, parallax y reveals; API declarativa                                                                           |
-| Formularios   | React Hook Form + Zod                                          | Un esquema Zod valida cliente y servidor                                                                                     |
-| Datos (panel) | TanStack Query + Server Actions                                | Caché, optimistic updates, invalidación                                                                                      |
-| Copys         | `content/copy.es.json` + hook `useCopy()` tipado               | **Todo en castellano.** Sin librería de i18n: una capa propia y ligera que impide textos en código y centraliza la redacción |
-| Tablas        | TanStack Table                                                 | Filtros, orden y export CSV para invitados/gastos                                                                            |
-| Emails        | Resend (free tier)                                             | Confirmaciones de RSVP y recordatorios                                                                                       |
-| Tests         | Vitest + Testing Library + Playwright                          | Unitarios y E2E del flujo crítico (RSVP y login)                                                                             |
-| Calidad       | ESLint + Prettier + Stylelint + Husky + lint-staged            | Las reglas del §2 se aplican solas                                                                                           |
-| Errores       | Sentry (free tier)                                             | Ya disponible en el entorno                                                                                                  |
-| Analítica     | PostHog (free tier)                                            | Ya disponible en el entorno                                                                                                  |
+| Capa          | Elección                                                       | Por qué                                                                                                                           |
+| ------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Framework     | **Next.js 15 (App Router)**                                    | SSR/ISR para la landing, Server Actions para el panel, un solo repo para ambas caras                                              |
+| Hosting       | **Vercel**                                                     | Despliegue nativo de Next.js: no hay adaptador que mantener. Deploy previews por PR, CDN global, free tier suficiente             |
+| BBDD          | **Supabase** (PostgreSQL, open source)                         | Postgres puro + Auth + Storage + RLS + Realtime en un free tier. Autoalojable si algún día hace falta                             |
+| Auth          | Supabase Auth (magic link + OAuth Google)                      | Sin gestionar contraseñas. Solo 2-4 usuarios                                                                                      |
+| Ficheros      | Supabase Storage                                               | Fotos de la landing, contratos y facturas de proveedores                                                                          |
+| Estilos       | Tailwind CSS v4 + design tokens en CSS vars                    | Tokens nativos vía `@theme`, sin capa de traducción                                                                               |
+| Componentes   | shadcn/ui (copiado al repo, re-tematizado con nuestros tokens) | Base accesible; el código es nuestro y se adapta a los tokens                                                                     |
+| Animación     | CSS `animation-timeline: view()` (BODA-21)                     | Reveals al scroll sin JavaScript ni librerías. Se descartaron Motion y Lenis: el navegador ya lo hace, y fuera del hilo principal |
+| Formularios   | React Hook Form + Zod                                          | Un esquema Zod valida cliente y servidor                                                                                          |
+| Datos (panel) | TanStack Query + Server Actions                                | Caché, optimistic updates, invalidación                                                                                           |
+| Copys         | `content/copy.es.json` + `t()` tipado (`src/lib/copy.ts`)      | **Todo en castellano.** Sin librería de i18n: una capa propia y ligera que impide textos en código y centraliza la redacción      |
+| Tablas        | TanStack Table                                                 | Filtros, orden y export CSV para invitados/gastos                                                                                 |
+| Emails        | Resend (free tier)                                             | Confirmaciones de RSVP y recordatorios                                                                                            |
+| Tests         | Vitest + Testing Library + Playwright                          | Unitarios y E2E del flujo crítico (RSVP y login)                                                                                  |
+| Calidad       | ESLint + Prettier + Stylelint + Husky + lint-staged            | Las reglas del §2 se aplican solas                                                                                                |
+| Errores       | Sentry (free tier)                                             | Ya disponible en el entorno                                                                                                       |
+| Analítica     | PostHog (free tier)                                            | Ya disponible en el entorno                                                                                                       |
 
 **Alternativas descartadas:** Astro (mejor landing, peor panel — no compensa mantener dos apps); Neon + Auth.js (Postgres excelente, pero habría que construir auth, storage y RLS por separado); PocketBase (ligero, pero requiere servidor propio y sigue pre-1.0).
 
@@ -113,7 +113,7 @@ Orden de precedencia si algo entra en conflicto: **estas reglas fundacionales > 
                  ┌──────────────────────────────┐
    Invitados ───►│  Vercel CDN / Edge           │
                  │  ├─ / (landing, ISR)         │
-                 │  ├─ /save-the-date           │
+                 │  ├─ /reserva-la-fecha        │
                  │  └─ /rsvp/[token]            │
                  └──────────┬───────────────────┘
                             │ Server Actions / Route Handlers
@@ -170,8 +170,12 @@ Todas las tablas llevan `id uuid pk default gen_random_uuid()`, `created_at`, `u
 
 ### Configuración
 
-**`wedding_settings`** (fila única) — fecha, hora, nombres de los novios, lugar de ceremonia y banquete, coordenadas, hashtag, moneda, idioma por defecto, fecha límite de RSVP, flags de secciones visibles.
+**`configuracion_boda`** (fila única) — fecha y hora de ceremonia y banquete, nombres de los novios, lugares, direcciones, coordenadas, hashtag, correo de contacto, moneda, zona horaria, idioma por defecto y fecha límite de RSVP. La vista `v_configuracion_publica` es lo único que lee `anon`: enumera columna a columna lo que puede salir a la web, para que una columna añadida mañana no aparezca sola en la landing.
 → _Elimina de raíz todo hardcode de datos de la boda._
+
+**`secciones_landing`** — qué secciones se enseñan y en qué orden (`seccion`, `visible`, `orden`). Sustituye a los nueve flags `mostrar_*` que este documento describía: añadir una sección es una fila, no una migración de esquema más un despliegue. Su política RLS es `using (visible)`, así que a un invitado no le llega siquiera el nombre de una sección apagada. La landing la usa para decidir qué pinta y qué ofrece en el menú (BODA-20).
+
+**`configuracion_privada`** (fila única) — lo que no puede salir a la web: presupuesto objetivo, aforo máximo, teléfono de contacto, IBAN de regalos y notas.
 
 **`profiles`** — extiende `auth.users`. `role`: `owner` | `editor` | `viewer`.
 
@@ -236,22 +240,31 @@ Ambas con rate limiting y validación de que el token existe y el plazo no ha ve
 
 ### Landing (`/`)
 
-Secciones (orden y visibilidad configurables desde `wedding_settings`):
+El orden y la visibilidad de las secciones salen de `secciones_landing`, no del JSX: la landing recorre esa tabla y pinta lo que le dice (BODA-20). Una sección se enseña si la base de datos la da por visible **y** hay contenido que pintar; ninguna aparece en el menú si su código todavía no existe, porque un enlace a una sección inexistente es peor que no tener menú.
 
-1. **Hero** — foto a pantalla completa, nombres, fecha, cuenta atrás. Parallax suave al scroll.
-2. **Nuestra historia** — timeline con reveals escalonados al entrar en viewport.
-3. **Galería** — grid tipo masonry, lightbox, lazy loading con blur placeholder.
-4. **Cuándo y dónde** — ceremonia y banquete, mapa embebido, cómo llegar.
-5. **Alojamiento y transporte** — recomendaciones y horarios de bus.
-6. **FAQ** — acordeón (dress code, niños, aparcamiento…).
-7. **Regalo** — número de cuenta / Bizum, revelado con interacción.
-8. **CTA RSVP** — sticky en móvil.
+Secciones del enumerado `seccion_landing`:
+
+| Valor                  | Qué es                                                      | Ticket  |
+| ---------------------- | ----------------------------------------------------------- | ------- |
+| `portada`              | Nombres, fecha y lugar a pantalla completa                  | BODA-22 |
+| `cuenta_atras`         | Lo que falta, calculado desde la fecha de la BBDD           | BODA-23 |
+| `historia`             | Hitos de la pareja, con reveal al entrar en pantalla        | BODA-24 |
+| `galeria`              | Rejilla de fotos con lightbox                               | BODA-25 |
+| `programa`             | El día hora a hora                                          | BODA-22 |
+| `ubicaciones`          | Ceremonia y banquete, con mapa                              | BODA-26 |
+| `transporte`           | Cómo llegar: coche, tren, autobús                           | BODA-26 |
+| `alojamiento`          | Hoteles recomendados con tarifa y enlace de reserva         | BODA-27 |
+| `regalos`              | Número de cuenta, revelado sólo al interactuar              | BODA-28 |
+| `preguntas_frecuentes` | Acordeón nativo: etiqueta, niños, aparcamiento…             | BODA-27 |
+| `playlist`             | Canciones que sugieren los invitados                        | BODA-29 |
+| `rsvp`                 | Llamada a confirmar asistencia                              | BODA-28 |
+| `reserva_la_fecha`     | **No es una sección: es una página aparte** (ver más abajo) | BODA-30 |
 
 **Principios de animación:** el movimiento sirve a la narrativa, no la interrumpe. Todas las duraciones y curvas son tokens. Con `prefers-reduced-motion` los reveals se convierten en fades cortos o desaparecen. Ninguna animación puede provocar layout shift (CLS objetivo < 0.1).
 
-### Save the Date (`/save-the-date`)
+### Reserva la fecha (`/reserva-la-fecha`)
 
-Página independiente, ligera y compartible: fecha grande, foto, "añadir al calendario" (`.ics` generado desde `wedding_settings`), Open Graph propio para que se vea bien en WhatsApp.
+Página independiente, ligera y compartible: fecha grande, foto, «añadir al calendario» (`.ics` generado desde `configuracion_boda`) y Open Graph propio para que se vea bien en WhatsApp. La ruta va en castellano como el resto del producto, y existe sólo si su fila de `secciones_landing` está visible: apagada, devuelve 404 en vez de una página a medias.
 
 ### RSVP (`/rsvp/[token]`)
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,12 @@
+import { Fragment, type ReactNode } from "react";
+
+import { Navegacion } from "@/components/marketing/navegacion";
+import { Pie } from "@/components/marketing/pie";
 import { CuentaAtras } from "@/components/marketing/cuenta-atras";
 import { BotonEnlace } from "@/components/ui/boton";
 import { Cita, Cuerpo, Display, Etiqueta, Titulo2, Titulo3 } from "@/components/ui/tipografia";
-import { IDIOMA, ZONA_HORARIA } from "@/config/constants";
+import { ID_CONTENIDO, IDIOMA, ZONA_HORARIA } from "@/config/constants";
+import { anclaDe, esAncla, type Seccion } from "@/config/secciones";
 import {
   obtenerAlojamientos,
   obtenerCanciones,
@@ -10,6 +15,8 @@ import {
   obtenerPreguntasFrecuentes,
   obtenerPrograma,
   obtenerRutas,
+  obtenerSecciones,
+  type ConfiguracionBoda,
 } from "@/lib/bbdd/landing";
 import { t } from "@/lib/copy";
 
@@ -19,6 +26,16 @@ import { t } from "@/lib/copy";
  * Todo lo que se ve aquí sale de la base de datos. No hay ni un dato de la boda
  * escrito en el código: cambiar la hora de la ceremonia o añadir un hotel se
  * hace desde el panel y se refleja aquí sin tocar nada.
+ *
+ * QUÉ SE ENSEÑA Y EN QUÉ ORDEN TAMPOCO LO DECIDE ESTE FICHERO. Lo decide la
+ * tabla `secciones_landing`: apagar una sección la quita de la página y del
+ * menú a la vez. Aquí solo vive el cómo se pinta cada una.
+ *
+ * Una sección se enseña si cumple las dos cosas: que la base de datos la dé
+ * por visible **y** que haya contenido que pintar. La segunda condición no es
+ * un capricho: `galeria` y `ubicaciones` están encendidas desde el primer día
+ * y todavía no existen (son BODA-25 y BODA-26). Sin ese filtro, el menú
+ * ofrecería dos enlaces que no llevan a ninguna parte.
  *
  * Se revalida cada hora: la landing no cambia a menudo, y así los invitados
  * reciben HTML de la caché en lugar de esperar a una consulta.
@@ -41,16 +58,25 @@ const formatoFechaCorta = new Intl.DateTimeFormat(IDIOMA, {
 });
 
 export default async function PaginaInicio() {
-  const [configuracion, programa, historia, alojamientos, rutas, preguntas, canciones] =
-    await Promise.all([
-      obtenerConfiguracion(),
-      obtenerPrograma(),
-      obtenerHistoria(),
-      obtenerAlojamientos(),
-      obtenerRutas(),
-      obtenerPreguntasFrecuentes(),
-      obtenerCanciones(),
-    ]);
+  const [
+    secciones,
+    configuracion,
+    programa,
+    historia,
+    alojamientos,
+    rutas,
+    preguntas,
+    canciones,
+  ] = await Promise.all([
+    obtenerSecciones(),
+    obtenerConfiguracion(),
+    obtenerPrograma(),
+    obtenerHistoria(),
+    obtenerAlojamientos(),
+    obtenerRutas(),
+    obtenerPreguntasFrecuentes(),
+    obtenerCanciones(),
+  ]);
 
   // Sin configuración no hay boda que enseñar: puede que falte la variable de
   // entorno o que aún no se haya rellenado el panel. Se dice con claridad, en
@@ -66,304 +92,403 @@ export default async function PaginaInicio() {
     );
   }
 
+  const nombres = `${configuracion.nombreNovia} ${t("portada.conjuncion")} ${configuracion.nombreNovio}`;
+
+  const contenido: Partial<Record<Seccion, ReactNode>> = {
+    portada: <Portada configuracion={configuracion} />,
+    cuenta_atras: <CuentaAtrasSeccion configuracion={configuracion} />,
+    historia: historia.length > 0 ? <Historia hitos={historia} /> : undefined,
+    programa:
+      programa.length > 0 ? (
+        <Programa hitos={programa} fecha={configuracion.fechaCeremonia} />
+      ) : undefined,
+    alojamiento: alojamientos.length > 0 ? <Alojamiento sitios={alojamientos} /> : undefined,
+    transporte:
+      rutas.length > 0 ? <Transporte rutas={rutas} configuracion={configuracion} /> : undefined,
+    preguntas_frecuentes:
+      preguntas.length > 0 ? <Preguntas preguntas={preguntas} /> : undefined,
+    playlist: <Playlist canciones={canciones} />,
+    rsvp: <Rsvp configuracion={configuracion} />,
+  };
+
+  // El orden lo pone la base de datos; el filtro, lo que de verdad hay hecho.
+  const aPintar = secciones.filter((seccion) => esAncla(seccion) && contenido[seccion]);
+
+  const enlaces = aPintar.map((seccion) => ({
+    seccion,
+    ancla: anclaDe(seccion),
+    rotulo: t(`navegacion.secciones.${seccion}`),
+  }));
+
+  return (
+    <>
+      {/* Primer elemento enfocable del documento: quien navega con teclado no
+          debería tener que recorrer once enlaces para llegar al contenido. */}
+      <a
+        href={`#${ID_CONTENIDO}`}
+        className="sr-only capa-cabecera focus:not-sr-only focus:absolute focus:m-interno focus:rounded-boton focus:bg-superficie focus:px-interno focus:py-pila focus:text-tinta"
+      >
+        {t("navegacion.irAlContenido")}
+      </a>
+
+      <Navegacion
+        enlaces={enlaces}
+        etiqueta={t("navegacion.etiquetaPrincipal")}
+        marca={nombres}
+      />
+
+      <main id={ID_CONTENIDO}>
+        {aPintar.map((seccion) => (
+          <Fragment key={seccion}>{contenido[seccion]}</Fragment>
+        ))}
+      </main>
+
+      <Pie
+        nombres={nombres}
+        correoContacto={configuracion.correoContacto}
+        hashtag={configuracion.hashtag}
+        enlaces={enlaces}
+      />
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------------ */
+/* Secciones                                                                 */
+/* ------------------------------------------------------------------------ */
+
+function Portada({ configuracion }: { configuracion: ConfiguracionBoda }) {
   const lugar = configuracion.lugarCeremonia ?? configuracion.lugarBanquete;
   const procedencia = configuracion.direccionCeremonia;
 
   return (
-    <main id="contenido">
-      {/* ---------------------------------------------------------------- */}
-      {/* Portada                                                          */}
-      {/* ---------------------------------------------------------------- */}
-      <section
-        id="portada"
-        className="grid min-h-dvh items-center px-interno py-seccion-compacta"
-      >
-        <div className="mx-auto w-full max-w-contenido">
-          {procedencia ? (
-            <p className="animacion-aparecer text-etiqueta uppercase tracking-marcado text-tinta-tenue">
-              {procedencia}
-            </p>
-          ) : null}
+    <section
+      id={anclaDe("portada")}
+      className="grid min-h-dvh items-center px-interno py-seccion-compacta"
+    >
+      <div className="mx-auto w-full max-w-contenido">
+        {procedencia ? (
+          <p className="animacion-aparecer text-etiqueta uppercase tracking-marcado text-tinta-tenue">
+            {procedencia}
+          </p>
+        ) : null}
 
-          <Display className="animacion-subir mt-pila">{configuracion.nombreNovia}</Display>
-          <div className="animacion-subir flex flex-wrap items-baseline gap-elemento">
-            <span className="font-titulo text-titulo-1 italic text-marca">
-              {t("portada.conjuncion")}
-            </span>
-            <Display como="p">{configuracion.nombreNovio}</Display>
+        <Display className="animacion-subir mt-pila">{configuracion.nombreNovia}</Display>
+        <div className="animacion-subir flex flex-wrap items-baseline gap-elemento">
+          <span className="font-titulo text-titulo-1 italic text-marca">
+            {t("portada.conjuncion")}
+          </span>
+          <Display como="p">{configuracion.nombreNovio}</Display>
+        </div>
+
+        <hr className="animacion-trazar my-bloque border-t border-borde-fuerte" />
+
+        <dl className="animacion-subir flex flex-wrap gap-bloque">
+          <div>
+            <dt className="text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">
+              {t("portada.etiquetaFecha")}
+            </dt>
+            <dd className="mt-linea font-titulo text-titulo-2">
+              <time dateTime={configuracion.fechaCeremonia.toISOString()}>
+                {formatoFechaCorta.format(configuracion.fechaCeremonia)}
+              </time>
+            </dd>
           </div>
-
-          <hr className="animacion-trazar my-bloque border-t border-borde-fuerte" />
-
-          <dl className="animacion-subir flex flex-wrap gap-bloque">
+          {lugar ? (
             <div>
               <dt className="text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">
-                {t("portada.etiquetaFecha")}
+                {t("portada.etiquetaLugar")}
               </dt>
-              <dd className="mt-linea font-titulo text-titulo-2">
-                <time dateTime={configuracion.fechaCeremonia.toISOString()}>
-                  {formatoFechaCorta.format(configuracion.fechaCeremonia)}
-                </time>
-              </dd>
+              <dd className="mt-linea font-titulo text-titulo-2">{lugar}</dd>
             </div>
-            {lugar ? (
-              <div>
-                <dt className="text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">
-                  {t("portada.etiquetaLugar")}
-                </dt>
-                <dd className="mt-linea font-titulo text-titulo-2">{lugar}</dd>
-              </div>
+          ) : null}
+        </dl>
+
+        <div className="animacion-subir mt-bloque flex flex-wrap gap-interno">
+          <BotonEnlace href={`#${anclaDe("rsvp")}`}>
+            {t("portada.confirmarAsistencia")}
+          </BotonEnlace>
+          <BotonEnlace href={`#${anclaDe("programa")}`} jerarquia="secundario">
+            {t("portada.verElDia")}
+          </BotonEnlace>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CuentaAtrasSeccion({ configuracion }: { configuracion: ConfiguracionBoda }) {
+  const idTitulo = `titulo-${anclaDe("cuenta_atras")}`;
+  return (
+    <section
+      id={anclaDe("cuenta_atras")}
+      data-seccion="inversa"
+      className="px-interno py-seccion-compacta text-center"
+      aria-labelledby={idTitulo}
+    >
+      <div className="mx-auto max-w-estrecho">
+        <Etiqueta id={idTitulo}>{t("cuentaAtras.titulo")}</Etiqueta>
+        <div className="mt-elemento">
+          <CuentaAtras fechaIso={configuracion.fechaCeremonia.toISOString()} />
+        </div>
+        <p className="mt-bloque text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">
+          {formatoFecha.format(configuracion.fechaCeremonia)}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function Historia({
+  hitos,
+}: {
+  hitos: {
+    id: string;
+    titulo: string;
+    fechaTexto: string | null;
+    descripcion: string | null;
+  }[];
+}) {
+  return (
+    <Bloque seccion="historia" etiqueta={null} titulo={null}>
+      <ol className="grid gap-bloque sm:grid-cols-3">
+        {hitos.map((hito) => (
+          <li key={hito.id} className="animacion-subir-al-ver">
+            {hito.fechaTexto ? <Etiqueta>{hito.fechaTexto}</Etiqueta> : null}
+            <Titulo3 className="mt-pila">{hito.titulo}</Titulo3>
+            {hito.descripcion ? <Cuerpo className="mt-linea">{hito.descripcion}</Cuerpo> : null}
+          </li>
+        ))}
+      </ol>
+    </Bloque>
+  );
+}
+
+function Programa({
+  hitos,
+  fecha,
+}: {
+  hitos: { id: string; hora: string; titulo: string; descripcion: string | null }[];
+  fecha: Date;
+}) {
+  return (
+    <Bloque
+      seccion="programa"
+      etiqueta={formatoFecha.format(fecha)}
+      titulo={t("programa.titulo")}
+    >
+      <ol className="border-t border-borde">
+        {hitos.map((hito) => (
+          <li
+            key={hito.id}
+            className="animacion-subir-al-ver rejilla-dato gap-elemento border-b border-borde py-elemento"
+          >
+            <span className="font-titulo text-titulo-3 text-marca tabular-nums">
+              {hito.hora}
+            </span>
+            <div>
+              <Titulo3 como="h3">{hito.titulo}</Titulo3>
+              {hito.descripcion ? (
+                <Cuerpo className="mt-linea max-w-texto">{hito.descripcion}</Cuerpo>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </Bloque>
+  );
+}
+
+function Alojamiento({
+  sitios,
+}: {
+  sitios: {
+    id: string;
+    nombre: string;
+    distintivo: string | null;
+    descripcion: string | null;
+    precioTexto: string | null;
+    urlReserva: string | null;
+  }[];
+}) {
+  return (
+    <Bloque
+      seccion="alojamiento"
+      etiqueta={t("alojamiento.etiqueta")}
+      titulo={t("alojamiento.titulo")}
+      hundida
+    >
+      <ul className="grid gap-elemento sm:grid-cols-2 lg:grid-cols-3">
+        {sitios.map((sitio) => (
+          <li
+            key={sitio.id}
+            className="animacion-subir-al-ver flex flex-col rounded-tarjeta border border-borde bg-superficie p-elemento"
+          >
+            {sitio.distintivo ? <Etiqueta>{sitio.distintivo}</Etiqueta> : null}
+            <Titulo3 como="h3" className="mt-pila">
+              {sitio.nombre}
+            </Titulo3>
+            {sitio.descripcion ? (
+              <Cuerpo className="mt-linea flex-1">{sitio.descripcion}</Cuerpo>
             ) : null}
-          </dl>
-
-          <div className="animacion-subir mt-bloque flex flex-wrap gap-interno">
-            <BotonEnlace href="#rsvp">{t("portada.confirmarAsistencia")}</BotonEnlace>
-            <BotonEnlace href="#programa" jerarquia="secundario">
-              {t("portada.verElDia")}
-            </BotonEnlace>
-          </div>
-        </div>
-      </section>
-
-      {/* ---------------------------------------------------------------- */}
-      {/* Cuenta atrás — bloque inverso                                    */}
-      {/* ---------------------------------------------------------------- */}
-      <section
-        data-seccion="inversa"
-        className="px-interno py-seccion-compacta text-center"
-        aria-labelledby="titulo-cuenta"
-      >
-        <div className="mx-auto max-w-estrecho">
-          <Etiqueta id="titulo-cuenta">{t("cuentaAtras.titulo")}</Etiqueta>
-          <div className="mt-elemento">
-            <CuentaAtras fechaIso={configuracion.fechaCeremonia.toISOString()} />
-          </div>
-          <p className="mt-bloque text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">
-            {formatoFecha.format(configuracion.fechaCeremonia)}
-          </p>
-        </div>
-      </section>
-
-      {/* ---------------------------------------------------------------- */}
-      {/* Nuestra historia                                                 */}
-      {/* ---------------------------------------------------------------- */}
-      {historia.length > 0 ? (
-        <Seccion id="historia" etiqueta={null} titulo={null}>
-          <ol className="grid gap-bloque sm:grid-cols-3">
-            {historia.map((hito) => (
-              <li key={hito.id} className="animacion-subir-al-ver">
-                {hito.fechaTexto ? <Etiqueta>{hito.fechaTexto}</Etiqueta> : null}
-                <Titulo3 className="mt-pila">{hito.titulo}</Titulo3>
-                {hito.descripcion ? (
-                  <Cuerpo className="mt-linea">{hito.descripcion}</Cuerpo>
-                ) : null}
-              </li>
-            ))}
-          </ol>
-        </Seccion>
-      ) : null}
-
-      {/* ---------------------------------------------------------------- */}
-      {/* Programa                                                         */}
-      {/* ---------------------------------------------------------------- */}
-      {programa.length > 0 ? (
-        <Seccion
-          id="programa"
-          etiqueta={formatoFecha.format(configuracion.fechaCeremonia)}
-          titulo={t("programa.titulo")}
-        >
-          <ol className="border-t border-borde">
-            {programa.map((hito) => (
-              <li
-                key={hito.id}
-                className="animacion-subir-al-ver rejilla-dato gap-elemento border-b border-borde py-elemento"
-              >
-                <span className="font-titulo text-titulo-3 text-marca tabular-nums">
-                  {hito.hora}
-                </span>
-                <div>
-                  <Titulo3 como="h3">{hito.titulo}</Titulo3>
-                  {hito.descripcion ? (
-                    <Cuerpo className="mt-linea max-w-texto">{hito.descripcion}</Cuerpo>
-                  ) : null}
-                </div>
-              </li>
-            ))}
-          </ol>
-        </Seccion>
-      ) : null}
-
-      {/* ---------------------------------------------------------------- */}
-      {/* Alojamiento                                                      */}
-      {/* ---------------------------------------------------------------- */}
-      {alojamientos.length > 0 ? (
-        <Seccion
-          id="alojamiento"
-          etiqueta={t("alojamiento.etiqueta")}
-          titulo={t("alojamiento.titulo")}
-          hundida
-        >
-          <ul className="grid gap-elemento sm:grid-cols-2 lg:grid-cols-3">
-            {alojamientos.map((sitio) => (
-              <li
-                key={sitio.id}
-                className="animacion-subir-al-ver flex flex-col rounded-tarjeta border border-borde bg-superficie p-elemento"
-              >
-                {sitio.distintivo ? <Etiqueta>{sitio.distintivo}</Etiqueta> : null}
-                <Titulo3 como="h3" className="mt-pila">
-                  {sitio.nombre}
-                </Titulo3>
-                {sitio.descripcion ? (
-                  <Cuerpo className="mt-linea flex-1">{sitio.descripcion}</Cuerpo>
-                ) : null}
-                <div className="mt-elemento flex items-baseline justify-between gap-interno border-t border-borde-tenue pt-interno">
-                  {sitio.precioTexto ? (
-                    <span className="font-titulo text-titulo-3">{sitio.precioTexto}</span>
-                  ) : (
-                    <span />
-                  )}
-                  {sitio.urlReserva ? (
-                    <a
-                      href={sitio.urlReserva}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-etiqueta uppercase tracking-etiqueta text-marca transicion-color hover:text-tinta"
-                    >
-                      {t("alojamiento.reservar")}
-                    </a>
-                  ) : null}
-                </div>
-              </li>
-            ))}
-          </ul>
-        </Seccion>
-      ) : null}
-
-      {/* ---------------------------------------------------------------- */}
-      {/* Cómo llegar                                                      */}
-      {/* ---------------------------------------------------------------- */}
-      {rutas.length > 0 ? (
-        <Seccion
-          id="como-llegar"
-          etiqueta={t("comoLlegar.etiqueta")}
-          titulo={t("comoLlegar.titulo")}
-        >
-          <div className="grid gap-bloque lg:grid-cols-2">
-            <ul className="border-t border-borde">
-              {rutas.map((ruta) => (
-                <li
-                  key={ruta.id}
-                  className="rejilla-dato gap-elemento border-b border-borde py-pila"
-                >
-                  <span className="font-titulo text-titulo-3 text-marca">{ruta.duracion}</span>
-                  <div>
-                    <h3 className="text-etiqueta uppercase tracking-etiqueta text-tinta">
-                      {ruta.modo}
-                    </h3>
-                    {ruta.detalle ? <Cuerpo className="mt-linea">{ruta.detalle}</Cuerpo> : null}
-                  </div>
-                </li>
-              ))}
-            </ul>
-
-            {configuracion.latitud !== null && configuracion.longitud !== null ? (
-              <div className="self-start">
-                <BotonEnlace
-                  href={`https://www.google.com/maps/search/?api=1&query=${configuracion.latitud},${configuracion.longitud}`}
+            <div className="mt-elemento flex items-baseline justify-between gap-interno border-t border-borde-tenue pt-interno">
+              {sitio.precioTexto ? (
+                <span className="font-titulo text-titulo-3">{sitio.precioTexto}</span>
+              ) : (
+                <span />
+              )}
+              {sitio.urlReserva ? (
+                <a
+                  href={sitio.urlReserva}
                   target="_blank"
                   rel="noopener noreferrer"
+                  className="text-etiqueta uppercase tracking-etiqueta text-marca transicion-color hover:text-tinta"
                 >
-                  {t("comoLlegar.abrirMapa")}
-                </BotonEnlace>
+                  {t("alojamiento.reservar")}
+                </a>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Bloque>
+  );
+}
+
+function Transporte({
+  rutas,
+  configuracion,
+}: {
+  rutas: { id: string; modo: string; duracion: string | null; detalle: string | null }[];
+  configuracion: ConfiguracionBoda;
+}) {
+  return (
+    <Bloque
+      seccion="transporte"
+      etiqueta={t("comoLlegar.etiqueta")}
+      titulo={t("comoLlegar.titulo")}
+    >
+      <div className="grid gap-bloque lg:grid-cols-2">
+        <ul className="border-t border-borde">
+          {rutas.map((ruta) => (
+            <li
+              key={ruta.id}
+              className="rejilla-dato gap-elemento border-b border-borde py-pila"
+            >
+              <span className="font-titulo text-titulo-3 text-marca">{ruta.duracion}</span>
+              <div>
+                <h3 className="text-etiqueta uppercase tracking-etiqueta text-tinta">
+                  {ruta.modo}
+                </h3>
+                {ruta.detalle ? <Cuerpo className="mt-linea">{ruta.detalle}</Cuerpo> : null}
               </div>
-            ) : null}
+            </li>
+          ))}
+        </ul>
+
+        {configuracion.latitud !== null && configuracion.longitud !== null ? (
+          <div className="self-start">
+            <BotonEnlace
+              href={`https://www.google.com/maps/search/?api=1&query=${configuracion.latitud},${configuracion.longitud}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t("comoLlegar.abrirMapa")}
+            </BotonEnlace>
           </div>
-        </Seccion>
-      ) : null}
+        ) : null}
+      </div>
+    </Bloque>
+  );
+}
 
-      {/* ---------------------------------------------------------------- */}
-      {/* Preguntas frecuentes                                             */}
-      {/* ---------------------------------------------------------------- */}
-      {preguntas.length > 0 ? (
-        <Seccion id="preguntas" etiqueta={null} titulo={null} hundida>
-          <ul className="mx-auto max-w-estrecho border-t border-borde">
-            {preguntas.map((pregunta) => (
-              <li key={pregunta.id} className="border-b border-borde">
-                {/* Acordeón nativo: accesible por teclado sin una línea de JS */}
-                <details className="group">
-                  <summary className="cursor-pointer list-none py-elemento font-titulo text-titulo-3 transicion-color hover:text-tinta-marca">
-                    {pregunta.pregunta}
-                  </summary>
-                  <Cuerpo className="max-w-texto pb-elemento">{pregunta.respuesta}</Cuerpo>
-                </details>
-              </li>
-            ))}
-          </ul>
-        </Seccion>
-      ) : null}
+function Preguntas({
+  preguntas,
+}: {
+  preguntas: { id: string; pregunta: string; respuesta: string }[];
+}) {
+  return (
+    <Bloque seccion="preguntas_frecuentes" etiqueta={null} titulo={null} hundida>
+      <ul className="mx-auto max-w-estrecho border-t border-borde">
+        {preguntas.map((pregunta) => (
+          <li key={pregunta.id} className="border-b border-borde">
+            {/* Acordeón nativo: accesible por teclado sin una línea de JS */}
+            <details className="group">
+              <summary className="cursor-pointer list-none py-elemento font-titulo text-titulo-3 transicion-color hover:text-tinta-marca">
+                {pregunta.pregunta}
+              </summary>
+              <Cuerpo className="max-w-texto pb-elemento">{pregunta.respuesta}</Cuerpo>
+            </details>
+          </li>
+        ))}
+      </ul>
+    </Bloque>
+  );
+}
 
-      {/* ---------------------------------------------------------------- */}
-      {/* Playlist                                                         */}
-      {/* ---------------------------------------------------------------- */}
-      <Seccion id="playlist" etiqueta={t("playlist.etiqueta")} titulo={t("playlist.titulo")}>
-        <Cuerpo className="mx-auto max-w-texto text-center">{t("playlist.descripcion")}</Cuerpo>
-        {canciones.length > 0 ? (
-          <ul className="mt-elemento flex flex-wrap justify-center gap-interno-compacto">
-            {canciones.map((cancion) => (
-              <li
-                key={cancion.id}
-                className="rounded-etiqueta bg-superficie-tenue px-interno py-linea text-pequeno text-tinta-marca"
-              >
-                {cancion.texto}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <Cuerpo className="mt-elemento text-center">{t("playlist.vacia")}</Cuerpo>
-        )}
-      </Seccion>
+function Playlist({ canciones }: { canciones: { id: string; texto: string }[] }) {
+  return (
+    <Bloque seccion="playlist" etiqueta={t("playlist.etiqueta")} titulo={t("playlist.titulo")}>
+      <Cuerpo className="mx-auto max-w-texto text-center">{t("playlist.descripcion")}</Cuerpo>
+      {canciones.length > 0 ? (
+        <ul className="mt-elemento flex flex-wrap justify-center gap-interno-compacto">
+          {canciones.map((cancion) => (
+            <li
+              key={cancion.id}
+              className="rounded-etiqueta bg-superficie-tenue px-interno py-linea text-pequeno text-tinta-marca"
+            >
+              {cancion.texto}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <Cuerpo className="mt-elemento text-center">{t("playlist.vacia")}</Cuerpo>
+      )}
+    </Bloque>
+  );
+}
 
-      {/* ---------------------------------------------------------------- */}
-      {/* RSVP                                                             */}
-      {/* ---------------------------------------------------------------- */}
-      <section
-        id="rsvp"
-        data-seccion="inversa"
-        className="px-interno py-seccion-compacta text-center"
-        aria-labelledby="titulo-rsvp"
-      >
-        <div className="mx-auto max-w-estrecho">
-          {configuracion.fechaLimiteRsvp ? (
-            <Etiqueta>{formatoFecha.format(configuracion.fechaLimiteRsvp)}</Etiqueta>
-          ) : null}
-          <Titulo2 id="titulo-rsvp" className="mt-pila">
-            {t("rsvp.titulo")}
-          </Titulo2>
-          <Cita className="mx-auto mt-elemento max-w-texto">{t("meta.descripcion")}</Cita>
-        </div>
-      </section>
-    </main>
+function Rsvp({ configuracion }: { configuracion: ConfiguracionBoda }) {
+  const idTitulo = `titulo-${anclaDe("rsvp")}`;
+  return (
+    <section
+      id={anclaDe("rsvp")}
+      data-seccion="inversa"
+      className="px-interno py-seccion-compacta text-center"
+      aria-labelledby={idTitulo}
+    >
+      <div className="mx-auto max-w-estrecho">
+        {configuracion.fechaLimiteRsvp ? (
+          <Etiqueta>{formatoFecha.format(configuracion.fechaLimiteRsvp)}</Etiqueta>
+        ) : null}
+        <Titulo2 id={idTitulo} className="mt-pila">
+          {t("rsvp.titulo")}
+        </Titulo2>
+        <Cita className="mx-auto mt-elemento max-w-texto">{t("meta.descripcion")}</Cita>
+      </div>
+    </section>
   );
 }
 
 /** Envoltura de sección: mantiene el ritmo vertical sin repetirlo por página. */
-function Seccion({
-  id,
+function Bloque({
+  seccion,
   etiqueta,
   titulo,
   hundida = false,
   children,
 }: {
-  id: string;
+  seccion: Seccion;
   etiqueta: string | null;
   titulo: string | null;
   hundida?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
-  const idTitulo = `titulo-${id}`;
+  const ancla = anclaDe(seccion);
+  const idTitulo = `titulo-${ancla}`;
   return (
     <section
-      id={id}
+      id={ancla}
       className={`px-interno py-seccion-compacta ${hundida ? "bg-superficie-hundida" : ""}`}
       aria-labelledby={titulo ? idTitulo : undefined}
     >

--- a/src/components/marketing/navegacion.tsx
+++ b/src/components/marketing/navegacion.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { anclaDe } from "@/config/secciones";
+
+/**
+ * NAVEGACIÓN DE LA LANDING
+ *
+ * Es de cliente por una sola razón: marcar en qué sección está el invitado
+ * mientras baja. Todo lo demás —qué enlaces hay, en qué orden y con qué
+ * rótulo— llega ya resuelto desde el servidor, así que el fichero de copys no
+ * viaja al navegador y el menú funciona igual antes de hidratar: son anclas.
+ *
+ * EN MÓVIL NO HAY HAMBURGUESA, y es deliberado. Un menú desplegable son dos
+ * toques, un panel que atrapa el foco, una trampa de scroll y un montón de
+ * ARIA que se rompe en cuanto alguien mueve el diseño. Una tira que se desplaza
+ * en horizontal enseña las secciones de golpe, se toca a la primera y no
+ * necesita ni estado ni `aria-expanded`.
+ */
+
+export interface EnlaceSeccion {
+  /** Valor del enumerado. Solo se usa como clave de React. */
+  seccion: string;
+  /** `id` del elemento al que salta y que se observa para marcarlo. */
+  ancla: string;
+  rotulo: string;
+}
+
+export function Navegacion({
+  enlaces,
+  etiqueta,
+  marca,
+}: {
+  enlaces: EnlaceSeccion[];
+  etiqueta: string;
+  marca: string;
+}) {
+  const cabecera = useRef<HTMLElement>(null);
+  const tira = useRef<HTMLUListElement>(null);
+  const anclaActiva = useAnclaVisible(enlaces, cabecera);
+
+  // La sección activa se trae a la vista dentro de la tira: si no, en móvil el
+  // invitado va por «Playlist» y el menú sigue enseñando «Inicio».
+  useEffect(() => {
+    if (!anclaActiva || !tira.current) return;
+
+    const elemento = tira.current.querySelector(`[data-ancla="${anclaActiva}"]`);
+    if (!(elemento instanceof HTMLElement)) return;
+
+    // `scroll-behavior: auto !important` del CSS no alcanza a un scroll pedido
+    // por JavaScript con `behavior: "smooth"`: hay que preguntar aquí también.
+    const sinMovimiento = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    elemento.scrollIntoView({
+      behavior: sinMovimiento ? "auto" : "smooth",
+      block: "nearest",
+      inline: "center",
+    });
+  }, [anclaActiva]);
+
+  return (
+    <header
+      ref={cabecera}
+      className="velada capa-cabecera fixed inset-x-0 top-0 border-b border-borde-tenue"
+    >
+      <div className="mx-auto flex h-cabecera max-w-amplio items-center gap-interno px-interno">
+        {/*
+          En móvil la marca no cabe: dos nombres largos dejaban la tira de
+          secciones reducida a «INICIO CUE…». Se esconde y la barra entera es
+          para navegar, que es a lo que se viene. Los nombres siguen siendo lo
+          primero que se lee en la portada, así que no se pierde nada.
+        */}
+        <a
+          href={`#${anclaDe("portada")}`}
+          className="hidden shrink-0 font-titulo text-titulo-3 leading-titulo-corto text-tinta transicion-color hover:text-tinta-marca sm:block"
+        >
+          {marca}
+        </a>
+
+        <nav aria-label={etiqueta} className="min-w-0 flex-1">
+          <ul
+            ref={tira}
+            className="flex items-center gap-interno overflow-x-auto sm:justify-end"
+          >
+            {enlaces.map((enlace) => {
+              const activo = enlace.ancla === anclaActiva;
+              return (
+                <li key={enlace.seccion} className="shrink-0">
+                  <a
+                    href={`#${enlace.ancla}`}
+                    data-ancla={enlace.ancla}
+                    aria-current={activo ? "location" : undefined}
+                    className={[
+                      "marca-activa block whitespace-nowrap py-linea text-etiqueta uppercase tracking-etiqueta transicion-color",
+                      activo
+                        ? "border-borde-marca text-tinta-marca"
+                        : "border-transparent text-tinta-suave hover:text-tinta",
+                    ].join(" ")}
+                  >
+                    {enlace.rotulo}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+/**
+ * Devuelve el `id` de la sección que ocupa la franja de lectura: la banda que
+ * va justo por debajo de la barra hasta el primer tercio de la pantalla. Es lo
+ * que una persona percibe como «dónde estoy». Observando la ventana entera
+ * habría dos secciones activas a la vez.
+ *
+ * El alto se MIDE del propio elemento en lugar de leer el token, porque
+ * `rootMargin` solo acepta píxeles y porcentajes: ni `calc()` ni `var()`.
+ *
+ * Sin `IntersectionObserver` —o antes de hidratar— no hay sección marcada, que
+ * es un estado correcto y no un fallo: los enlaces funcionan igual.
+ */
+function useAnclaVisible(
+  enlaces: EnlaceSeccion[],
+  cabecera: React.RefObject<HTMLElement | null>,
+): string | null {
+  const [activa, setActiva] = useState<string | null>(null);
+
+  // El orden importa para desempatar, pero `enlaces` es un array nuevo en cada
+  // render: se depende de su contenido, no de su identidad.
+  const anclas = enlaces.map((enlace) => enlace.ancla).join(",");
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const orden = anclas.split(",").filter(Boolean);
+    if (orden.length === 0) return;
+
+    const visibles = new Set<string>();
+    const altoBarra = cabecera.current?.offsetHeight ?? 0;
+
+    const observador = new IntersectionObserver(
+      (entradas) => {
+        for (const entrada of entradas) {
+          if (entrada.isIntersecting) visibles.add(entrada.target.id);
+          else visibles.delete(entrada.target.id);
+        }
+        // La primera del documento entre las visibles: al bajar, la sección
+        // nueva no roba el marcado hasta que la anterior sale del todo.
+        setActiva(orden.find((ancla) => visibles.has(ancla)) ?? null);
+      },
+      { rootMargin: `-${altoBarra}px 0px -70% 0px` },
+    );
+
+    for (const ancla of orden) {
+      const elemento = document.getElementById(ancla);
+      if (elemento) observador.observe(elemento);
+    }
+
+    return () => observador.disconnect();
+  }, [anclas, cabecera]);
+
+  return activa;
+}

--- a/src/components/marketing/pie.tsx
+++ b/src/components/marketing/pie.tsx
@@ -1,0 +1,76 @@
+import { t } from "@/lib/copy";
+
+/**
+ * PIE DE LA LANDING
+ *
+ * Cierra la página y recoge lo que un invitado busca cuando ya ha leído todo:
+ * a quién escribir si le queda una duda.
+ *
+ * `data-seccion="pie"` reasigna los tokens semánticos a la paleta oscura. El
+ * componente no sabe de qué color se pinta: por eso no lleva ni una clase
+ * distinta de las de cualquier otro bloque.
+ */
+export function Pie({
+  nombres,
+  correoContacto,
+  hashtag,
+  enlaces,
+}: {
+  nombres: string;
+  correoContacto: string | null;
+  hashtag: string | null;
+  enlaces: { seccion: string; ancla: string; rotulo: string }[];
+}) {
+  return (
+    <footer data-seccion="pie" className="px-interno py-seccion-compacta">
+      <div className="mx-auto grid max-w-contenido gap-bloque sm:grid-cols-2">
+        <div>
+          <p className="font-titulo text-titulo-2 leading-titulo-corto">{nombres}</p>
+          {hashtag ? (
+            <p className="mt-pila text-etiqueta uppercase tracking-marcado text-tinta-marca">
+              {hashtag}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="sm:justify-self-end">
+          {enlaces.length > 0 ? (
+            <nav aria-label={t("pie.etiquetaNavegacion")}>
+              <ul className="flex flex-wrap gap-x-elemento gap-y-pila">
+                {enlaces.map((enlace) => (
+                  <li key={enlace.seccion}>
+                    <a
+                      href={`#${enlace.ancla}`}
+                      className="text-etiqueta uppercase tracking-etiqueta text-tinta-suave transicion-color hover:text-tinta"
+                    >
+                      {enlace.rotulo}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ) : null}
+
+          {correoContacto ? (
+            <div className="mt-bloque">
+              <p className="text-pequeno text-tinta-suave">{t("pie.contacto")}</p>
+              <a
+                href={`mailto:${correoContacto}`}
+                className="mt-linea inline-block font-titulo text-titulo-3 text-tinta-marca transicion-color hover:text-tinta"
+              >
+                {correoContacto}
+              </a>
+            </div>
+          ) : null}
+
+          <a
+            href="#portada"
+            className="mt-bloque inline-block text-etiqueta uppercase tracking-etiqueta text-tinta-suave transicion-color hover:text-tinta"
+          >
+            {t("pie.volverArriba")}
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,8 +5,15 @@
  * su nombre es la explicación.
  *
  * Ojo: aquí NO van datos de la boda (fecha, lugar, nombres). Eso vive en la
- * tabla `wedding_settings` y se lee en runtime.
+ * tabla `configuracion_boda` y se lee en runtime.
  */
+
+/**
+ * `id` del elemento al que salta el enlace de «ir al contenido». Vive aquí
+ * porque lo escriben dos sitios —el enlace y el `<main>`— y si dejan de
+ * coincidir, el salto deja de funcionar sin que nada avise.
+ */
+export const ID_CONTENIDO = "contenido";
 
 /** Atributo del elemento raíz que fuerza el tema. */
 export const ATRIBUTO_TEMA = "data-tema";

--- a/src/config/secciones.ts
+++ b/src/config/secciones.ts
@@ -1,0 +1,72 @@
+/**
+ * SECCIONES DE LA LANDING
+ *
+ * La lista de secciones, su visibilidad y su orden viven en la tabla
+ * `secciones_landing`. Lo que vive aquí es lo único que la base de datos no
+ * puede saber: qué forma tiene cada sección en la web —un ancla dentro de la
+ * landing o una página aparte— y cómo se llama su destino.
+ *
+ * Por qué el listado se repite en TypeScript teniendo el enumerado en SQL: el
+ * frontend tiene un componente por sección, así que la lista es también un
+ * contrato de compilación. Gracias a él, `t("navegacion.secciones.programa")`
+ * falla en `typecheck` si a alguien se le olvida el rótulo, en vez de reventar
+ * en runtime delante de un invitado.
+ *
+ * `tests/unidad/secciones.test.ts` compara esta lista con el SQL de las
+ * migraciones: si divergen, el CI se pone rojo. Es el fallo que provocó esta
+ * pantalla —la landing pintaba el programa y la playlist, y el enumerado no
+ * las conocía, así que no había forma de enseñarlas en el menú ni de apagarlas.
+ */
+
+/**
+ * Todos los valores del enumerado `public.seccion_landing`, en el mismo orden
+ * en que se declararon.
+ */
+export const SECCIONES = [
+  "portada",
+  "reserva_la_fecha",
+  "cuenta_atras",
+  "historia",
+  "galeria",
+  "programa",
+  "ubicaciones",
+  "transporte",
+  "alojamiento",
+  "regalos",
+  "preguntas_frecuentes",
+  "playlist",
+  "rsvp",
+] as const;
+
+export type Seccion = (typeof SECCIONES)[number];
+
+/**
+ * Secciones que no son un trozo de la landing sino una página propia. Su fila
+ * en `secciones_landing` decide si la ruta existe o devuelve 404, pero no
+ * aparecen en el menú: quien está leyendo la web ya no necesita que le
+ * recuerden la fecha.
+ */
+const RUTAS_PROPIAS = {
+  reserva_la_fecha: "/reserva-la-fecha",
+} as const satisfies Partial<Record<Seccion, string>>;
+
+export type SeccionConRuta = keyof typeof RUTAS_PROPIAS;
+
+/** El identificador del elemento en el documento, y el destino de su enlace. */
+export function anclaDe(seccion: Seccion): string {
+  return seccion.replaceAll("_", "-");
+}
+
+/** `true` si la sección se recorre haciendo scroll dentro de la landing. */
+export function esAncla(seccion: Seccion): boolean {
+  return !(seccion in RUTAS_PROPIAS);
+}
+
+export function rutaDe(seccion: SeccionConRuta): string {
+  return RUTAS_PROPIAS[seccion];
+}
+
+/** Convierte lo que devuelve la base de datos en un valor que sabemos pintar. */
+export function esSeccionConocida(valor: string): valor is Seccion {
+  return (SECCIONES as readonly string[]).includes(valor);
+}

--- a/src/lib/bbdd/landing.ts
+++ b/src/lib/bbdd/landing.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { esSeccionConocida, type Seccion } from "@/config/secciones";
+
 import { leerComoAnonimo } from "./cliente";
 
 /**
@@ -69,6 +71,43 @@ export interface Cancion {
 }
 
 /**
+ * Secciones que la web debe enseñar, en el orden en que van.
+ *
+ * Se lee de `v_secciones_publicas`, que ya filtra por `visible` y ordena por
+ * `orden`. Además la política RLS de la tabla base es `using (visible)`, así
+ * que a `anon` no le llega una sección apagada ni saltándose la vista: el
+ * frontend no filtra nada porque no le hace falta.
+ *
+ * Si la consulta falla devuelve lista vacía y quien llama decide qué enseñar;
+ * nunca se inventa un orden por defecto.
+ *
+ * Un valor que el frontend no sepa pintar se descarta con un aviso en el log,
+ * en lugar de tumbar la página: la base de datos puede ir por delante de un
+ * despliegue.
+ */
+export async function obtenerSecciones(): Promise<Seccion[]> {
+  const filas = await leerComoAnonimo(
+    (tx) => tx<{ seccion: string }[]>`
+      select seccion
+      from public.v_secciones_publicas
+    `,
+  );
+
+  const conocidas: Seccion[] = [];
+  for (const fila of filas ?? []) {
+    if (esSeccionConocida(fila.seccion)) {
+      conocidas.push(fila.seccion);
+    } else {
+      console.warn(
+        `Sección desconocida en secciones_landing: "${fila.seccion}". Se omite; ` +
+          "probablemente la base de datos va por delante del despliegue.",
+      );
+    }
+  }
+  return conocidas;
+}
+
+/**
  * Configuración de la boda. Devuelve `null` si todavía no se ha configurado,
  * para que la landing pueda decirlo en lugar de romperse.
  */
@@ -93,7 +132,7 @@ export async function obtenerConfiguracion(): Promise<ConfiguracionBoda | null> 
         nombre_novia, nombre_novio, fecha_hora_ceremonia, fecha_limite_rsvp,
         lugar_ceremonia, direccion_ceremonia, lugar_banquete,
         latitud_ceremonia, longitud_ceremonia, correo_contacto, hashtag
-      from public.configuracion_boda
+      from public.v_configuracion_publica
       limit 1
     `,
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,6 +50,7 @@
   --color-superficie-hundida: var(--superficie-hundida);
   --color-superficie-tenue: var(--superficie-tenue);
   --color-superficie-inversa: var(--superficie-inversa);
+  --color-superficie-cabecera: var(--superficie-cabecera);
 
   /* Texto */
   --color-tinta: var(--tinta);
@@ -136,6 +137,9 @@
   --spacing-campo: var(--alto-campo);
   --spacing-cifra: var(--ancho-cifra);
 
+  /* Un solo token da `h-cabecera`, `pt-cabecera` y `scroll-mt-cabecera`. */
+  --spacing-cabecera: var(--alto-cabecera);
+
   /* Forma */
   --radius-boton: var(--radio-boton);
   --radius-campo: var(--radio-campo);
@@ -180,6 +184,39 @@
   grid-template-columns: auto minmax(0, 1fr);
 }
 
+/**
+ * Tailwind v4 no tiene familia de utilidades para `z-index`, así que los siete
+ * tokens `--capa-*` no llegan solos al sistema de clases. Se expone la única
+ * capa que usa la web pública. `z-[60]` está prohibido por ESLint, y con razón:
+ * es el número mágico que acaba compitiendo con otro número mágico.
+ */
+@utility capa-cabecera {
+  z-index: var(--capa-cabecera);
+}
+
+/**
+ * Superficie translúcida con desenfoque por detrás. Se escribe aquí y no como
+ * `backdrop-blur-*` porque esas clases traen la escala por defecto de Tailwind,
+ * que es hardcode entrando por la puerta de atrás.
+ */
+@utility velada {
+  backdrop-filter: blur(var(--desenfoque-cabecera));
+  background-color: var(--superficie-cabecera);
+}
+
+/**
+ * Subrayado que señala la sección en la que está el invitado. El grosor sale
+ * del token; el color lo pone quien la usa, según esté activa o no.
+ *
+ * No se escribe `border-b-2`: las utilidades de grosor de borde de Tailwind
+ * traen sus píxeles de fábrica y no pasan por la capa de primitivos, así que
+ * son hardcode con otra cara.
+ */
+@utility marca-activa {
+  border-bottom-style: solid;
+  border-bottom-width: var(--grosor-marca-activa);
+}
+
 /* --------------------------------------------------------------------------
  * Base
  * ----------------------------------------------------------------------- */
@@ -192,6 +229,18 @@
   html {
     scroll-behavior: smooth;
     -webkit-text-size-adjust: 100%;
+  }
+
+  /**
+   * Con una barra fija arriba, saltar a `#programa` deja el título justo
+   * debajo de ella. El mismo token que da su alto reserva aquí el hueco, así
+   * que no hay dos números que mantener sincronizados.
+   *
+   * Va en `section[id]` y no en `[id]` a secas para no repartir margen de
+   * scroll por cada elemento identificado del documento.
+   */
+  section[id] {
+    scroll-margin-top: var(--alto-cabecera);
   }
 
   body {

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -82,6 +82,19 @@
   --color-velo-medio: rgb(20 20 15 / 55%);
   --color-velo-fuerte: rgb(20 20 15 / 72%);
 
+  /**
+   * Los dos tonos de fondo de la paleta, translúcidos. Son para superficies
+   * que se apoyan sobre el contenido y dejan intuir lo que pasa por debajo,
+   * como una barra fija sobre una portada a pantalla completa. El alfa es alto
+   * a propósito: por debajo, el texto encima deja de cumplir contraste.
+   *
+   * Mismos valores que `--color-crema-50` y `--color-oliva-950`, que son los
+   * dos fondos de página. Van escritos porque `rgb(from …)` todavía no llega a
+   * todos los navegadores que abre un invitado desde WhatsApp.
+   */
+  --color-velado-crema: rgb(251 250 248 / 86%);
+  --color-velado-oliva: rgb(20 23 15 / 86%);
+
   /* ---------------------------------------------------------------------
    * Tipografía — Cormorant Garamond para titulares, Jost para cuerpo
    * ------------------------------------------------------------------- */
@@ -143,6 +156,14 @@
   /* Ancho mínimo de una cifra grande, para que la cuenta atrás no baile. */
   --size-cifra: 5.5rem;
 
+  /**
+   * Alto de la barra de navegación. Sale una vez de aquí y sirve para tres
+   * cosas a la vez: el alto de la barra, el hueco que deja bajo ella y el
+   * `scroll-margin-top` de las secciones, para que un salto no deje el título
+   * escondido detrás.
+   */
+  --size-cabecera: 4.25rem;
+
   /* ---------------------------------------------------------------------
    * Forma
    * ------------------------------------------------------------------- */
@@ -158,6 +179,8 @@
   --shadow-2: 0 18px 44px -24px rgb(20 20 15 / 32%);
   --shadow-3: 0 24px 60px -34px rgb(20 20 15 / 45%);
   --shadow-4: 0 40px 90px -30px rgb(20 20 15 / 55%);
+  --blur-1: 6px;
+  --blur-2: 12px;
 
   /* ---------------------------------------------------------------------
    * Movimiento — las animaciones también son tokens

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -24,6 +24,12 @@
   --superficie-tenue: var(--color-oliva-100);
   --superficie-inversa: var(--color-carbon-950);
 
+  /**
+   * Fondo de la barra de navegación. Translúcido porque se apoya sobre la
+   * portada a pantalla completa: opaco, cortaría la foto con una franja.
+   */
+  --superficie-cabecera: var(--color-velado-crema);
+
   /* --- Texto --------------------------------------------------------- */
   --tinta: var(--color-carbon-900);
   --tinta-suave: var(--color-carbon-600);
@@ -112,6 +118,7 @@
   --alto-control-compacto: var(--size-control-compacto);
   --alto-campo: var(--size-campo);
   --ancho-cifra: var(--size-cifra);
+  --alto-cabecera: var(--size-cabecera);
 
   /* --- Forma --------------------------------------------------------- */
   --radio-boton: var(--radius-redondo);
@@ -124,6 +131,8 @@
   --sombra-tarjeta: var(--shadow-2);
   --sombra-elevada: var(--shadow-3);
   --sombra-modal: var(--shadow-4);
+  --desenfoque-cabecera: var(--blur-2);
+  --grosor-marca-activa: var(--border-width-2);
 
   /* --- Movimiento semántico ------------------------------------------ */
   --transicion-color: var(--duration-fast) var(--ease-salida);
@@ -165,6 +174,7 @@
     --superficie-hundida: var(--color-oliva-975);
     --superficie-tenue: var(--color-oliva-750);
     --superficie-inversa: var(--color-crema-50);
+    --superficie-cabecera: var(--color-velado-oliva);
     --tinta: var(--color-crema-150);
     --tinta-suave: var(--color-oliva-200);
     --tinta-tenue: var(--color-oliva-450);
@@ -204,6 +214,7 @@
   --superficie-hundida: var(--color-oliva-975);
   --superficie-tenue: var(--color-oliva-750);
   --superficie-inversa: var(--color-crema-50);
+  --superficie-cabecera: var(--color-velado-oliva);
   --tinta: var(--color-crema-150);
   --tinta-suave: var(--color-oliva-200);
   --tinta-tenue: var(--color-oliva-450);

--- a/supabase/migrations/20260809100000_secciones_faltantes_enum.sql
+++ b/supabase/migrations/20260809100000_secciones_faltantes_enum.sql
@@ -1,0 +1,20 @@
+-- BODA-20 · Las dos secciones que la landing pinta y el enumerado no conocía
+--
+-- `secciones_landing` es la lista de la que sale la navegación: qué secciones
+-- se enseñan y en qué orden. Al cablearla se vio que faltaban dos de las que la
+-- landing ya pinta —el programa del día y la playlist—, así que ninguna de las
+-- dos podía aparecer en el menú ni apagarse desde el panel.
+--
+-- POR QUÉ ESTE FICHERO SOLO TOCA EL ENUMERADO
+--
+-- PostgreSQL no deja usar un valor nuevo de un enumerado dentro de la misma
+-- transacción que lo añade. Las filas van en la migración siguiente, que corre
+-- en su propia transacción: así el par funciona igual lo aplique `psql` en
+-- autocommit o el CLI de Supabase envolviendo cada fichero.
+--
+-- `asegurar_enum` no sirve aquí: sale sin hacer nada si el tipo ya existe, que
+-- es justo el caso.
+
+alter type public.seccion_landing add value if not exists 'programa' after 'galeria';
+
+alter type public.seccion_landing add value if not exists 'playlist' after 'preguntas_frecuentes';

--- a/supabase/migrations/20260809100100_secciones_faltantes_filas.sql
+++ b/supabase/migrations/20260809100100_secciones_faltantes_filas.sql
@@ -1,0 +1,20 @@
+-- BODA-20 · Alta de las secciones `programa` y `playlist`
+--
+-- Segunda mitad de la migración anterior: allí se añadieron los valores al
+-- enumerado, aquí se usan. Van en ficheros distintos porque PostgreSQL no
+-- permite usar un valor de enumerado en la misma transacción que lo crea.
+--
+-- Los huecos de `orden` estaban pensados para esto: se intercalan sin tocar el
+-- orden de ninguna de las secciones que ya existían, así que la restricción de
+-- unicidad no llega ni a rozarse.
+--
+--   … galeria 30 · [programa 35] · ubicaciones 40 …
+--   … preguntas_frecuentes 70 · [playlist 75] · rsvp 80 …
+--
+-- Visibles desde el primer momento: son secciones que la web ya está pintando,
+-- no funcionalidad nueva a la espera de que alguien la encienda.
+
+insert into public.secciones_landing (seccion, visible, orden) values
+  ('programa', true, 35),
+  ('playlist', true, 75)
+on conflict (seccion) do nothing;

--- a/supabase/migrations/rollback/20260809100000_secciones_faltantes_enum.sql
+++ b/supabase/migrations/rollback/20260809100000_secciones_faltantes_enum.sql
@@ -1,0 +1,21 @@
+-- Rollback de 20260809100000_secciones_faltantes_enum.sql
+--
+-- NO SE PUEDE DESHACER, y conviene decirlo en voz alta en lugar de dejar un
+-- fichero vacío que aparente lo contrario: PostgreSQL no permite quitar un
+-- valor de un enumerado. `ALTER TYPE ... DROP VALUE` no existe.
+--
+-- Deshacerlo de verdad exige recrear el tipo entero y reescribir todas las
+-- columnas que lo usan, con la tabla bloqueada:
+--
+--   alter table public.secciones_landing alter column seccion type text;
+--   drop type public.seccion_landing;
+--   select public.asegurar_enum('seccion_landing', array[...sin los dos...]);
+--   alter table public.secciones_landing
+--     alter column seccion type public.seccion_landing
+--     using seccion::public.seccion_landing;
+--
+-- No merece la pena. Dos valores de más en un enumerado no molestan a nadie:
+-- lo que decide qué se enseña es la columna `visible` de `secciones_landing`.
+-- Para retirar las secciones, aplicad el rollback de la migración de filas.
+
+-- Sin operación: leed el comentario de arriba.

--- a/supabase/migrations/rollback/20260809100100_secciones_faltantes_filas.sql
+++ b/supabase/migrations/rollback/20260809100100_secciones_faltantes_filas.sql
@@ -1,0 +1,10 @@
+-- Rollback de 20260809100100_secciones_faltantes_filas.sql
+--
+-- Retira el programa del día y la playlist de la lista de secciones. La
+-- navegación deja de ofrecerlas y la landing deja de pintarlas.
+--
+-- No borra ningún contenido: los hitos de `hitos_programa` y las canciones de
+-- `canciones_sugeridas` siguen donde estaban. Volver a insertar las dos filas
+-- las devuelve a la web tal como estaban.
+
+delete from public.secciones_landing where seccion in ('programa', 'playlist');

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -46,7 +46,7 @@ test.describe("Landing", () => {
   });
 
   test("las preguntas frecuentes se abren y cierran con teclado", async ({ page }) => {
-    const primera = page.locator("#preguntas details").first();
+    const primera = page.locator("#preguntas-frecuentes details").first();
     await expect(primera).not.toHaveAttribute("open", "");
 
     await primera.locator("summary").focus();

--- a/tests/e2e/navegacion.spec.ts
+++ b/tests/e2e/navegacion.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import copy from "../../content/copy.es.json";
+
+/**
+ * BODA-20 · Navegación y pie
+ *
+ * Lo que se prueba aquí no es que el menú se vea, sino que **sale de la base de
+ * datos**: `secciones_landing` decide qué secciones hay y en qué orden, y la
+ * política RLS de esa tabla (`using (visible)`) hace que a un invitado ni
+ * siquiera le lleguen las apagadas.
+ *
+ * Los dos casos de error son los que de verdad importan y los que fallarían si
+ * alguien escribiera el menú a mano:
+ *
+ *  1. Una sección APAGADA en la base de datos no puede aparecer (`regalos`).
+ *  2. Una sección ENCENDIDA pero todavía sin construir tampoco (`galeria` y
+ *     `ubicaciones`, que son BODA-25 y BODA-26). Un menú que ofrece un enlace
+ *     a una sección que no existe es peor que no tener menú.
+ */
+
+const menu = (page: Page) =>
+  page.getByRole("navigation", { name: copy.navegacion.etiquetaPrincipal });
+
+test.describe("Navegación", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("el menú lista las secciones que la base de datos da por visibles", async ({ page }) => {
+    const enlaces = menu(page).getByRole("link");
+
+    await expect(enlaces.filter({ hasText: copy.navegacion.secciones.portada })).toHaveCount(1);
+    await expect(enlaces.filter({ hasText: copy.navegacion.secciones.programa })).toHaveCount(
+      1,
+    );
+    await expect(enlaces.filter({ hasText: copy.navegacion.secciones.rsvp })).toHaveCount(1);
+  });
+
+  test("el orden del menú es el que manda la base de datos", async ({ page }) => {
+    // `orden` en la tabla: portada 0 · cuenta_atras 10 · historia 20 ·
+    // programa 35 · transporte 50 · alojamiento 60 · preguntas 70 ·
+    // playlist 75 · rsvp 80. Si alguien reordena el JSX, esto se cae.
+    // `allTextContents` y no `allInnerTexts`: el segundo devuelve el texto ya
+    // pasado por el `text-transform: uppercase` del CSS, así que compararía
+    // contra la presentación en vez de contra el copy.
+    const rotulos = await menu(page).getByRole("link").allTextContents();
+
+    expect(rotulos.map((rotulo) => rotulo.trim())).toEqual([
+      copy.navegacion.secciones.portada,
+      copy.navegacion.secciones.cuenta_atras,
+      copy.navegacion.secciones.historia,
+      copy.navegacion.secciones.programa,
+      copy.navegacion.secciones.transporte,
+      copy.navegacion.secciones.alojamiento,
+      copy.navegacion.secciones.preguntas_frecuentes,
+      copy.navegacion.secciones.playlist,
+      copy.navegacion.secciones.rsvp,
+    ]);
+  });
+
+  test("pulsar un enlace del menú lleva a su sección", async ({ page }) => {
+    await menu(page).getByRole("link", { name: copy.navegacion.secciones.playlist }).click();
+
+    await expect(page).toHaveURL(/#playlist$/);
+    await expect(page.locator("#playlist")).toBeInViewport();
+  });
+
+  test("la sección de destino no se queda debajo de la barra", async ({ page }) => {
+    await menu(page).getByRole("link", { name: copy.navegacion.secciones.alojamiento }).click();
+
+    // El `scroll-margin-top` tiene que dejar el título de la sección por debajo
+    // de la barra fija, no tapado por ella.
+    const barra = page.locator("header").first();
+    const seccion = page.locator("#alojamiento");
+
+    const cajaBarra = await barra.boundingBox();
+    const cajaSeccion = await seccion.boundingBox();
+
+    expect(cajaBarra).not.toBeNull();
+    expect(cajaSeccion).not.toBeNull();
+    expect(cajaSeccion!.y).toBeGreaterThanOrEqual(cajaBarra!.y + cajaBarra!.height - 1);
+  });
+
+  test("ningún enlace del menú lleva a una sección que no existe", async ({ page }) => {
+    const destinos = await menu(page)
+      .getByRole("link")
+      .evaluateAll((enlaces) =>
+        enlaces.map((enlace) => (enlace as HTMLAnchorElement).getAttribute("href") ?? ""),
+      );
+
+    expect(destinos.length).toBeGreaterThan(0);
+    for (const destino of destinos) {
+      expect(destino.startsWith("#")).toBe(true);
+      await expect(page.locator(destino)).toHaveCount(1);
+    }
+  });
+
+  test("marca la sección en la que está el invitado", async ({ page }) => {
+    await page.locator("#programa").scrollIntoViewIfNeeded();
+
+    const activo = menu(page).getByRole("link", { name: copy.navegacion.secciones.programa });
+    await expect(activo).toHaveAttribute("aria-current", "location");
+  });
+
+  // --- Casos de error -----------------------------------------------------
+
+  test("una sección apagada en la base de datos no aparece en el menú", async ({ page }) => {
+    // `regalos` está en `secciones_landing` con `visible = false`.
+    await expect(
+      menu(page).getByRole("link", { name: copy.navegacion.secciones.regalos }),
+    ).toHaveCount(0);
+    await expect(page.locator("#regalos")).toHaveCount(0);
+  });
+
+  test("una sección encendida pero sin construir tampoco aparece", async ({ page }) => {
+    // `galeria` y `ubicaciones` están visibles en la base de datos desde el
+    // primer día, y su código todavía no existe.
+    await expect(
+      menu(page).getByRole("link", { name: copy.navegacion.secciones.galeria }),
+    ).toHaveCount(0);
+    await expect(
+      menu(page).getByRole("link", { name: copy.navegacion.secciones.ubicaciones }),
+    ).toHaveCount(0);
+  });
+
+  test("la reserva de fecha es una página aparte y no se cuela en el menú", async ({
+    page,
+  }) => {
+    await expect(
+      menu(page).getByRole("link", { name: copy.navegacion.secciones.reserva_la_fecha }),
+    ).toHaveCount(0);
+  });
+});
+
+test.describe("Accesibilidad de la navegación", () => {
+  test("el primer elemento enfocable salta al contenido", async ({ page }) => {
+    await page.goto("/");
+    await page.keyboard.press("Tab");
+
+    const enfocado = page.locator(":focus");
+    await expect(enfocado).toHaveText(copy.navegacion.irAlContenido);
+    await expect(enfocado).toHaveAttribute("href", "#contenido");
+    // Oculto hasta que se enfoca, pero visible en cuanto lo está.
+    await expect(enfocado).toBeInViewport();
+  });
+
+  test("se puede recorrer el menú entero con el teclado", async ({ page }) => {
+    await page.goto("/");
+
+    const primerEnlace = menu(page).getByRole("link").first();
+    await primerEnlace.focus();
+    await expect(primerEnlace).toBeFocused();
+
+    await page.keyboard.press("Tab");
+    await expect(menu(page).getByRole("link").nth(1)).toBeFocused();
+  });
+
+  test("hay dos navegaciones y cada una se identifica", async ({ page }) => {
+    await page.goto("/");
+    await expect(menu(page)).toHaveCount(1);
+    await expect(
+      page.getByRole("navigation", { name: copy.pie.etiquetaNavegacion }),
+    ).toHaveCount(1);
+  });
+});
+
+test.describe("Pie", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("el correo de contacto sale de la base de datos", async ({ page }) => {
+    const pie = page.getByRole("contentinfo");
+    const correo = pie.getByRole("link", { name: /@/ });
+
+    await expect(correo).toBeVisible();
+    await expect(correo).toHaveAttribute("href", /^mailto:/);
+  });
+
+  test("el hashtag se pinta con el de la base de datos", async ({ page }) => {
+    await expect(page.getByRole("contentinfo").getByText(/^#/)).toBeVisible();
+  });
+
+  test("desde el pie se puede volver arriba", async ({ page }) => {
+    await page
+      .getByRole("contentinfo")
+      .getByRole("link", { name: copy.pie.volverArriba })
+      .click();
+
+    await expect(page.locator("#portada")).toBeInViewport();
+  });
+});

--- a/tests/unidad/secciones.test.ts
+++ b/tests/unidad/secciones.test.ts
@@ -1,0 +1,88 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { SECCIONES, anclaDe, esAncla, esSeccionConocida } from "@/config/secciones";
+
+/**
+ * BODA-20 · La lista de secciones de TypeScript y la de SQL no pueden divergir
+ *
+ * Este test existe por un fallo real. La landing llevaba meses pintando el
+ * programa del día y la playlist, y el enumerado `seccion_landing` no las
+ * conocía: no había forma de enseñarlas en el menú ni de apagarlas desde el
+ * panel, y nada avisaba. El fallo solo salió al cablear la navegación.
+ *
+ * Se compara contra el SQL y no contra la base de datos a propósito: así el
+ * guardián funciona sin levantar PostgreSQL, y falla en el momento exacto en
+ * que alguien añade un valor en un sitio y se olvida del otro.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+const MIGRACIONES = join(RAIZ, "supabase", "migrations");
+
+/** Todos los valores del enumerado, tal y como quedan tras las migraciones. */
+function valoresDelEnumeradoSql(): string[] {
+  const ficheros = readdirSync(MIGRACIONES)
+    .filter((nombre) => nombre.endsWith(".sql"))
+    .sort();
+
+  const valores: string[] = [];
+
+  for (const fichero of ficheros) {
+    const sql = readFileSync(join(MIGRACIONES, fichero), "utf8").replace(/--[^\n]*/g, "");
+
+    // Creación: asegurar_enum('seccion_landing', array['a', 'b', …])
+    const creacion = sql.match(
+      /asegurar_enum\(\s*'seccion_landing'\s*,\s*array\s*\[([\s\S]*?)\]/i,
+    );
+    if (creacion) {
+      for (const cita of creacion[1].matchAll(/'([^']+)'/g)) valores.push(cita[1]);
+    }
+
+    // Ampliación: alter type public.seccion_landing add value … 'x'
+    for (const alta of sql.matchAll(
+      /alter\s+type\s+public\.seccion_landing\s+add\s+value[^;]*?'([^']+)'/gi,
+    )) {
+      valores.push(alta[1]);
+    }
+  }
+
+  return valores;
+}
+
+describe("Secciones de la landing", () => {
+  const enSql = valoresDelEnumeradoSql();
+
+  it("el SQL declara secciones (si no, el test se estaría engañando solo)", () => {
+    expect(enSql.length).toBeGreaterThan(0);
+  });
+
+  it("TypeScript conoce exactamente las mismas que SQL", () => {
+    expect([...SECCIONES].sort()).toEqual([...enSql].sort());
+  });
+
+  it("ninguna sección está declarada dos veces en SQL", () => {
+    expect(new Set(enSql).size).toBe(enSql.length);
+  });
+
+  it("el ancla de cada sección es un identificador válido para una URL", () => {
+    for (const seccion of SECCIONES) {
+      expect(anclaDe(seccion)).toMatch(/^[a-z]+(-[a-z]+)*$/);
+    }
+  });
+
+  it("las anclas no se repiten entre secciones distintas", () => {
+    const anclas = SECCIONES.map(anclaDe);
+    expect(new Set(anclas).size).toBe(anclas.length);
+  });
+
+  it("la reserva de fecha es una página aparte, no un ancla de la landing", () => {
+    expect(esAncla("reserva_la_fecha")).toBe(false);
+    expect(esAncla("portada")).toBe(true);
+  });
+
+  it("un valor que no existe no se reconoce como sección", () => {
+    expect(esSeccionConocida("seccion_inventada")).toBe(false);
+    expect(esSeccionConocida("portada")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Qué cambia

Barra fija con salto a cada sección y marca de la sección actual, pie con contacto, y —lo que de verdad importa— **la landing deja de decidir qué enseña**.

Closes #20

### `secciones_landing` llevaba desde la primera migración sin que la leyera nadie

La tabla tenía su `visible` y su `orden` desde el día uno, y la página pintaba lo que tenía escrito, en el orden en que estaba escrito. Eso es la regla 3 incumplida: una tabla que existe y no está cableada. Ahora la landing la recorre, así que apagar una sección la quita de la página y del menú a la vez, sin desplegar.

Una sección se enseña si se cumplen **las dos** cosas: que la base de datos la dé por visible **y** que haya contenido que pintar. La segunda condición sale de un problema real que apareció al cablearlo: `galeria` y `ubicaciones` llevan encendidas desde el primer día y su código todavía no existe (#25 y #26). Sin ese filtro, el menú ofrecería dos enlaces que no llevan a ninguna parte.

### Dos secciones que la landing pintaba y el enumerado no conocía

El programa del día y la playlist no figuraban en `seccion_landing`, así que no había forma de enseñarlas en el menú ni de apagarlas desde el panel, y nada avisaba. Entran por migración, **en dos ficheros** porque PostgreSQL no deja usar un valor de enumerado en la misma transacción que lo crea — así el par funciona igual lo aplique `psql` en autocommit o el CLI de Supabase envolviendo cada fichero.

El rollback del enumerado dice en voz alta que **no se puede deshacer** (`ALTER TYPE ... DROP VALUE` no existe) en lugar de ser un fichero vacío que aparente lo contrario.

`tests/unidad/secciones.test.ts` compara la lista de TypeScript con el SQL de las migraciones. Es el guardián de la causa raíz: si vuelven a separarse, el CI se pone rojo sin necesidad de levantar PostgreSQL.

### Tokens nuevos, ningún valor suelto

| Capa | Qué entra |
| --- | --- |
| Primitivos | `--size-cabecera`, `--color-velado-crema`, `--color-velado-oliva`, `--blur-1`, `--blur-2` |
| Semánticos | `--alto-cabecera`, `--superficie-cabecera` (reasignado en los dos bloques de tema oscuro), `--desenfoque-cabecera`, `--grosor-marca-activa` |
| Tailwind | `--spacing-cabecera` y `--color-superficie-cabecera` |
| `@utility` | `capa-cabecera`, `velada`, `marca-activa` |

Los tres `@utility` existen porque Tailwind v4 no tiene familia de `z-index`, y sus clases `backdrop-blur-*` y `border-b-2` traen píxeles de fábrica que no pasan por la capa de primitivos: hardcode entrando por la puerta de atrás.

El mismo token del alto sirve para tres cosas —el alto de la barra, el hueco que deja y el `scroll-margin-top` de las secciones—, así que no hay dos números que mantener sincronizados. Comprobado en el navegador: `#fbfaf8db` en claro y `#14170fdb` en oscuro, desenfoque 12px, capa 60, todo resuelto desde tokens.

### En móvil no hay hamburguesa

Es deliberado: un desplegable son dos toques, un panel que atrapa el foco, una trampa de scroll y un montón de ARIA que se rompe en cuanto alguien mueve el diseño. Una tira que se desplaza en horizontal enseña las secciones de golpe y la activa se centra sola.

La marca se esconde por debajo de `sm` porque **dos nombres largos dejaban el menú en «INICIO CUE…»** — lo vi en la captura, no lo supuse.

### Un fallo de mi propio código que la revisión pilló a tiempo

`IntersectionObserver` no acepta `calc()` ni `var()` en `rootMargin`, solo píxeles y porcentajes. La primera versión leía el token ahí. Ahora se mide el alto real del elemento, que además aguanta cualquier cambio futuro del token.

## Cómo probarlo en el preview

1. Bajar por la landing: la sección del menú se va marcando sola.
2. Pulsar «Alojamiento»: el título queda **debajo** de la barra, no tapado por ella.
3. En móvil, la tira se desplaza y centra la sección actual.
4. `Tab` desde el principio: el primer elemento enfocable es «Ir al contenido».
5. **El menú no ofrece «Galería», «Dónde» ni «Regalo»**, que es lo que se está probando: los dos primeros están encendidos en la BBDD pero sin construir, y el tercero está apagado.
6. Tema oscuro: la barra se vuelve oliva translúcida sin que ningún componente cambie de clase.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados — el menú entero sale de `v_secciones_publicas`
- [x] Cero hardcode
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error — 16 tests nuevos, tres de ellos casos de error
- [ ] CI verde entero
- [x] Responsive en móvil, tablet y escritorio — suite completa pasada también a 393×852
- [x] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion` — enlace de salto, `aria-current="location"`, dos `<nav>` etiquetados, `scrollIntoView` respeta el ajuste del sistema
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

**Verificado en local antes de subir:** 21 unitarios · 36 comprobaciones de seguridad de BBDD · 40 E2E en escritorio · 40 E2E a viewport de iPhone. WebKit no se puede descargar en este entorno, así que el móvil real lo cubre el CI.

## Base de datos

- [x] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

Probado aplicando las migraciones desde cero contra un PostgreSQL limpio, y el rollback de las filas ida y vuelta.

## Documentación

- [x] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR

Describía un esquema que no existe. Corregido lo que este cambio invalida: los flags `mostrar_*` (que nunca llegaron a existir; son `secciones_landing`), `wedding_settings` → `configuracion_boda`, `media` → `medios`, el hook `useCopy()` que en realidad es `t()`, Motion + Lenis que acabaron siendo CSS puro, y la ruta `/save-the-date` → `/reserva-la-fecha`, que estaba en inglés contra la regla 2.

**Queda pendiente** el resto del §5: describe treinta tablas con nombres en inglés (`guest_groups`, `budget_items`, `vendor_categories`…) que en la base real están en castellano. No entra aquí para no mezclar un cambio de código con una reescritura de documentación; abro ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_