### PR TITLE
feat(BODA-30): página de reserva de fecha

### DIFF
--- a/src/app/reserva-la-fecha/page.tsx
+++ b/src/app/reserva-la-fecha/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { BotonEnlace } from "@/components/ui/boton";
+import { Cuerpo, Etiqueta, Titulo2, Titulo3 } from "@/components/ui/tipografia";
+import { IDIOMA, ZONA_HORARIA } from "@/config/constants";
+import { obtenerConfiguracion, obtenerSecciones } from "@/lib/bbdd/landing";
+import { t } from "@/lib/copy";
+
+/**
+ * RESERVA LA FECHA
+ *
+ * Lo primero que se manda a los invitados, meses antes de la invitación. Se
+ * abre casi siempre desde WhatsApp, en móvil, y se mira dos segundos: tiene que
+ * decir quién, cuándo y dónde sin que nadie haga scroll.
+ *
+ * NO SE CACHEA, y es lo contrario que la landing. Su existencia depende de una
+ * fila de `secciones_landing`, así que revalidar cada hora significaría que
+ * apagarla desde el panel tarda una hora en surtir efecto —o, peor, que se
+ * sigue enseñando una página que ya se quiso retirar—. Es una consulta a dos
+ * tablas de once y una filas: sale más barato preguntar que explicar por qué
+ * el interruptor no hace nada.
+ */
+export const dynamic = "force-dynamic";
+
+const formatoFechaLarga = new Intl.DateTimeFormat(IDIOMA, {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+  timeZone: ZONA_HORARIA,
+});
+
+export async function generateMetadata(): Promise<Metadata> {
+  const configuracion = await obtenerConfiguracion();
+  if (!configuracion) return {};
+
+  const nombres = `${configuracion.nombreNovia} ${t("portada.conjuncion")} ${configuracion.nombreNovio}`;
+  const fecha = formatoFechaLarga.format(configuracion.fechaCeremonia);
+  const lugar = configuracion.lugarCeremonia ?? configuracion.lugarBanquete;
+
+  return {
+    title: `${nombres} · ${t("saveTheDate.etiqueta")}`,
+    description: lugar ? `${fecha} · ${lugar}` : fecha,
+  };
+}
+
+export default async function PaginaReservaLaFecha() {
+  const [secciones, configuracion] = await Promise.all([
+    obtenerSecciones(),
+    obtenerConfiguracion(),
+  ]);
+
+  // La página existe sólo si su fila está visible. Apagada, 404: mejor que una
+  // página a medias, y mejor que dejarla en pie cuando ya se ha querido
+  // retirar. `obtenerSecciones` sólo devuelve las visibles, porque la política
+  // RLS de la tabla ya filtra por `visible`.
+  if (!secciones.includes("reserva_la_fecha")) notFound();
+
+  // Sin configuración no hay nada que reservar. Se dice, no se finge.
+  if (!configuracion) {
+    return (
+      <main className="mx-auto grid min-h-dvh max-w-texto place-items-center px-interno text-center">
+        <div>
+          <Titulo2 como="h1">{t("portada.enPreparacion")}</Titulo2>
+          <Cuerpo className="mt-pila">{t("portada.enPreparacionTexto")}</Cuerpo>
+        </div>
+      </main>
+    );
+  }
+
+  const lugar = configuracion.lugarCeremonia ?? configuracion.lugarBanquete;
+
+  // El relleno vertical es corto a propósito: la página ya ocupa la pantalla
+  // entera y centra su contenido, así que `py-seccion-compacta` solo servía
+  // para empujar el bloque fuera de la ventana en pantallas bajas. El criterio
+  // de este ticket es que quepa sin hacer scroll, no el ritmo de la landing.
+  return (
+    <main
+      data-seccion="inversa"
+      className="grid min-h-dvh place-items-center px-interno py-pila text-center"
+    >
+      <div className="mx-auto w-full max-w-estrecho">
+        <Etiqueta>{t("saveTheDate.etiqueta")}</Etiqueta>
+
+        {/* Un solo h1 con los dos nombres: es el título de la página, y para un
+            lector de pantalla partirlo en dos encabezados no significa nada. */}
+        <h1 className="mt-pila font-titulo text-display leading-display tracking-display">
+          {configuracion.nombreNovia}
+          <span className="block text-titulo-1 italic text-marca">
+            {t("portada.conjuncion")}
+          </span>
+          {configuracion.nombreNovio}
+        </h1>
+
+        <hr className="mx-auto my-pila w-full border-t border-borde-fuerte" />
+
+        <p className="font-titulo text-titulo-2">
+          <time dateTime={configuracion.fechaCeremonia.toISOString()}>
+            {formatoFechaLarga.format(configuracion.fechaCeremonia)}
+          </time>
+        </p>
+        {lugar ? (
+          <Titulo3 como="p" className="mt-linea text-tinta-suave">
+            {lugar}
+          </Titulo3>
+        ) : null}
+
+        <p className="mx-auto mt-pila max-w-texto text-pequeno text-tinta-suave">
+          {t("saveTheDate.nota")}
+        </p>
+
+        <div className="mt-elemento">
+          <BotonEnlace href="/">{t("saveTheDate.verLaWeb")}</BotonEnlace>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -267,6 +267,16 @@
   --tinta-marca: var(--color-oliva-350);
   --marca: var(--color-oliva-350);
   --marca-hover: var(--color-oliva-200);
+
+  /**
+   * El acento se invierte, por la misma razón que en el tema oscuro: sobre
+   * fondo oliva, un botón oliva no se ve. Faltaba, y el resultado era un botón
+   * primario invisible dentro de cualquier bloque inverso.
+   */
+  --acento: var(--color-crema-200);
+  --acento-hover: var(--color-crema-50);
+  --acento-tenue: var(--color-oliva-800);
+  --tinta-sobre-acento: var(--color-oliva-875);
   --borde: var(--color-oliva-600);
   --borde-fuerte: var(--color-oliva-500);
   --borde-tenue: var(--color-oliva-750);
@@ -281,6 +291,10 @@
   --tinta-tenue: var(--color-oliva-450);
   --tinta-marca: var(--color-oliva-350);
   --marca: var(--color-oliva-350);
+  --acento: var(--color-crema-200);
+  --acento-hover: var(--color-crema-50);
+  --acento-tenue: var(--color-oliva-800);
+  --tinta-sobre-acento: var(--color-carbon-900);
   --borde: var(--color-oliva-800);
   --foco: var(--color-oliva-350);
 }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -102,6 +102,15 @@ update public.configuracion_privada set
   telefono_contacto    = '+34 600 000 000',
   notas_privadas       = '(DES) Fila de desarrollo. No son cifras reales.';
 
+-- La reserva de fecha nace apagada en la migración base, que es lo correcto en
+-- producción: no se publica hasta que los novios lo deciden. En desarrollo se
+-- enciende, porque el entorno tiene que parecerse a una web ya publicada y
+-- porque si no, no hay forma de probar la página.
+--
+-- `regalos` se queda apagada a propósito: hace de sección de control para
+-- comprobar que una sección invisible no se cuela en la navegación.
+update public.secciones_landing set visible = true where seccion = 'reserva_la_fecha';
+
 
 -- ----------------------------------------------------------------------------
 -- 2. Invitados

--- a/tests/e2e/reserva-la-fecha.spec.ts
+++ b/tests/e2e/reserva-la-fecha.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "@playwright/test";
+import postgres from "postgres";
+
+import copy from "../../content/copy.es.json";
+
+/**
+ * BODA-30 · Reserva la fecha
+ *
+ * Lo primero que se manda a los invitados. Se comprueba lo mismo de siempre —
+ * que los datos salen de la base y no de un literal— y una cosa más que este
+ * ticket sí exige: que la página **deje de existir** si se apaga su fila de
+ * `secciones_landing`.
+ *
+ * Ese caso de error se prueba de verdad, apagando el interruptor contra la
+ * base real y comprobando el 404. Un test que solo mirara el copy no probaría
+ * nada: la página seguiría en pie con la sección apagada y el test pasaría.
+ */
+
+const SECCION = "reserva_la_fecha";
+const RUTA = "/reserva-la-fecha";
+
+/**
+ * TODO EL FICHERO EN SERIE, y no solo el bloque que toca la base de datos.
+ *
+ * `fullyParallel` reparte los tests de un mismo fichero entre workers, así que
+ * marcar en serie solo el bloque de abajo no impide que apague la sección
+ * mientras otro worker está probando la página encendida. Pasó: los tests del
+ * camino feliz empezaron a recibir 404. En CI no se habría visto —allí hay un
+ * único worker— y habría sido un test que falla el día que alguien sube el
+ * paralelismo.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("Reserva la fecha", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(RUTA);
+  });
+
+  test("responde y muestra los nombres de la base de datos", async ({ page }) => {
+    const titulo = page.getByRole("heading", { level: 1 });
+    await expect(titulo).toBeVisible();
+    // El prefijo (DES) solo existe en el seed: si se ve, viene de la base.
+    await expect(titulo).toContainText("(DES)");
+  });
+
+  test("muestra la fecha y el lugar de la base de datos", async ({ page }) => {
+    const fecha = page.locator("time");
+    await expect(fecha).toBeVisible();
+    // `datetime` en ISO: es lo que leen los lectores de pantalla y lo que
+    // usará el `.ics` de BODA-31.
+    await expect(fecha).toHaveAttribute("datetime", /^\d{4}-\d{2}-\d{2}T/);
+
+    await expect(page.getByText(/\(DES\).*[Ff]inca/).first()).toBeVisible();
+  });
+
+  test("cabe en una pantalla de móvil sin desplazarse", async ({ page }) => {
+    const desbordamiento = await page.evaluate(() => ({
+      alto: document.documentElement.scrollHeight,
+      ventana: window.innerHeight,
+      anchoDocumento: document.documentElement.scrollWidth,
+      anchoVentana: window.innerWidth,
+    }));
+
+    // Un píxel de margen por el redondeo de los navegadores.
+    expect(desbordamiento.alto).toBeLessThanOrEqual(desbordamiento.ventana + 1);
+    // Y nunca scroll horizontal, ni en el móvil más estrecho.
+    expect(desbordamiento.anchoDocumento).toBeLessThanOrEqual(desbordamiento.anchoVentana + 1);
+  });
+
+  test("desde aquí se llega a la web completa", async ({ page }) => {
+    await page.getByRole("link", { name: copy.saveTheDate.verLaWeb }).click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.locator("#portada")).toBeVisible();
+  });
+
+  test("las meta tags llevan los datos reales, no un texto de plantilla", async ({ page }) => {
+    await expect(page).toHaveTitle(/\(DES\)/);
+
+    const descripcion = page.locator('meta[name="description"]');
+    await expect(descripcion).toHaveAttribute("content", /\(DES\)/);
+  });
+
+  test("no se ofrece nada que todavía no exista", async ({ page }) => {
+    // El `.ics` es BODA-31. Hasta entonces no puede haber un botón que no haga
+    // nada: la regla 3 prohíbe entregar botones sin acción.
+    await expect(
+      page.getByRole("link", { name: copy.saveTheDate.anadirCalendario }),
+    ).toHaveCount(0);
+  });
+});
+
+/**
+ * Caso de error: apagar la sección tiene que retirar la página.
+ *
+ * Se toca la base de datos, así que va en serie y se restaura pase lo que
+ * pase. La fila sólo la lee esta ruta —`reserva_la_fecha` no se pinta en la
+ * landing, es una página aparte—, de modo que no puede interferir con el resto
+ * de la suite.
+ */
+test.describe("Reserva la fecha apagada", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const cadena = process.env.DATABASE_URL;
+
+  test.skip(!cadena, "Hace falta DATABASE_URL para apagar la sección.");
+
+  async function fijarVisible(visible: boolean) {
+    const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
+    try {
+      await sql`
+        update public.secciones_landing
+        set visible = ${visible}
+        where seccion = ${SECCION}
+      `;
+    } finally {
+      await sql.end();
+    }
+  }
+
+  test.afterAll(async () => {
+    if (cadena) await fijarVisible(true);
+  });
+
+  test("con la sección desactivada la ruta devuelve 404", async ({ page }) => {
+    await fijarVisible(false);
+
+    const respuesta = await page.goto(RUTA);
+    expect(respuesta?.status()).toBe(404);
+
+    // Y no se filtra ni un dato por el camino.
+    await expect(page.locator("body")).not.toContainText("(DES)");
+  });
+
+  test("volver a encenderla la devuelve", async ({ page }) => {
+    await fijarVisible(true);
+
+    const respuesta = await page.goto(RUTA);
+    expect(respuesta?.status()).toBe(200);
+    await expect(page.getByRole("heading", { level: 1 })).toContainText("(DES)");
+  });
+});

--- a/tests/e2e/tokens.spec.ts
+++ b/tests/e2e/tokens.spec.ts
@@ -218,4 +218,52 @@ test.describe("Bloques inversos", () => {
     // AA para texto normal exige 4.5:1.
     expect(ratio).toBeGreaterThanOrEqual(4.5);
   });
+
+  /**
+   * Este test existe por un fallo real. El bloque inverso reasignaba `--marca`
+   * y las tintas, pero se dejó `--acento` sin tocar: un botón primario dentro
+   * salía oliva sobre oliva, prácticamente invisible, y el test de contraste
+   * de arriba no lo veía porque solo mira el texto del contenedor.
+   *
+   * Se comprueba el botón contra su PROPIO fondo, que es lo que ve quien mira.
+   */
+  test("el botón primario se ve dentro de un bloque inverso", async ({ page }) => {
+    await page.goto("/cocina");
+
+    const medida = await page.evaluate(() => {
+      const bloque = document.querySelector('[data-prueba="bloque-inverso"]')!;
+      const boton = bloque.querySelector("button") as HTMLElement;
+      const estiloBoton = getComputedStyle(boton);
+      const estiloBloque = getComputedStyle(bloque as HTMLElement);
+
+      const luminancia = (color: string) => {
+        const [r, g, b] = color
+          .match(/\d+(\.\d+)?/g)!
+          .slice(0, 3)
+          .map(Number);
+        const canal = (v: number) => {
+          const s = v / 255;
+          return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+        };
+        return 0.2126 * canal(r) + 0.7152 * canal(g) + 0.0722 * canal(b);
+      };
+
+      const contraste = (a: string, b: string) => {
+        const claro = Math.max(luminancia(a), luminancia(b));
+        const oscuro = Math.min(luminancia(a), luminancia(b));
+        return (claro + 0.05) / (oscuro + 0.05);
+      };
+
+      return {
+        // El rótulo tiene que leerse sobre el relleno del botón…
+        rotulo: contraste(estiloBoton.backgroundColor, estiloBoton.color),
+        // …y el botón tiene que distinguirse del fondo de la sección.
+        relleno: contraste(estiloBoton.backgroundColor, estiloBloque.backgroundColor),
+      };
+    });
+
+    expect(medida.rotulo).toBeGreaterThanOrEqual(4.5);
+    // 3:1 es el umbral AA para elementos de interfaz no textuales.
+    expect(medida.relleno).toBeGreaterThanOrEqual(3);
+  });
 });


### PR DESCRIPTION
## Qué cambia

`/reserva-la-fecha`: lo primero que se manda a los invitados, meses antes de la invitación. Se abre desde WhatsApp, en móvil, y se mira dos segundos — dice quién, cuándo y dónde en una pantalla, sin scroll.

Closes #30

La ruta va en castellano como el resto del producto. El plan decía `/save-the-date`, que incumplía la regla 2.

### No se cachea, al revés que la landing

Su existencia depende de una fila de `secciones_landing`. Revalidar cada hora significaría que apagarla tarda una hora en surtir efecto — o, peor, que se sigue enseñando una página que ya se quiso retirar. Son dos consultas a tablas de once y una filas: sale más barato preguntar que explicar por qué el interruptor no hace nada.

En producción nace apagada, que es lo correcto: no se publica hasta que lo decidís. El seed de desarrollo la enciende, porque el entorno tiene que parecerse a una web publicada y porque si no, no hay forma de probarla. `regalos` se queda apagada a propósito, haciendo de sección de control en los tests de navegación.

### Un botón primario invisible que no era de este ticket

Al montar la página salió un fallo de fondo: `[data-seccion="inversa"]` reasignaba las tintas y la marca pero **se dejaba `--acento`**, así que cualquier botón primario dentro de un bloque inverso salía oliva sobre oliva. Afectaba también al bloque de RSVP de la landing y al pie, y lo habría heredado el CTA de #28.

Se reasignan los cuatro tokens del acento en los dos bloques. El test de contraste que ya existía no lo veía porque sólo mide el texto del contenedor; el nuevo mide **el botón contra su propio fondo** y, además, que el relleno se distinga de la sección.

### El test que apaga la sección va en serie — el fichero entero

`fullyParallel` reparte los tests de un mismo fichero entre workers, así que marcar en serie sólo el bloque que toca la base de datos no impedía que apagase la sección mientras otro worker probaba la página encendida. Me pasó: los tests del camino feliz empezaron a recibir 404. **En CI no se habría visto**, porque allí hay un único worker, y habría reventado el día que alguien subiera el paralelismo.

## Cómo probarlo en el preview

1. `/reserva-la-fecha` cabe en la pantalla sin desplazarse, en móvil y en escritorio.
2. Nombres, fecha y lugar llevan el prefijo `(DES)` del seed: vienen de la base.
3. «Ver la web» lleva a la landing.
4. Compartir el enlace: el título y la descripción llevan los datos reales.
5. **No hay botón de «Añadir al calendario»** — eso es #31, y la regla 3 prohíbe entregar botones sin acción.
6. En `/cocina`, el botón primario del bloque inverso ahora se ve.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error — el 404 se prueba apagando la sección de verdad contra la base, no mirando un copy
- [ ] CI verde entero
- [x] Responsive en móvil, tablet y escritorio — el test mide el desbordamiento vertical **y** el horizontal; suite completa pasada también a 393×852
- [x] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion` — un solo `h1`, `<time datetime>` en ISO, y el contraste del botón ahora se mide
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

**Verificado en local:** 21 unitarios · 36 comprobaciones de seguridad de BBDD · 49 E2E en escritorio · 48 a viewport de iPhone.

## Base de datos

- [x] No la toca

Sólo cambia el seed de desarrollo, que no es una migración.

## Documentación

- [x] No hace falta — el §6 del plan ya se corrigió en #77, con la ruta en castellano y el 404 al apagar la sección

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_