### PR TITLE
feat(BODA-31): descarga del evento para el calendario

### DIFF
--- a/src/app/reserva-la-fecha/evento.ics/route.ts
+++ b/src/app/reserva-la-fecha/evento.ics/route.ts
@@ -1,0 +1,67 @@
+import { HORAS_DURACION_EVENTO, NOMBRE_FICHERO_CALENDARIO } from "@/config/constants";
+import { construirIcs } from "@/lib/calendario";
+import { obtenerConfiguracion, obtenerSecciones } from "@/lib/bbdd/landing";
+import { t } from "@/lib/copy";
+
+/**
+ * DESCARGA DEL EVENTO PARA EL CALENDARIO
+ *
+ * Que el invitado se lo apunte en el momento es la mitad del trabajo de una
+ * reserva de fecha: dentro de ocho meses nadie se acuerda de buscar el enlace.
+ *
+ * La ruta termina en `.ics` porque hay clientes de correo y navegadores que
+ * miran la extensión antes que la cabecera para decidir si abren el fichero
+ * con el calendario.
+ *
+ * Se genera al vuelo desde la base de datos, nunca es un fichero estático:
+ * mover la hora de la ceremonia tiene que cambiar lo que se descarga.
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET(peticion: Request) {
+  const [secciones, configuracion] = await Promise.all([
+    obtenerSecciones(),
+    obtenerConfiguracion(),
+  ]);
+
+  // Mismo criterio que la página: si la sección está apagada, esto tampoco
+  // existe. Si no, quedaría una puerta trasera para sacar la fecha de una
+  // página que se ha querido retirar.
+  if (!secciones.includes("reserva_la_fecha") || !configuracion) {
+    return new Response(null, { status: 404 });
+  }
+
+  const origen = new URL(peticion.url).origin;
+  const nombres = `${configuracion.nombreNovia} ${t("portada.conjuncion")} ${configuracion.nombreNovio}`;
+  const lugar = configuracion.lugarCeremonia ?? configuracion.lugarBanquete;
+  const direccion = configuracion.direccionCeremonia;
+  const ultimoHito = configuracion.fechaBanquete ?? configuracion.fechaCeremonia;
+
+  const ics = construirIcs({
+    // Estable mientras no cambie la fecha: volver a descargarlo actualiza el
+    // evento en vez de duplicarlo.
+    identificador: `boda-${configuracion.fechaCeremonia.toISOString().slice(0, 10)}@${new URL(origen).hostname}`,
+    titulo: nombres,
+    descripcion: t("meta.descripcion"),
+    lugar: [lugar, direccion].filter(Boolean).join(", ") || null,
+    latitud: configuracion.latitud,
+    longitud: configuracion.longitud,
+    url: origen,
+    inicio: configuracion.fechaCeremonia,
+    // El fin se cuenta desde el último hito con hora conocida. Ojo: el
+    // banquete es cuándo EMPIEZA el banquete, no cuándo acaba la boda; usarlo
+    // como final dejaría un evento que termina justo cuando empieza lo bueno.
+    fin: new Date(ultimoHito.getTime() + HORAS_DURACION_EVENTO * 60 * 60 * 1000),
+    generadoEn: new Date(),
+  });
+
+  return new Response(ics, {
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${NOMBRE_FICHERO_CALENDARIO}"`,
+      // No se cachea por lo mismo que la página: la fecha puede cambiar y un
+      // calendario con la hora vieja es peor que no tener nada.
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/src/app/reserva-la-fecha/page.tsx
+++ b/src/app/reserva-la-fecha/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 
 import { BotonEnlace } from "@/components/ui/boton";
 import { Cuerpo, Etiqueta, Titulo2, Titulo3 } from "@/components/ui/tipografia";
-import { IDIOMA, ZONA_HORARIA } from "@/config/constants";
+import { IDIOMA, RUTA_CALENDARIO, ZONA_HORARIA } from "@/config/constants";
 import { obtenerConfiguracion, obtenerSecciones } from "@/lib/bbdd/landing";
 import { t } from "@/lib/copy";
 
@@ -110,8 +110,18 @@ export default async function PaginaReservaLaFecha() {
           {t("saveTheDate.nota")}
         </p>
 
-        <div className="mt-elemento">
-          <BotonEnlace href="/">{t("saveTheDate.verLaWeb")}</BotonEnlace>
+        <div className="mt-elemento flex flex-wrap justify-center gap-interno">
+          {/*
+            Enlace normal y no `next/link`: el destino no es una página, es un
+            fichero que se descarga. Con el enrutador de Next por medio, el
+            navegador intentaría navegar a él.
+          */}
+          <BotonEnlace href={RUTA_CALENDARIO} prefetch={false} download>
+            {t("saveTheDate.anadirCalendario")}
+          </BotonEnlace>
+          <BotonEnlace href="/" jerarquia="secundario">
+            {t("saveTheDate.verLaWeb")}
+          </BotonEnlace>
         </div>
       </div>
     </main>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -42,3 +42,18 @@ export const IDIOMA = "es-ES";
 
 /** Zona horaria de referencia para fechas y cuentas atrás. */
 export const ZONA_HORARIA = "Europe/Madrid";
+
+/** Nombre con el que se descarga el evento de la boda para el calendario. */
+export const NOMBRE_FICHERO_CALENDARIO = "nuestra-boda.ics";
+
+/**
+ * Cuánto dura el evento que se apunta en el calendario, contando desde el
+ * último hito con hora conocida. La base guarda cuándo *empieza* la ceremonia
+ * y cuándo *empieza* el banquete, pero no cuándo acaba la fiesta — y nadie lo
+ * sabe de antemano. Marcar un rato largo es mejor que dejar un evento que
+ * parece terminar cuando en realidad empieza lo bueno.
+ */
+export const HORAS_DURACION_EVENTO = 6;
+
+/** Descarga del evento para el calendario. La escriben la página y su test. */
+export const RUTA_CALENDARIO = "/reserva-la-fecha/evento.ics";

--- a/src/lib/bbdd/landing.ts
+++ b/src/lib/bbdd/landing.ts
@@ -19,6 +19,7 @@ export interface ConfiguracionBoda {
   nombreNovia: string;
   nombreNovio: string;
   fechaCeremonia: Date;
+  fechaBanquete: Date | null;
   fechaLimiteRsvp: Date | null;
   lugarCeremonia: string | null;
   direccionCeremonia: string | null;
@@ -118,6 +119,7 @@ export async function obtenerConfiguracion(): Promise<ConfiguracionBoda | null> 
         nombre_novia: string;
         nombre_novio: string;
         fecha_hora_ceremonia: Date;
+        fecha_hora_banquete: Date | null;
         fecha_limite_rsvp: Date | null;
         lugar_ceremonia: string | null;
         direccion_ceremonia: string | null;
@@ -129,7 +131,7 @@ export async function obtenerConfiguracion(): Promise<ConfiguracionBoda | null> 
       }[]
     >`
       select
-        nombre_novia, nombre_novio, fecha_hora_ceremonia, fecha_limite_rsvp,
+        nombre_novia, nombre_novio, fecha_hora_ceremonia, fecha_hora_banquete, fecha_limite_rsvp,
         lugar_ceremonia, direccion_ceremonia, lugar_banquete,
         latitud_ceremonia, longitud_ceremonia, correo_contacto, hashtag
       from public.v_configuracion_publica
@@ -144,6 +146,7 @@ export async function obtenerConfiguracion(): Promise<ConfiguracionBoda | null> 
     nombreNovia: fila.nombre_novia,
     nombreNovio: fila.nombre_novio,
     fechaCeremonia: fila.fecha_hora_ceremonia,
+    fechaBanquete: fila.fecha_hora_banquete,
     fechaLimiteRsvp: fila.fecha_limite_rsvp,
     lugarCeremonia: fila.lugar_ceremonia,
     direccionCeremonia: fila.direccion_ceremonia,

--- a/src/lib/calendario.ts
+++ b/src/lib/calendario.ts
@@ -1,0 +1,128 @@
+/**
+ * GENERACIÓN DE FICHEROS iCalendar (.ics)
+ *
+ * Sin librería: el formato son unas pocas reglas, y las tres que suelen
+ * romperlo —el plegado de líneas, el escapado y los finales de línea— caben
+ * aquí con su explicación al lado. Una dependencia más sería más código que
+ * mantener, no menos.
+ *
+ * SOBRE LA HORA. El ticket avisaba de que «un .ics en UTC aparece a otra hora».
+ * Es al revés: el fallo clásico es emitir `20270226T120000` sin sufijo —una
+ * hora *flotante*, que cada calendario interpreta en su propia zona— y ahí sí
+ * la boda se mueve. Con el sufijo `Z` la fecha designa un instante exacto, y
+ * cada invitado lo ve traducido a su hora local, que es justo lo que se quiere:
+ * quien vive en Canarias tiene que leer las 11:00, no las 12:00.
+ */
+
+import { HORAS_DURACION_EVENTO } from "@/config/constants";
+
+const SALTO = "\r\n";
+
+export interface EventoCalendario {
+  identificador: string;
+  titulo: string;
+  descripcion?: string | null;
+  lugar?: string | null;
+  latitud?: number | null;
+  longitud?: number | null;
+  url?: string | null;
+  inicio: Date;
+  fin?: Date | null;
+  /** Momento de generación. Se recibe para que la salida sea reproducible. */
+  generadoEn: Date;
+}
+
+/**
+ * Escapa un texto para un valor de propiedad iCalendar.
+ *
+ * Coma y punto y coma son separadores dentro de un valor: sin escapar, un lugar
+ * llamado «Finca El Olivar, Toledo» parte la propiedad en dos y el calendario
+ * se queda con la mitad.
+ */
+function escapar(texto: string): string {
+  return texto
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r?\n/g, "\\n");
+}
+
+/**
+ * Pliega una línea a 75 octetos, como exige el RFC 5545.
+ *
+ * Se cuenta en OCTETOS y no en caracteres: en UTF-8 una «ñ» ocupa dos y una
+ * «€» tres, así que contar caracteres deja líneas largas que Outlook trunca.
+ * Y no se puede partir por la mitad de un carácter multibyte, de ahí que se
+ * avance carácter a carácter midiendo lo que ocupa cada uno.
+ */
+function plegar(linea: string): string {
+  const codificador = new TextEncoder();
+  if (codificador.encode(linea).length <= 75) return linea;
+
+  const trozos: string[] = [];
+  let actual = "";
+  let octetos = 0;
+  // El límite baja a 74 en las continuaciones porque llevan un espacio delante.
+  let limite = 75;
+
+  for (const caracter of linea) {
+    const ocupa = codificador.encode(caracter).length;
+    if (octetos + ocupa > limite) {
+      trozos.push(actual);
+      actual = "";
+      octetos = 0;
+      limite = 74;
+    }
+    actual += caracter;
+    octetos += ocupa;
+  }
+  if (actual) trozos.push(actual);
+
+  return trozos.join(`${SALTO} `);
+}
+
+/** `20270226T110000Z` — formato UTC básico, sin guiones ni dos puntos. */
+function comoMarcaUtc(fecha: Date): string {
+  return `${fecha.toISOString().replace(/[-:]/g, "").split(".")[0]}Z`;
+}
+
+export function construirIcs(evento: EventoCalendario): string {
+  const fin =
+    evento.fin ?? new Date(evento.inicio.getTime() + HORAS_DURACION_EVENTO * 60 * 60 * 1000);
+
+  const lineas: string[] = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    // PRODID identifica al programa que lo generó. Va sin traducir: es un
+    // identificador técnico, no texto que lea nadie.
+    "PRODID:-//boda//ES",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    // El UID es estable a propósito: volver a descargar el fichero actualiza
+    // el evento que ya está en el calendario en lugar de crear un duplicado.
+    `UID:${escapar(evento.identificador)}`,
+    `DTSTAMP:${comoMarcaUtc(evento.generadoEn)}`,
+    `DTSTART:${comoMarcaUtc(evento.inicio)}`,
+    `DTEND:${comoMarcaUtc(fin)}`,
+    `SUMMARY:${escapar(evento.titulo)}`,
+  ];
+
+  if (evento.descripcion) lineas.push(`DESCRIPTION:${escapar(evento.descripcion)}`);
+  if (evento.lugar) lineas.push(`LOCATION:${escapar(evento.lugar)}`);
+  if (
+    evento.latitud !== null &&
+    evento.latitud !== undefined &&
+    evento.longitud !== null &&
+    evento.longitud !== undefined
+  ) {
+    // GEO va con punto y coma y sin escapar: son dos números, no texto.
+    lineas.push(`GEO:${evento.latitud};${evento.longitud}`);
+  }
+  if (evento.url) lineas.push(`URL:${escapar(evento.url)}`);
+
+  lineas.push("END:VEVENT", "END:VCALENDAR");
+
+  // El RFC exige CRLF. Con saltos de línea de Unix, Outlook no abre el fichero.
+  return `${lineas.map(plegar).join(SALTO)}${SALTO}`;
+}

--- a/tests/e2e/reserva-la-fecha.spec.ts
+++ b/tests/e2e/reserva-la-fecha.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import postgres from "postgres";
 
 import copy from "../../content/copy.es.json";
+import { NOMBRE_FICHERO_CALENDARIO, RUTA_CALENDARIO } from "../../src/config/constants";
 
 /**
  * BODA-30 · Reserva la fecha
@@ -80,12 +81,65 @@ test.describe("Reserva la fecha", () => {
     await expect(descripcion).toHaveAttribute("content", /\(DES\)/);
   });
 
-  test("no se ofrece nada que todavía no exista", async ({ page }) => {
-    // El `.ics` es BODA-31. Hasta entonces no puede haber un botón que no haga
-    // nada: la regla 3 prohíbe entregar botones sin acción.
-    await expect(
-      page.getByRole("link", { name: copy.saveTheDate.anadirCalendario }),
-    ).toHaveCount(0);
+  test("el botón de calendario apunta al fichero y se descarga", async ({ page }) => {
+    const boton = page.getByRole("link", { name: copy.saveTheDate.anadirCalendario });
+
+    await expect(boton).toBeVisible();
+    await expect(boton).toHaveAttribute("href", RUTA_CALENDARIO);
+    // `download` para que el navegador lo guarde en vez de intentar pintarlo.
+    await expect(boton).toHaveAttribute("download", "");
+  });
+});
+
+/**
+ * El fichero del calendario. Se pide por HTTP en lugar de hacer clic: lo que
+ * importa es lo que llega, y una descarga no deja nada que mirar en pantalla.
+ */
+test.describe("Evento para el calendario", () => {
+  test("se sirve como calendario y se descarga con nombre", async ({ request }) => {
+    const respuesta = await request.get(RUTA_CALENDARIO);
+
+    expect(respuesta.status()).toBe(200);
+    expect(respuesta.headers()["content-type"]).toContain("text/calendar");
+    expect(respuesta.headers()["content-disposition"]).toContain(NOMBRE_FICHERO_CALENDARIO);
+  });
+
+  test("lleva la fecha y el lugar que hay en la base de datos", async ({ request, page }) => {
+    const ics = await (await request.get(RUTA_CALENDARIO)).text();
+
+    // La fecha del fichero tiene que ser la misma que pinta la página: si
+    // alguien incrustara una fecha en el código, esto se cae.
+    await page.goto(RUTA);
+    const fechaEnPagina = await page.locator("time").getAttribute("datetime");
+    const esperada = fechaEnPagina!.replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+
+    expect(ics).toContain(`DTSTART:${esperada}`);
+    expect(ics).toContain("(DES) Finca de pruebas");
+    expect(ics).toMatch(/SUMMARY:.*\(DES\)/);
+  });
+
+  test("el evento no acaba cuando empieza el banquete", async ({ request }) => {
+    const ics = await (await request.get(RUTA_CALENDARIO)).text();
+
+    const inicio = ics.match(/DTSTART:(\S+)/)?.[1];
+    const fin = ics.match(/DTEND:(\S+)/)?.[1];
+
+    expect(inicio).toBeDefined();
+    expect(fin).toBeDefined();
+    expect(fin! > inicio!).toBe(true);
+  });
+
+  test("cumple el formato que exigen los calendarios", async ({ request }) => {
+    const ics = await (await request.get(RUTA_CALENDARIO)).text();
+
+    // CRLF: sin esto Outlook no abre el fichero.
+    expect(/[^\r]\n/.test(ics)).toBe(false);
+
+    // Y ninguna línea por encima de 75 octetos, contando en UTF-8.
+    const codificador = new TextEncoder();
+    for (const linea of ics.split("\r\n")) {
+      expect(codificador.encode(linea).length).toBeLessThanOrEqual(75);
+    }
   });
 });
 
@@ -129,6 +183,15 @@ test.describe("Reserva la fecha apagada", () => {
 
     // Y no se filtra ni un dato por el camino.
     await expect(page.locator("body")).not.toContainText("(DES)");
+  });
+
+  test("con la sección desactivada el calendario tampoco se descarga", async ({ request }) => {
+    await fijarVisible(false);
+
+    // Si no, quedaría una puerta trasera para sacar la fecha de una página que
+    // se ha querido retirar.
+    const respuesta = await request.get(RUTA_CALENDARIO);
+    expect(respuesta.status()).toBe(404);
   });
 
   test("volver a encenderla la devuelve", async ({ page }) => {

--- a/tests/unidad/calendario.test.ts
+++ b/tests/unidad/calendario.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { construirIcs } from "@/lib/calendario";
+
+/**
+ * BODA-31 · Formato iCalendar
+ *
+ * Las tres cosas que rompen un `.ics` en producción no se ven en pantalla: el
+ * plegado de líneas, el escapado de comas y los finales de línea. Se prueban
+ * aquí, en unitarios, porque comprobarlas por E2E significaría abrir el
+ * fichero en tres clientes de calendario distintos.
+ */
+
+const GENERADO = new Date("2026-08-09T10:00:00.000Z");
+const INICIO = new Date("2027-02-26T11:00:00.000Z");
+const FIN = new Date("2027-02-26T17:00:00.000Z");
+
+function base() {
+  return {
+    identificador: "boda-2027-02-26@ejemplo.test",
+    titulo: "Ana y Luis",
+    inicio: INICIO,
+    fin: FIN,
+    generadoEn: GENERADO,
+  };
+}
+
+/** Deshace el plegado, para poder comprobar el valor entero de una propiedad. */
+function desplegar(ics: string): string {
+  return ics.replace(/\r\n /g, "");
+}
+
+/** Deshace el escapado. Es lo que hace un cliente de calendario al leerlo. */
+function desescapar(texto: string): string {
+  return texto
+    .replace(/\\n/g, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}
+
+describe("construirIcs", () => {
+  it("envuelve el evento en un calendario válido", () => {
+    const ics = construirIcs(base());
+
+    expect(ics.startsWith("BEGIN:VCALENDAR\r\n")).toBe(true);
+    expect(ics.trimEnd().endsWith("END:VCALENDAR")).toBe(true);
+    expect(ics).toContain("BEGIN:VEVENT");
+    expect(ics).toContain("VERSION:2.0");
+  });
+
+  it("todas las líneas acaban en CRLF", () => {
+    const ics = construirIcs(base());
+
+    // Un `.ics` con saltos de Unix no lo abre Outlook. Se comprueba que no
+    // queda ni un `\n` suelto.
+    expect(/[^\r]\n/.test(ics)).toBe(false);
+    expect(ics.endsWith("\r\n")).toBe(true);
+  });
+
+  it("las fechas van en UTC, sin guiones ni dos puntos", () => {
+    const ics = construirIcs(base());
+
+    expect(ics).toContain("DTSTART:20270226T110000Z");
+    expect(ics).toContain("DTEND:20270226T170000Z");
+    expect(ics).toContain("DTSTAMP:20260809T100000Z");
+  });
+
+  it("si no se da fin, el evento no se queda abierto", () => {
+    const ics = construirIcs({ ...base(), fin: null });
+
+    const fin = desplegar(ics).match(/DTEND:(\S+)/)?.[1];
+    expect(fin).toBeDefined();
+    expect(fin).not.toBe("20270226T110000Z");
+  });
+
+  it("escapa las comas y los puntos y coma del texto", () => {
+    const ics = desplegar(
+      construirIcs({ ...base(), lugar: "Finca El Olivar, Toledo; junto al río" }),
+    );
+
+    // Sin escapar, la coma parte la propiedad y el calendario se queda con
+    // «Finca El Olivar» a secas.
+    expect(ics).toContain("LOCATION:Finca El Olivar\\, Toledo\\; junto al río");
+  });
+
+  it("escapa las barras invertidas y los saltos de línea", () => {
+    const ics = desplegar(construirIcs({ ...base(), descripcion: "Una\nlínea\\rara" }));
+
+    expect(ics).toContain("DESCRIPTION:Una\\nlínea\\\\rara");
+  });
+
+  it("ninguna línea pasa de 75 octetos", () => {
+    const ics = construirIcs({
+      ...base(),
+      titulo: "Ana y Luis",
+      // Acentos y eñes a propósito: en UTF-8 ocupan dos octetos, así que un
+      // plegado que cuente caracteres deja líneas demasiado largas.
+      descripcion:
+        "Nos casamos en una finca con muchísimos años de historia, ñoñerías incluidas, y nos encantaría que vinierais a acompañarnos ese día tan señalado.",
+    });
+
+    const codificador = new TextEncoder();
+    for (const linea of ics.split("\r\n")) {
+      expect(codificador.encode(linea).length).toBeLessThanOrEqual(75);
+    }
+  });
+
+  it("un cliente recupera el texto original al desplegar y desescapar", () => {
+    // La vuelta completa: es exactamente lo que hace un calendario al leer el
+    // fichero, y la única forma de saber que plegado y escapado se llevan bien.
+    const descripcion =
+      "Nos casamos. Aquí tenéis todo lo que necesitáis saber, y algo más; incluida una coma, un punto y coma y una \\ barra.";
+    const ics = construirIcs({ ...base(), descripcion });
+
+    const valor = desplegar(ics).match(/DESCRIPTION:(.*)\r\n/)?.[1];
+    expect(valor).toBeDefined();
+    expect(desescapar(valor!)).toBe(descripcion);
+  });
+
+  it("las coordenadas van sin escapar, que son números", () => {
+    const ics = desplegar(construirIcs({ ...base(), latitud: 40.416775, longitud: -3.70379 }));
+
+    expect(ics).toContain("GEO:40.416775;-3.70379");
+  });
+
+  it("sin coordenadas no inventa una propiedad GEO", () => {
+    const ics = construirIcs({ ...base(), latitud: null, longitud: null });
+
+    expect(ics).not.toContain("GEO:");
+  });
+
+  it("el identificador es estable: reimportar no duplica el evento", () => {
+    const primero = construirIcs(base());
+    const segundo = construirIcs({
+      ...base(),
+      generadoEn: new Date("2026-09-01T00:00:00.000Z"),
+    });
+
+    const uid = (ics: string) => desplegar(ics).match(/UID:(\S+)/)?.[1];
+    expect(uid(primero)).toBe(uid(segundo));
+  });
+});


### PR DESCRIPTION
## Qué cambia

`/reserva-la-fecha/evento.ics`, generado al vuelo desde la base de datos. Que el invitado se lo apunte en el momento es la mitad del trabajo de una reserva de fecha: dentro de ocho meses nadie se acuerda de buscar el enlace.

Closes #31

La ruta acaba en `.ics` porque hay clientes de correo y navegadores que miran la extensión antes que la cabecera para decidir si lo abren con el calendario.

### Sobre la hora, el ticket se equivocaba

El criterio decía que «un `.ics` en UTC aparece a otra hora». Es al revés. El fallo clásico es emitir `20270226T120000` **sin sufijo** —una hora *flotante*, que cada calendario interpreta en su propia zona— y ahí sí se mueve la boda. Con el sufijo `Z` la fecha designa un instante exacto y cada invitado lo ve traducido a su hora local, que es justo lo que se quiere: quien vive en Canarias tiene que leer una hora menos, no la misma.

Lo digo aquí porque el ticket se cierra con este cambio y el criterio, tal como estaba escrito, llevaba a la implementación equivocada.

### El banquete no es el final

La base guarda cuándo **empieza** el banquete, no cuándo acaba la fiesta. Usarlo como `DTEND` —que fue mi primer intento— dejaba un evento que termina justo cuando empieza lo bueno. El fin se cuenta desde el último hito con hora conocida más `HORAS_DURACION_EVENTO`, que es una constante con nombre y no un número suelto.

### Sin librería, pero con las tres trampas cubiertas

El formato son unas pocas reglas. Las tres que lo rompen en producción no se ven en pantalla:

| Trampa | Qué pasa si se ignora |
| --- | --- |
| Plegado a 75 **octetos** | Contar caracteres deja líneas largas: una «ñ» ocupa dos octetos en UTF-8 y Outlook trunca |
| Escapar `,` y `;` | «Finca El Olivar, Toledo» se queda en «Finca El Olivar» |
| Finales CRLF | Outlook ni abre el fichero |

Once tests unitarios las cubren, incluido el viaje de ida y vuelta: desplegar y desescapar tiene que devolver el texto original, que es literalmente lo que hace un cliente de calendario al leerlo.

El fichero **se apaga con la sección**, igual que la página. Si no, quedaría una puerta trasera para sacar la fecha de algo que se ha querido retirar.

## Cómo probarlo en el preview

1. En `/reserva-la-fecha`, «Añadir al calendario» descarga `nuestra-boda.ics`.
2. Abrirlo: la fecha, el lugar y las coordenadas son los de la base de datos.
3. Volver a descargarlo e importarlo **no duplica** el evento — el UID es estable.
4. Cambiar la fecha en la base cambia la del fichero: no hay ninguna incrustada.
5. Con la sección apagada, tanto la página como el `.ics` devuelven 404.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode — la duración, el nombre del fichero y la ruta son constantes con nombre
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error — el 404 del fichero con la sección apagada
- [ ] CI verde entero
- [x] Responsive en móvil, tablet y escritorio — suite completa pasada también a 393×852
- [x] Accesible: el botón es un enlace de verdad, con `download`, alcanzable por teclado
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

**Verificado en local:** 32 unitarios · 36 comprobaciones de seguridad de BBDD · 54 E2E en escritorio · 54 a viewport de iPhone. Y una inspección del fichero generado, byte a byte.

## Base de datos

- [x] No la toca

`obtenerConfiguracion` ahora también lee `fecha_hora_banquete`, que ya estaba en la vista pública.

## Documentación

- [x] No hace falta — el §6 del plan ya describe el `.ics` generado desde `configuracion_boda`

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_