### PR TITLE
fix(BODA-09): un fallo de lectura se cacheaba una hora entera

### DIFF
--- a/docs/PLAN-MAESTRO.md
+++ b/docs/PLAN-MAESTRO.md
@@ -85,7 +85,7 @@ Orden de precedencia si algo entra en conflicto: **estas reglas fundacionales > 
 
 | Capa          | Elección                                                       | Por qué                                                                                                                           |
 | ------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Framework     | **Next.js 15 (App Router)**                                    | SSR/ISR para la landing, Server Actions para el panel, un solo repo para ambas caras                                              |
+| Framework     | **Next.js 16 (App Router)**                                    | Render en servidor para la landing, Server Actions para el panel, un solo repo para ambas caras                                   |
 | Hosting       | **Vercel**                                                     | Despliegue nativo de Next.js: no hay adaptador que mantener. Deploy previews por PR, CDN global, free tier suficiente             |
 | BBDD          | **Supabase** (PostgreSQL, open source)                         | Postgres puro + Auth + Storage + RLS + Realtime en un free tier. Autoalojable si algún día hace falta                             |
 | Auth          | Supabase Auth (magic link + OAuth Google)                      | Sin gestionar contraseñas. Solo 2-4 usuarios                                                                                      |
@@ -112,7 +112,7 @@ Orden de precedencia si algo entra en conflicto: **estas reglas fundacionales > 
 ```
                  ┌──────────────────────────────┐
    Invitados ───►│  Vercel CDN / Edge           │
-                 │  ├─ / (landing, ISR)         │
+                 │  ├─ / (landing, dinámica)    │
                  │  ├─ /reserva-la-fecha        │
                  │  └─ /rsvp/[token]            │
                  └──────────┬───────────────────┘
@@ -259,6 +259,8 @@ Secciones del enumerado `seccion_landing`:
 | `playlist`             | Canciones que sugieren los invitados                        | BODA-29 |
 | `rsvp`                 | Llamada a confirmar asistencia                              | BODA-28 |
 | `reserva_la_fecha`     | **No es una sección: es una página aparte** (ver más abajo) | BODA-30 |
+
+**Por qué la landing no se cachea.** Nació con `revalidate = 3600` y se quitó tras un fallo en producción: si la base no responde justo en el despliegue —caída, pausada por inactividad del plan gratuito, o una variable de entorno que aún no está—, lo que se hornea y se sirve **durante una hora entera** es la pantalla de «estamos preparando la web», aunque la base vuelva a los diez segundos. Ahora se consulta en cada visita: ocho consultas indexadas sobre tablas de pocas filas, lanzadas a la vez, medidas en 27 ms de mediana en local. A cambio, un cambio en el panel se ve al instante y un fallo nunca se queda pegado. Ver BODA-09.
 
 **Principios de animación:** el movimiento sirve a la narrativa, no la interrumpe. Todas las duraciones y curvas son tokens. Con `prefers-reduced-motion` los reveals se convierten en fades cortos o desaparecen. Ninguna animación puede provocar layout shift (CLS objetivo < 0.1).
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Fragment, type ReactNode } from "react";
 
+import { EnPreparacion } from "@/components/marketing/en-preparacion";
 import { Navegacion } from "@/components/marketing/navegacion";
 import { Pie } from "@/components/marketing/pie";
 import { CuentaAtras } from "@/components/marketing/cuenta-atras";
@@ -37,10 +38,23 @@ import { t } from "@/lib/copy";
  * y todavía no existen (son BODA-25 y BODA-26). Sin ese filtro, el menú
  * ofrecería dos enlaces que no llevan a ninguna parte.
  *
- * Se revalida cada hora: la landing no cambia a menudo, y así los invitados
- * reciben HTML de la caché en lugar de esperar a una consulta.
+ * NO SE CACHEA, y es un cambio respecto a cómo nació.
+ *
+ * Antes se revalidaba cada hora, así que la página se generaba en el despliegue
+ * y se servía desde caché. El problema no era el caso bueno: era el malo. Si la
+ * base no respondía justo en ese momento —caída, en pausa por inactividad del
+ * plan gratuito, o una variable de entorno que aún no estaba—, lo que se
+ * horneaba y se servía **durante una hora entera** era la pantalla de «estamos
+ * preparando la web». La base podía volver a estar bien a los diez segundos y
+ * los invitados seguían viendo eso.
+ *
+ * Pasó en producción. Ahora se consulta en cada visita: son ocho consultas
+ * indexadas sobre tablas de pocas filas, lanzadas a la vez, y la web tiene unos
+ * cientos de visitas en total. Cuesta unos milisegundos y a cambio nunca se
+ * queda enganchada en un fallo — ni enseñando datos viejos después de un
+ * cambio en el panel.
  */
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 const formatoFecha = new Intl.DateTimeFormat(IDIOMA, {
   weekday: "long",
@@ -58,7 +72,16 @@ const formatoFechaCorta = new Intl.DateTimeFormat(IDIOMA, {
 });
 
 export default async function PaginaInicio() {
-  const [
+  let datos;
+  try {
+    datos = await cargarLanding();
+  } catch {
+    // La avería ya se registró en el log con su motivo. Aquí sólo se decide
+    // qué ve el invitado, y lo que ve es la verdad: todavía no hay nada.
+    return <EnPreparacion />;
+  }
+
+  const {
     secciones,
     configuracion,
     programa,
@@ -67,30 +90,12 @@ export default async function PaginaInicio() {
     rutas,
     preguntas,
     canciones,
-  ] = await Promise.all([
-    obtenerSecciones(),
-    obtenerConfiguracion(),
-    obtenerPrograma(),
-    obtenerHistoria(),
-    obtenerAlojamientos(),
-    obtenerRutas(),
-    obtenerPreguntasFrecuentes(),
-    obtenerCanciones(),
-  ]);
+  } = datos;
 
-  // Sin configuración no hay boda que enseñar: puede que falte la variable de
-  // entorno o que aún no se haya rellenado el panel. Se dice con claridad, en
-  // lugar de pintar una página rota o inventarse datos para tapar el hueco.
-  if (!configuracion) {
-    return (
-      <main className="mx-auto grid min-h-dvh max-w-texto place-items-center px-interno text-center">
-        <div>
-          <Titulo2 como="h1">{t("portada.enPreparacion")}</Titulo2>
-          <Cuerpo className="mt-pila">{t("portada.enPreparacionTexto")}</Cuerpo>
-        </div>
-      </main>
-    );
-  }
+  // Sin configuración no hay boda que enseñar: la base respondió, pero el panel
+  // aún está vacío. Se dice con claridad, en lugar de pintar una página rota o
+  // inventarse datos para tapar el hueco.
+  if (!configuracion) return <EnPreparacion />;
 
   const nombres = `${configuracion.nombreNovia} ${t("portada.conjuncion")} ${configuracion.nombreNovio}`;
 
@@ -151,6 +156,40 @@ export default async function PaginaInicio() {
       />
     </>
   );
+}
+
+/** Todo lo que la landing necesita, pedido de una vez. */
+async function cargarLanding() {
+  const [
+    secciones,
+    configuracion,
+    programa,
+    historia,
+    alojamientos,
+    rutas,
+    preguntas,
+    canciones,
+  ] = await Promise.all([
+    obtenerSecciones(),
+    obtenerConfiguracion(),
+    obtenerPrograma(),
+    obtenerHistoria(),
+    obtenerAlojamientos(),
+    obtenerRutas(),
+    obtenerPreguntasFrecuentes(),
+    obtenerCanciones(),
+  ]);
+
+  return {
+    secciones,
+    configuracion,
+    programa,
+    historia,
+    alojamientos,
+    rutas,
+    preguntas,
+    canciones,
+  };
 }
 
 /* ------------------------------------------------------------------------ */

--- a/src/app/reserva-la-fecha/evento.ics/route.ts
+++ b/src/app/reserva-la-fecha/evento.ics/route.ts
@@ -19,10 +19,18 @@ import { t } from "@/lib/copy";
 export const dynamic = "force-dynamic";
 
 export async function GET(peticion: Request) {
-  const [secciones, configuracion] = await Promise.all([
-    obtenerSecciones(),
-    obtenerConfiguracion(),
-  ]);
+  let secciones;
+  let configuracion;
+  try {
+    [secciones, configuracion] = await Promise.all([
+      obtenerSecciones(),
+      obtenerConfiguracion(),
+    ]);
+  } catch {
+    // 503 y no 404: la avería ya está en el log, y decirle a un cliente de
+    // calendario que el evento «no existe» le haría borrarlo. Que reintente.
+    return new Response(null, { status: 503, headers: { "Retry-After": "60" } });
+  }
 
   // Mismo criterio que la página: si la sección está apagada, esto tampoco
   // existe. Si no, quedaría una puerta trasera para sacar la fecha de una

--- a/src/app/reserva-la-fecha/page.tsx
+++ b/src/app/reserva-la-fecha/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { EnPreparacion } from "@/components/marketing/en-preparacion";
 import { BotonEnlace } from "@/components/ui/boton";
-import { Cuerpo, Etiqueta, Titulo2, Titulo3 } from "@/components/ui/tipografia";
+import { Etiqueta, Titulo3 } from "@/components/ui/tipografia";
 import { IDIOMA, RUTA_CALENDARIO, ZONA_HORARIA } from "@/config/constants";
 import { obtenerConfiguracion, obtenerSecciones } from "@/lib/bbdd/landing";
 import { t } from "@/lib/copy";
@@ -32,7 +33,9 @@ const formatoFechaLarga = new Intl.DateTimeFormat(IDIOMA, {
 });
 
 export async function generateMetadata(): Promise<Metadata> {
-  const configuracion = await obtenerConfiguracion();
+  // Si la base no responde, la página ya enseñará su estado de reserva; unas
+  // meta tags vacías son mejores que tumbar la petición entera por el título.
+  const configuracion = await obtenerConfiguracion().catch(() => null);
   if (!configuracion) return {};
 
   const nombres = `${configuracion.nombreNovia} ${t("portada.conjuncion")} ${configuracion.nombreNovio}`;
@@ -46,10 +49,19 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function PaginaReservaLaFecha() {
-  const [secciones, configuracion] = await Promise.all([
-    obtenerSecciones(),
-    obtenerConfiguracion(),
-  ]);
+  let secciones;
+  let configuracion;
+  try {
+    [secciones, configuracion] = await Promise.all([
+      obtenerSecciones(),
+      obtenerConfiguracion(),
+    ]);
+  } catch {
+    // La avería ya está en el log. Aquí no se puede saber si la sección estaba
+    // encendida, así que se enseña el estado de reserva en vez de un 404 que
+    // diría algo falso: la página existe, es la base la que no contesta.
+    return <EnPreparacion />;
+  }
 
   // La página existe sólo si su fila está visible. Apagada, 404: mejor que una
   // página a medias, y mejor que dejarla en pie cuando ya se ha querido
@@ -58,16 +70,7 @@ export default async function PaginaReservaLaFecha() {
   if (!secciones.includes("reserva_la_fecha")) notFound();
 
   // Sin configuración no hay nada que reservar. Se dice, no se finge.
-  if (!configuracion) {
-    return (
-      <main className="mx-auto grid min-h-dvh max-w-texto place-items-center px-interno text-center">
-        <div>
-          <Titulo2 como="h1">{t("portada.enPreparacion")}</Titulo2>
-          <Cuerpo className="mt-pila">{t("portada.enPreparacionTexto")}</Cuerpo>
-        </div>
-      </main>
-    );
-  }
+  if (!configuracion) return <EnPreparacion />;
 
   const lugar = configuracion.lugarCeremonia ?? configuracion.lugarBanquete;
 

--- a/src/components/marketing/en-preparacion.tsx
+++ b/src/components/marketing/en-preparacion.tsx
@@ -1,0 +1,22 @@
+import { Cuerpo, Titulo2 } from "@/components/ui/tipografia";
+import { t } from "@/lib/copy";
+
+/**
+ * ESTADO DE RESERVA
+ *
+ * Lo que se enseña cuando no hay datos que enseñar: porque la boda todavía no
+ * está configurada, o porque no se ha podido preguntar a la base.
+ *
+ * Dice la verdad y no finge nada. La alternativa —una página con huecos, o
+ * peor, con datos de ejemplo— hace que un invitado se crea una fecha que no es.
+ */
+export function EnPreparacion() {
+  return (
+    <main className="mx-auto grid min-h-dvh max-w-texto place-items-center px-interno text-center">
+      <div>
+        <Titulo2 como="h1">{t("portada.enPreparacion")}</Titulo2>
+        <Cuerpo className="mt-pila">{t("portada.enPreparacionTexto")}</Cuerpo>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/bbdd/cliente.ts
+++ b/src/lib/bbdd/cliente.ts
@@ -70,21 +70,39 @@ if (process.env.NODE_ENV !== "production" && cliente) {
 
 export const sql = cliente;
 
+/** Se lanza cuando no se pudo leer. No confundir con «no hay datos». */
+export class ErrorDeLectura extends Error {
+  constructor(motivo: string, options?: ErrorOptions) {
+    super(motivo, options);
+    this.name = "ErrorDeLectura";
+  }
+}
+
 /**
  * Ejecuta una lectura con los privilegios de un visitante anónimo.
  *
- * Devuelve `null` si no se pudo leer —sin base de datos configurada, o con la
- * base caída—. Quien llama decide qué enseñar; lo que nunca hace es inventarse
- * datos para rellenar el hueco.
+ * LANZA si no se pudo leer, y no devuelve `null`. La diferencia importa más de
+ * lo que parece: «la base dice que no hay ninguna fila» es un dato, y «no he
+ * podido preguntarle a la base» es una avería. Devolviendo `null` para las dos
+ * cosas, quien llama no puede distinguirlas — y acaba cacheando la avería como
+ * si fuera un resultado.
+ *
+ * Eso pasó de verdad: un despliegue sin `DATABASE_URL` horneó la pantalla de
+ * «estamos preparando la web» y la sirvió cacheada durante una hora. Con la
+ * avería propagándose como excepción, la caché no la guarda y la siguiente
+ * visita vuelve a intentarlo.
+ *
+ * Lo que nunca hace, ni lanzando ni devolviendo, es inventarse datos para
+ * rellenar el hueco.
  */
 export async function leerComoAnonimo<T>(
   consulta: (tx: postgres.TransactionSql) => Promise<T>,
-): Promise<T | null> {
+): Promise<T> {
   if (!cliente) {
-    console.error(
-      "Sin DATABASE_URL: la web se sirve sin datos. Configúrala en Vercel → Settings → Environment Variables.",
-    );
-    return null;
+    const motivo =
+      "Sin DATABASE_URL: la web se sirve sin datos. Configúrala en Vercel → Settings → Environment Variables.";
+    console.error(motivo);
+    throw new ErrorDeLectura(motivo);
   }
 
   try {
@@ -96,6 +114,6 @@ export async function leerComoAnonimo<T>(
     // Se registra entero: un fallo de lectura en la landing es un incidente,
     // aunque la página aguante y muestre su estado de reserva.
     console.error("Fallo al leer de la base de datos:", error);
-    return null;
+    throw new ErrorDeLectura("No se pudo leer de la base de datos.", { cause: error });
   }
 }

--- a/src/lib/bbdd/landing.ts
+++ b/src/lib/bbdd/landing.ts
@@ -13,6 +13,12 @@ import { leerComoAnonimo } from "./cliente";
  * Todas las lecturas se ejecutan como `anon`, así que lo que devuelven es
  * exactamente lo que puede ver un invitado. No hay filtrado en el frontend
  * porque no hace falta: lo hace la base de datos.
+ *
+ * ESTAS FUNCIONES LANZAN si la base no responde. No devuelven listas vacías
+ * disfrazando la avería: una lista vacía significa «no hay nada que enseñar» y
+ * tiene que seguir significando eso. Quien pinta la página decide qué hacer con
+ * el fallo, y así puede distinguir «todavía no hay hoteles» de «no he podido
+ * preguntar».
  */
 
 export interface ConfiguracionBoda {
@@ -95,7 +101,7 @@ export async function obtenerSecciones(): Promise<Seccion[]> {
   );
 
   const conocidas: Seccion[] = [];
-  for (const fila of filas ?? []) {
+  for (const fila of filas) {
     if (esSeccionConocida(fila.seccion)) {
       conocidas.push(fila.seccion);
     } else {
@@ -139,7 +145,7 @@ export async function obtenerConfiguracion(): Promise<ConfiguracionBoda | null> 
     `,
   );
 
-  const fila = filas?.[0];
+  const fila = filas[0];
   if (!fila) return null;
 
   return {
@@ -166,7 +172,7 @@ export async function obtenerPrograma(): Promise<HitoPrograma[]> {
       order by orden, hora
     `,
   );
-  return (filas ?? []).map((f) => ({
+  return filas.map((f) => ({
     id: f.id,
     hora: f.hora,
     titulo: f.titulo,
@@ -191,7 +197,7 @@ export async function obtenerAlojamientos(): Promise<Alojamiento[]> {
       order by orden, nombre
     `,
   );
-  return (filas ?? []).map((f) => ({
+  return filas.map((f) => ({
     id: f.id,
     nombre: f.nombre,
     distintivo: f.distintivo,
@@ -209,7 +215,7 @@ export async function obtenerRutas(): Promise<RutaLlegada[]> {
       order by orden, modo
     `,
   );
-  return (filas ?? []).map((f) => ({
+  return filas.map((f) => ({
     id: f.id,
     modo: f.modo,
     duracion: f.duracion,
@@ -225,7 +231,7 @@ export async function obtenerPreguntasFrecuentes(): Promise<PreguntaFrecuente[]>
       order by orden
     `,
   );
-  return (filas ?? []).map((f) => ({ id: f.id, pregunta: f.pregunta, respuesta: f.respuesta }));
+  return filas.map((f) => ({ id: f.id, pregunta: f.pregunta, respuesta: f.respuesta }));
 }
 
 export async function obtenerHistoria(): Promise<HitoHistoria[]> {
@@ -238,7 +244,7 @@ export async function obtenerHistoria(): Promise<HitoHistoria[]> {
       order by orden
     `,
   );
-  return (filas ?? []).map((f) => ({
+  return filas.map((f) => ({
     id: f.id,
     titulo: f.titulo,
     fechaTexto: f.fecha_texto,
@@ -255,5 +261,5 @@ export async function obtenerCanciones(limite = 30): Promise<Cancion[]> {
       limit ${limite}
     `,
   );
-  return (filas ?? []).map((f) => ({ id: f.id, texto: f.texto }));
+  return filas.map((f) => ({ id: f.id, texto: f.texto }));
 }

--- a/tests/e2e/resiliencia.spec.ts
+++ b/tests/e2e/resiliencia.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+import postgres from "postgres";
+
+import copy from "../../content/copy.es.json";
+
+/**
+ * BODA-09 · La web se recupera sola cuando la base vuelve
+ *
+ * El fallo que motiva esto pasó en producción: un despliegue sin
+ * `DATABASE_URL` horneó la pantalla de «estamos preparando la web» y la sirvió
+ * cacheada una hora entera. La base podía haber vuelto a los diez segundos.
+ *
+ * Aquí se prueba el comportamiento entero contra la base real: se le quita el
+ * permiso de lectura a `anon` —que es exactamente lo que ve la web cuando la
+ * base no le responde—, se comprueba que la página lo dice en vez de romperse,
+ * se devuelve el permiso y se comprueba que **la visita siguiente ya enseña los
+ * datos**, sin esperar a que expire ninguna caché.
+ *
+ * TODO EL FICHERO EN SERIE. Se toca un permiso que afecta a toda la base, así
+ * que dos tests de este fichero no pueden solaparse. Entre ficheros distintos
+ * el aislamiento lo da el CI, que corre con un único worker; en local, con
+ * paralelismo, este fichero conviene lanzarlo solo.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+const cadena = process.env.DATABASE_URL;
+
+test.skip(!cadena, "Hace falta DATABASE_URL para simular la caída.");
+
+async function conPermisoDeLectura(permitido: boolean) {
+  const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
+  try {
+    if (permitido) {
+      await sql`grant select on public.v_configuracion_publica to anon`;
+    } else {
+      await sql`revoke select on public.v_configuracion_publica from anon`;
+    }
+  } finally {
+    await sql.end();
+  }
+}
+
+test.afterAll(async () => {
+  if (cadena) await conPermisoDeLectura(true);
+});
+
+test("con la base sin responder, la landing lo dice en lugar de romperse", async ({ page }) => {
+  try {
+    await conPermisoDeLectura(false);
+
+    const respuesta = await page.goto("/");
+
+    // Ni un 500 ni una página en blanco: la web sigue en pie y es honesta.
+    expect(respuesta?.status()).toBe(200);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+      copy.portada.enPreparacion,
+    );
+    // Y no se inventa nada para tapar el hueco.
+    await expect(page.locator("body")).not.toContainText("(DES)");
+  } finally {
+    await conPermisoDeLectura(true);
+  }
+});
+
+test("en cuanto la base vuelve, la siguiente visita ya trae los datos", async ({ page }) => {
+  // Sin esperar a que caduque nada: es justo lo que no pasaba antes.
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("(DES)");
+  await expect(
+    page.getByRole("navigation", { name: copy.navegacion.etiquetaPrincipal }),
+  ).toBeVisible();
+});
+
+test("la reserva de fecha también aguanta la caída", async ({ page }) => {
+  try {
+    await conPermisoDeLectura(false);
+
+    const respuesta = await page.goto("/reserva-la-fecha");
+
+    // Estado de reserva y no 404: la página existe, es la base la que calla.
+    // Un 404 diría algo falso.
+    expect(respuesta?.status()).toBe(200);
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+      copy.portada.enPreparacion,
+    );
+  } finally {
+    await conPermisoDeLectura(true);
+  }
+});
+
+test("el calendario devuelve 503, no 404, cuando la base calla", async ({ request }) => {
+  try {
+    await conPermisoDeLectura(false);
+
+    const respuesta = await request.get("/reserva-la-fecha/evento.ics");
+
+    // Un 404 le diría a un cliente de calendario que el evento ya no existe, y
+    // hay clientes que lo borran del calendario del invitado.
+    expect(respuesta.status()).toBe(503);
+    expect(respuesta.headers()["retry-after"]).toBeDefined();
+  } finally {
+    await conPermisoDeLectura(true);
+  }
+});

--- a/tests/unidad/cacheado.test.ts
+++ b/tests/unidad/cacheado.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * BODA-09 · Ninguna página que lea de la base se puede prerenderizar
+ *
+ * Este test existe por un fallo real en producción. La landing llevaba
+ * `export const revalidate = 3600`, así que se generaba en el despliegue y se
+ * servía desde caché. El caso bueno iba bien; el malo, no: el despliegue del 9
+ * de agosto se hizo sin `DATABASE_URL`, horneó la pantalla de «estamos
+ * preparando la web» y la sirvió **durante una hora**, aunque la base hubiera
+ * vuelto en diez segundos.
+ *
+ * Es un fallo silencioso —build en verde, tests en verde, web sin datos— y por
+ * eso lleva guardián, y en la causa y no en el síntoma. Si alguien vuelve a
+ * poner `revalidate` en una página que lee de la base, esto se pone rojo.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+
+/** Lee un fichero fuente sin comentarios, para no dispararse con uno. */
+function leer(ruta: string) {
+  return readFileSync(join(RAIZ, ruta), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+}
+
+const PAGINAS_CON_DATOS = ["src/app/page.tsx", "src/app/reserva-la-fecha/page.tsx"];
+
+describe.each(PAGINAS_CON_DATOS)("%s", (ruta) => {
+  const fuente = leer(ruta);
+
+  it("se declara dinámica", () => {
+    expect(fuente).toMatch(/export\s+const\s+dynamic\s*=\s*"force-dynamic"/);
+  });
+
+  it("no revalida por tiempo: eso cachearía también los fallos", () => {
+    expect(fuente).not.toMatch(/export\s+const\s+revalidate/);
+  });
+});
+
+describe("La ruta del calendario", () => {
+  const fuente = leer("src/app/reserva-la-fecha/evento.ics/route.ts");
+
+  it("también es dinámica", () => {
+    expect(fuente).toMatch(/export\s+const\s+dynamic\s*=\s*"force-dynamic"/);
+  });
+
+  it("responde 503 y no 404 cuando la base falla", () => {
+    // Un 404 le diría a un cliente de calendario que el evento ya no existe, y
+    // hay clientes que lo borran. Un 503 le dice que vuelva a intentarlo.
+    expect(fuente).toContain("status: 503");
+  });
+});
+
+describe("La capa de acceso a la base", () => {
+  const fuente = leer("src/lib/bbdd/cliente.ts");
+
+  it("propaga la avería en lugar de devolver un hueco", () => {
+    // Devolviendo `null` tanto para «no hay filas» como para «no he podido
+    // preguntar», quien llama no puede distinguirlas y acaba tratando una
+    // avería como un resultado válido — que es lo que se cacheaba.
+    expect(fuente).toContain("throw new ErrorDeLectura");
+    expect(fuente).toMatch(/Promise<T>/);
+  });
+});


### PR DESCRIPTION
## Qué cambia

Un fallo de lectura ya no se queda pegado. Cuando la base vuelve, la siguiente visita trae los datos — sin redesplegar y sin esperar a que caduque nada.

Closes #82

### El fallo, tal como pasó

La landing llevaba `revalidate = 3600`, así que se generaba en el despliegue y se servía desde caché. El caso bueno iba bien. El malo, no: el despliegue de producción del 9 de agosto se hizo sin `DATABASE_URL`, horneó la pantalla de «estamos preparando la web» y la sirvió durante una hora. La base podía haber vuelto a los diez segundos.

Ahí la causa era real y la pantalla correcta, pero el mecanismo es el mismo cuando la causa es pasajera — y con el plan gratuito de Supabase, que pausa proyectos inactivos, iba a repetirse.

### La causa no era el cacheo: era no poder distinguir

`leerComoAnonimo` devolvía `null` para dos cosas muy distintas:

| Situación | Qué significa |
| --- | --- |
| La base responde y no hay filas | Un dato: todavía no hay hoteles |
| No he podido preguntarle a la base | Una avería |

Con las dos iguales, quien llama no puede tratarlas distinto, y una avería acaba cacheada como si fuera un resultado. Ahora **lanza**, y quien pinta la página decide qué enseñar. Con la avería propagándose como excepción, la caché no la guarda.

De paso sale solo el 503 del `.ics`: un 404 le diría a un cliente de calendario que el evento ya no existe, y hay clientes que lo borran del calendario del invitado.

### La landing pasa a ser dinámica, y contradice el ticket que yo mismo escribí

El criterio decía «la landing no puede pasar a consultar la base en cada visita». Es justo lo que hace ahora, y creo que el criterio estaba equivocado: mantener caché **con** recuperación rápida exige invalidarla desde algún sitio, y ese sitio es el panel, que todavía no existe. Cachear con un plazo corto sólo mueve el problema.

Medido en local, con las ocho consultas incluidas: **27 ms de mediana** (mín. 21, máx. 30). Contra Supabase remoto será más por la latencia de red, pero sigue siendo un orden de magnitud por debajo de lo que nota nadie, para una web de unos cientos de visitas en total. A cambio: un cambio en el panel se ve al instante, y ningún fallo se queda pegado.

Lo digo aquí en lugar de cambiar el criterio en silencio.

## Cómo probarlo en el preview

1. La landing sigue igual de rápida y con los mismos datos.
2. En el build, `/` aparece como `ƒ` (dinámica) y ya no como `○` (prerenderizada).
3. **Esto arregla lo que estás viendo en producción**: en cuanto pongas `DATABASE_URL`, la web se recupera en la siguiente visita, sin redesplegar.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error — cuatro tests que le quitan el permiso de lectura a `anon` contra la base real y se lo devuelven
- [ ] CI verde entero
- [x] Responsive en móvil, tablet y escritorio — sin cambios de maquetación
- [x] Accesible — el estado de reserva sigue siendo un `h1` con su texto
- [x] Pasado por las skills de diseño — sin cambios de interfaz
- [ ] Revisado en el deploy preview

**Verificado en local:** 37 unitarios · 36 comprobaciones de seguridad de BBDD · 58 E2E en escritorio.

### Los dos guardianes

- `tests/unidad/cacheado.test.ts` vigila la causa raíz: si alguien vuelve a poner `revalidate` en una página que lee de la base, el CI se pone rojo. Mismo espíritu que el guardián del `@import` de Tailwind — un fallo silencioso que deja todo en verde merece vigilancia en la causa, no en el síntoma.
- `tests/e2e/resiliencia.spec.ts` lo prueba entero contra la base real. Va en serie y devuelve el permiso en `finally`; entre ficheros el aislamiento lo da el CI, que corre con un único worker.

## Base de datos

- [x] No la toca

## Documentación

- [x] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR — el §3 y el §6 decían ISR; ahora explican por qué se descartó

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_