### PR TITLE
feat(BODA-42): esqueleto del panel, navegación y sesión

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Probar el recorrido completo del acceso
         env:
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
-        run: npx playwright test --project=escritorio tests/e2e/acceso-real.spec.ts
+        run: npx playwright test --project=escritorio tests/e2e/acceso-real.spec.ts tests/e2e/panel.spec.ts
 
       - name: Guardar informe si algo falla
         if: failure()

--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -179,5 +179,46 @@
     "nuevaGuardar": "Guardar y entrar",
     "nuevaCorta": "La contraseña es demasiado corta.",
     "errorEnlace": "Ese enlace ya no vale. Pide uno nuevo y entra desde el último que recibas."
+  },
+  "panel": {
+    "titulo": "Panel",
+    "navegacion": "Secciones del panel",
+    "saltarAlContenido": "Saltar al contenido",
+    "sesionDe": "Has entrado como",
+    "cargando": "Cargando…",
+    "errorTitulo": "Algo no ha ido bien",
+    "errorTexto": "No hemos podido cargar esta pantalla. Vuelve a intentarlo; si sigue igual, avisa.",
+    "reintentar": "Reintentar",
+    "modulos": {
+      "resumen": "Resumen",
+      "invitados": "Invitados",
+      "mesas": "Mesas",
+      "menus": "Menús",
+      "actividades": "Actividades",
+      "proveedores": "Proveedores",
+      "presupuesto": "Presupuesto",
+      "tareas": "Tareas",
+      "cuenta": "Mi cuenta"
+    },
+    "resumen": {
+      "titulo": "Resumen",
+      "descripcion": "Aquí irán los números de la boda: cuántos han confirmado, qué queda por pagar y qué vence esta semana.",
+      "enConstruccion": "Los módulos aparecen en el menú según se van terminando."
+    },
+    "cuenta": {
+      "titulo": "Mi cuenta",
+      "descripcion": "Tu nombre es el que ve la otra persona en el panel.",
+      "nombre": "Nombre",
+      "guardar": "Guardar",
+      "guardado": "Nombre actualizado",
+      "errorGuardar": "No hemos podido guardar el nombre. Inténtalo de nuevo.",
+      "nombreCorto": "Escribe un nombre de al menos dos caracteres.",
+      "rol": "Permisos",
+      "roles": {
+        "propietario": "Propietario",
+        "editor": "Editor",
+        "lector": "Lector"
+      }
+    }
   }
 }

--- a/docs/PLAN-MAESTRO.md
+++ b/docs/PLAN-MAESTRO.md
@@ -152,7 +152,7 @@ src/
 │  ├─ tokens/                # primitives.css, semantic.css, motion.css
 │  └─ globals.css
 ├─ lib/
-│  ├─ supabase/              # client.ts, server.ts, middleware.ts
+│  ├─ supabase/              # servidor.ts (el middleware vive en src/middleware.ts)
 │  ├─ validators/            # Esquemas Zod (compartidos cliente/servidor)
 │  └─ queries/               # Acceso a datos tipado
 ├─ config/                   # constants.ts, navigation.ts, site.ts

--- a/src/app/panel/cuenta/acciones.ts
+++ b/src/app/panel/cuenta/acciones.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import {
+  LONGITUD_MINIMA_NOMBRE,
+  RUTA_ACCESO,
+  RUTA_CUENTA,
+  RUTA_PANEL,
+} from "@/config/constants";
+import { clienteServidor, hayAutenticacion } from "@/lib/supabase/servidor";
+
+/**
+ * Cambia el nombre con el que aparece uno en el panel.
+ *
+ * Escribe de verdad en `perfiles`, y quien decide si puede es RLS: la política
+ * `perfiles_propio_actualizar` deja tocar el nombre y **sólo** el nombre. Ni
+ * siquiera hace falta comprobar aquí de quién es la fila — la base no
+ * permitiría escribir en otra.
+ */
+export async function guardarNombre(datos: FormData) {
+  const nombre = String(datos.get("nombre") ?? "").trim();
+
+  if (nombre.length < LONGITUD_MINIMA_NOMBRE) redirect(`${RUTA_CUENTA}?estado=corto`);
+  if (!hayAutenticacion) redirect(RUTA_ACCESO);
+
+  try {
+    const supabase = await clienteServidor();
+    const { data: sesion } = await supabase.auth.getUser();
+    if (!sesion.user) redirect(RUTA_ACCESO);
+
+    const { error } = await supabase
+      .from("perfiles")
+      .update({ nombre_completo: nombre })
+      .eq("usuario_id", sesion.user.id);
+
+    if (error) {
+      console.error("No se pudo guardar el nombre:", error.message);
+      redirect(`${RUTA_CUENTA}?estado=error`);
+    }
+  } catch (error) {
+    // `redirect` funciona lanzando: si no se deja pasar, el salto de arriba se
+    // tragaría aquí y la pantalla se quedaría igual sin decir nada.
+    if (typeof error === "object" && error !== null && "digest" in error) throw error;
+    console.error("Fallo al guardar el nombre:", error);
+    redirect(`${RUTA_CUENTA}?estado=error`);
+  }
+
+  // La cabecera del panel enseña ese mismo nombre, y vive en el layout: sin
+  // esto se quedaría con el anterior hasta la siguiente recarga completa.
+  revalidatePath(RUTA_PANEL, "layout");
+  redirect(`${RUTA_CUENTA}?estado=guardado`);
+}

--- a/src/app/panel/cuenta/page.tsx
+++ b/src/app/panel/cuenta/page.tsx
@@ -1,0 +1,85 @@
+import { redirect } from "next/navigation";
+
+import { Boton } from "@/components/ui/boton";
+import { CampoTexto } from "@/components/ui/campo";
+import { Cuerpo, Etiqueta, Titulo2 } from "@/components/ui/tipografia";
+import { LONGITUD_MINIMA_NOMBRE, RUTA_ACCESO } from "@/config/constants";
+import { accesoActual, type RolPanel } from "@/lib/sesion";
+import { t } from "@/lib/copy";
+
+import { guardarNombre } from "./acciones";
+
+/**
+ * MI CUENTA
+ *
+ * Lo poco que uno puede cambiar de sí mismo: el nombre con el que aparece. El
+ * rol se enseña pero no se toca — quién puede qué lo decide un propietario, y
+ * un formulario que dejara ascenderse no sería un formulario, sería un agujero.
+ * La base lo impide igualmente con el trigger `perfiles_proteger_privilegios`;
+ * esto sólo es no ofrecerlo.
+ */
+export const dynamic = "force-dynamic";
+
+const AVISOS: Record<string, { texto: string; error: boolean }> = {
+  guardado: { texto: t("panel.cuenta.guardado"), error: false },
+  corto: { texto: t("panel.cuenta.nombreCorto"), error: true },
+  error: { texto: t("panel.cuenta.errorGuardar"), error: true },
+};
+
+const ROLES: Record<RolPanel, string> = {
+  propietario: t("panel.cuenta.roles.propietario"),
+  editor: t("panel.cuenta.roles.editor"),
+  lector: t("panel.cuenta.roles.lector"),
+};
+
+export default async function PaginaCuenta({
+  searchParams,
+}: {
+  searchParams: Promise<{ estado?: string }>;
+}) {
+  const acceso = await accesoActual();
+  if (!acceso) redirect(RUTA_ACCESO);
+
+  const { estado } = await searchParams;
+  const aviso = estado && estado in AVISOS ? AVISOS[estado] : null;
+
+  return (
+    <div className="grid max-w-texto gap-pila">
+      <div>
+        <Titulo2 como="h1">{t("panel.cuenta.titulo")}</Titulo2>
+        <Cuerpo className="mt-pila">{t("panel.cuenta.descripcion")}</Cuerpo>
+      </div>
+
+      {aviso ? (
+        <p
+          // El que sale bien se anuncia como `status` y el que sale mal como
+          // `alert`: el primero no debe interrumpir lo que esté leyendo un
+          // lector de pantalla, y el segundo sí.
+          role={aviso.error ? "alert" : "status"}
+          className={`text-pequeno ${aviso.error ? "text-error-tinta" : "text-tinta-marca"}`}
+        >
+          {aviso.texto}
+        </p>
+      ) : null}
+
+      <form action={guardarNombre} className="grid gap-elemento">
+        <CampoTexto
+          name="nombre"
+          etiqueta={t("panel.cuenta.nombre")}
+          defaultValue={acceso.nombre ?? ""}
+          minLength={LONGITUD_MINIMA_NOMBRE}
+          required
+          autoComplete="name"
+        />
+        <div>
+          <Boton type="submit">{t("panel.cuenta.guardar")}</Boton>
+        </div>
+      </form>
+
+      <div>
+        <Etiqueta>{t("panel.cuenta.rol")}</Etiqueta>
+        <Cuerpo className="mt-linea">{ROLES[acceso.rol]}</Cuerpo>
+      </div>
+    </div>
+  );
+}

--- a/src/app/panel/error.tsx
+++ b/src/app/panel/error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { Boton } from "@/components/ui/boton";
+import { Cuerpo, Titulo3 } from "@/components/ui/tipografia";
+import { t } from "@/lib/copy";
+
+/**
+ * ESTADO DE ERROR
+ *
+ * Sin este fichero, un fallo dentro del panel sube hasta la raíz y se lleva
+ * por delante la navegación y la sesión: pantalla en blanco y a empezar de
+ * nuevo. Aquí el fallo se queda dentro del contenido, con el marco en pie y un
+ * botón para reintentar sin recargar.
+ *
+ * NO SE ENSEÑA `error.message`. Un error del servidor puede llevar dentro una
+ * consulta, un nombre de tabla o un dato de un invitado. Va al registro, donde
+ * se puede investigar, y a la pantalla va lo único que le sirve a quien está
+ * mirando: que no ha ido bien y que puede volver a probar.
+ */
+export default function ErrorPanel({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Fallo en el panel:", error);
+  }, [error]);
+
+  return (
+    <div role="alert" className="grid max-w-texto gap-pila">
+      <Titulo3 como="h1">{t("panel.errorTitulo")}</Titulo3>
+      <Cuerpo>{t("panel.errorTexto")}</Cuerpo>
+      <div>
+        <Boton type="button" jerarquia="secundario" onClick={reset}>
+          {t("panel.reintentar")}
+        </Boton>
+      </div>
+    </div>
+  );
+}

--- a/src/app/panel/layout.tsx
+++ b/src/app/panel/layout.tsx
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { NavegacionPanel } from "@/components/panel/navegacion-panel";
+import { Boton } from "@/components/ui/boton";
+import { ID_CONTENIDO, RUTA_ACCESO } from "@/config/constants";
+import { accesoActual } from "@/lib/sesion";
+import { t } from "@/lib/copy";
+
+import { cerrarSesion } from "../acceso/acciones";
+
+/**
+ * EL MARCO DEL PANEL
+ *
+ * Aquí se comprueba el acceso una sola vez y valen todas las pantallas de
+ * dentro: el layout envuelve a todas, así que ninguna puede olvidarse de
+ * mirarlo. El middleware ya ha echado a quien no tiene sesión; lo que se
+ * decide aquí es lo otro, si además tiene **perfil activo**.
+ *
+ * `force-dynamic` porque el panel depende de quién mira. Cachear una página
+ * que enseña el nombre de quien ha entrado es servirle a la siguiente persona
+ * la sesión de la anterior.
+ */
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: t("panel.titulo"),
+  robots: { index: false, follow: false },
+};
+
+export default async function LayoutPanel({ children }: { children: ReactNode }) {
+  const acceso = await accesoActual();
+
+  // Ni sesión, ni perfil, ni perfil activo: los tres acaban en la puerta, y sin
+  // un mensaje que distinga cuál de los tres era.
+  if (!acceso) redirect(RUTA_ACCESO);
+
+  return (
+    <div className="min-h-dvh bg-fondo">
+      <a
+        href={`#${ID_CONTENIDO}`}
+        className="sr-only focus:not-sr-only focus:absolute focus:left-interno focus:top-interno focus:z-modal focus:rounded-campo focus:bg-superficie focus:px-interno focus:py-interno-compacto focus:text-pequeno"
+      >
+        {t("panel.saltarAlContenido")}
+      </a>
+
+      <NavegacionPanel />
+
+      {/*
+        El hueco lo deja el contenido, no la navegación: está fija, así que no
+        empuja nada. Abajo en móvil —donde vive la barra— y a la izquierda en
+        escritorio.
+      */}
+      <div className="hueco-barra-inferior md:pb-0 md:pl-lateral">
+        <header className="flex flex-wrap items-center justify-between gap-interno border-b border-borde px-interno py-interno-compacto">
+          <p className="text-pequeno text-tinta-suave">
+            {t("panel.sesionDe")}{" "}
+            <strong className="font-normal text-tinta">{acceso.nombre ?? acceso.correo}</strong>
+          </p>
+
+          <form action={cerrarSesion}>
+            <Boton type="submit" jerarquia="terciario">
+              {t("acceso.cerrarSesion")}
+            </Boton>
+          </form>
+        </header>
+
+        <main id={ID_CONTENIDO} className="px-interno py-elemento">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/panel/loading.tsx
+++ b/src/app/panel/loading.tsx
@@ -1,0 +1,20 @@
+import { t } from "@/lib/copy";
+
+/**
+ * ESTADO DE CARGA
+ *
+ * Sin este fichero, Next deja la pantalla anterior congelada mientras trae la
+ * siguiente: se pincha en un módulo, no pasa nada visible, y se vuelve a
+ * pinchar. Con él, el marco —navegación y cabecera— se queda en su sitio y
+ * sólo cambia el contenido, que es lo que de verdad está cargando.
+ *
+ * Es texto y no un esqueleto animado a propósito: un esqueleto que no se
+ * parece a lo que viene después miente sobre lo que va a aparecer.
+ */
+export default function CargandoPanel() {
+  return (
+    <p role="status" className="text-pequeno text-tinta-suave">
+      {t("panel.cargando")}
+    </p>
+  );
+}

--- a/src/app/panel/page.tsx
+++ b/src/app/panel/page.tsx
@@ -1,52 +1,21 @@
-import type { Metadata } from "next";
-import { redirect } from "next/navigation";
-
-import { Boton } from "@/components/ui/boton";
-import { Cuerpo, Etiqueta, Titulo2 } from "@/components/ui/tipografia";
-import { RUTA_ACCESO } from "@/config/constants";
-import { accesoActual } from "@/lib/sesion";
+import { Cuerpo, Titulo2 } from "@/components/ui/tipografia";
 import { t } from "@/lib/copy";
 
-import { cerrarSesion } from "../acceso/acciones";
-
 /**
- * PANEL — provisional
+ * RESUMEN — la portada del panel
  *
- * Esto es todavía el mínimo para que el acceso tenga a dónde llevar: enseña
- * quién ha entrado y deja salir. La navegación, los módulos y la portada con
- * los números son BODA-42 y BODA-43.
+ * Los números de la boda son BODA-43 y llegan con su propia consulta. Hasta
+ * entonces esto dice lo que hay y por qué el menú es corto, en lugar de
+ * enseñar unas cifras de mentira que habría que acordarse de quitar.
  *
- * Lo que sí es definitivo es la puerta: sin acceso, aquí no se pinta nada.
+ * El acceso ya lo ha comprobado el layout: aquí no se repite.
  */
-export const dynamic = "force-dynamic";
-
-export const metadata: Metadata = {
-  title: t("meta.titulo"),
-  robots: { index: false, follow: false },
-};
-
-export default async function PaginaPanel() {
-  const acceso = await accesoActual();
-
-  // Ni sesión, ni perfil, ni perfil activo: los tres acaban en la puerta. Sin
-  // mensaje que distinga cuál de los tres era.
-  if (!acceso) redirect(RUTA_ACCESO);
-
+export default function PaginaResumen() {
   return (
-    <main className="mx-auto grid min-h-dvh max-w-contenido content-start gap-elemento px-interno py-seccion-compacta">
-      <div>
-        <Etiqueta>{acceso.rol}</Etiqueta>
-        <Titulo2 como="h1" className="mt-pila">
-          {acceso.nombre ?? acceso.correo}
-        </Titulo2>
-        <Cuerpo className="mt-pila">{t("meta.descripcion")}</Cuerpo>
-      </div>
-
-      <form action={cerrarSesion}>
-        <Boton type="submit" jerarquia="secundario">
-          {t("acceso.cerrarSesion")}
-        </Boton>
-      </form>
-    </main>
+    <div className="grid max-w-texto gap-pila">
+      <Titulo2 como="h1">{t("panel.resumen.titulo")}</Titulo2>
+      <Cuerpo>{t("panel.resumen.descripcion")}</Cuerpo>
+      <p className="text-pequeno text-tinta-suave">{t("panel.resumen.enConstruccion")}</p>
+    </div>
   );
 }

--- a/src/components/panel/navegacion-panel.tsx
+++ b/src/components/panel/navegacion-panel.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { MODULOS_ENTREGADOS, moduloActivo, type ClaveModulo } from "@/config/modulos";
+import { t } from "@/lib/copy";
+
+/**
+ * NAVEGACIÓN DEL PANEL
+ *
+ * DOS SITIOS MUY DISTINTOS. En el portátil se planifica: sesiones largas,
+ * saltando entre módulos, y el lateral fijo permite hacerlo sin perder de
+ * vista dónde está uno. En el móvil se consulta el día de la boda, con una
+ * mano y a menudo de pie, así que los destinos bajan al alcance del pulgar en
+ * lugar de esconderse tras un menú que hay que abrir.
+ *
+ * Es la misma lista pintada dos veces con CSS, no dos componentes: un solo
+ * sitio donde añadir un módulo, y ningún riesgo de que el móvil se quede atrás.
+ *
+ * ES CLIENTE SÓLO POR `usePathname`. Los enlaces son enlaces y funcionan sin
+ * JavaScript; el subrayado del activo también, porque Next resuelve la ruta al
+ * renderizar en el servidor y llega ya puesto en el HTML.
+ */
+
+/** Sólo se pinta lo terminado: un menú con huecos es peor que un menú corto. */
+function etiquetaDe(clave: ClaveModulo): string {
+  return t(`panel.modulos.${clave}`);
+}
+
+export function NavegacionPanel() {
+  const ruta = usePathname();
+  const activo = moduloActivo(ruta);
+
+  return (
+    <>
+      {/* Lateral, en escritorio */}
+      <nav
+        aria-label={t("panel.navegacion")}
+        className="fixed inset-y-0 left-0 capa-lateral hidden w-lateral flex-col gap-elemento border-r border-borde bg-superficie px-interno py-elemento md:flex"
+      >
+        <Link
+          href="/"
+          className="px-interno-compacto font-titulo text-titulo-3 leading-titulo-corto text-tinta-marca transicion-color hover:text-tinta"
+        >
+          {t("meta.titulo")}
+        </Link>
+
+        <ul className="grid gap-linea">
+          {MODULOS_ENTREGADOS.map((modulo) => (
+            <li key={modulo.clave}>
+              <Enlace
+                ruta={modulo.ruta}
+                etiqueta={etiquetaDe(modulo.clave)}
+                activo={modulo.clave === activo}
+              />
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* Barra inferior, en móvil */}
+      <nav
+        aria-label={t("panel.navegacion")}
+        className="fixed inset-x-0 bottom-0 capa-lateral border-t border-borde bg-superficie barra-inferior md:hidden"
+      >
+        {/*
+          Se desplaza en horizontal si un día no caben. Es lo único que aguanta
+          crecer de dos módulos a nueve sin volverse ilegible ni esconder la
+          mitad detrás de un botón más.
+        */}
+        <ul className="flex h-barra-movil items-stretch overflow-x-auto">
+          {MODULOS_ENTREGADOS.map((modulo) => (
+            <li key={modulo.clave} className="flex min-w-0 flex-1 basis-0">
+              <Enlace
+                ruta={modulo.ruta}
+                etiqueta={etiquetaDe(modulo.clave)}
+                activo={modulo.clave === activo}
+                centrado
+              />
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </>
+  );
+}
+
+function Enlace({
+  ruta,
+  etiqueta,
+  activo,
+  centrado = false,
+}: {
+  ruta: string;
+  etiqueta: string;
+  activo: boolean;
+  centrado?: boolean;
+}) {
+  return (
+    <Link
+      href={ruta}
+      // `aria-current` es lo que hace que un lector de pantalla diga «página
+      // actual». El color solo no lo cuenta, y el subrayado tampoco.
+      aria-current={activo ? "page" : undefined}
+      className={[
+        "flex min-h-control-compacto w-full items-center whitespace-nowrap rounded-campo px-interno-compacto text-etiqueta uppercase tracking-etiqueta transicion-color",
+        centrado ? "justify-center" : "",
+        activo
+          ? "bg-marca-tenue text-tinta-marca"
+          : "text-tinta-suave hover:bg-superficie-hundida hover:text-tinta",
+      ].join(" ")}
+    >
+      {etiqueta}
+    </Link>
+  );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -64,6 +64,7 @@ export const RUTA_CONFIRMAR_ACCESO = "/acceso/confirmar";
 export const RUTA_PANEL = "/panel";
 export const RUTA_RECUPERAR = "/acceso/recuperar";
 export const RUTA_NUEVA_CONTRASENA = "/acceso/nueva-contrasena";
+export const RUTA_CUENTA = "/panel/cuenta";
 
 /**
  * Dónde se anota la ruta que alguien pidió antes de que le mandaran a la
@@ -77,3 +78,10 @@ export const PARAMETRO_VOLVER = "volver";
  * validación que solo vive en el navegador no es una validación.
  */
 export const LONGITUD_MINIMA_CONTRASENA = 12;
+
+/**
+ * Longitud mínima de un nombre en el panel. Dos caracteres: hay nombres
+ * cortos de verdad, y lo que se quiere evitar es el campo vacío o con un
+ * espacio, no obligar a nadie a escribir más de lo que se llama.
+ */
+export const LONGITUD_MINIMA_NOMBRE = 2;

--- a/src/config/modulos.ts
+++ b/src/config/modulos.ts
@@ -1,0 +1,70 @@
+import { RUTA_CUENTA, RUTA_PANEL } from "./constants";
+
+/**
+ * LOS MÓDULOS DEL PANEL
+ *
+ * La lista de lo que hay dentro, y —lo importante— qué está terminado.
+ *
+ * POR QUÉ EXISTE `entregado`
+ *
+ * Un menú que enseña ocho módulos cuando funcionan dos no es una promesa: es
+ * una trampa. Se pincha en «Mesas», sale un hueco, y a partir de ahí ya no se
+ * sabe si lo que falla es la aplicación o la conexión. Peor aún el día de la
+ * boda, con una mano ocupada y sin ganas de averiguarlo.
+ *
+ * Así que el menú enseña sólo lo que existe. Cada ticket que entrega su módulo
+ * cambia su `false` por un `true` en la misma PR, y ese cambio de una palabra
+ * es lo que lo hace visible. `tests/unidad/modulos.test.ts` comprueba que todo
+ * lo marcado como entregado tiene de verdad su página: marcarlo antes de
+ * tiempo pone el CI en rojo, que es exactamente cuando conviene enterarse.
+ *
+ * El orden es el del menú, y no es alfabético: es el de la cabeza de quien
+ * organiza una boda. Primero cuántos somos, luego dónde se sientan y qué
+ * comen, después quién lo trae y cuánto cuesta.
+ */
+
+export interface Modulo {
+  /** Identifica el módulo y da su rótulo: `panel.modulos.<clave>`. */
+  readonly clave: string;
+  readonly ruta: string;
+  /** `false` mientras no haya pantalla detrás. No aparece en el menú. */
+  readonly entregado: boolean;
+}
+
+export const MODULOS = [
+  { clave: "resumen", ruta: RUTA_PANEL, entregado: true },
+  { clave: "invitados", ruta: `${RUTA_PANEL}/invitados`, entregado: false },
+  { clave: "mesas", ruta: `${RUTA_PANEL}/mesas`, entregado: false },
+  { clave: "menus", ruta: `${RUTA_PANEL}/menus`, entregado: false },
+  { clave: "actividades", ruta: `${RUTA_PANEL}/actividades`, entregado: false },
+  { clave: "proveedores", ruta: `${RUTA_PANEL}/proveedores`, entregado: false },
+  { clave: "presupuesto", ruta: `${RUTA_PANEL}/presupuesto`, entregado: false },
+  { clave: "tareas", ruta: `${RUTA_PANEL}/tareas`, entregado: false },
+  { clave: "cuenta", ruta: RUTA_CUENTA, entregado: true },
+] as const satisfies readonly Modulo[];
+
+export type ClaveModulo = (typeof MODULOS)[number]["clave"];
+
+/** Lo que se pinta en el menú. Lo demás todavía no existe. */
+export const MODULOS_ENTREGADOS = MODULOS.filter((modulo) => modulo.entregado);
+
+/**
+ * Cuál de los módulos corresponde a una ruta.
+ *
+ * Un módulo se marca también en sus pantallas de dentro: estando en la ficha
+ * de un invitado, el menú tiene que seguir señalando «Invitados».
+ *
+ * EL RESUMEN ES LA EXCEPCIÓN, porque su ruta es la raíz y todo cuelga de ella.
+ * Si contara como prefijo, cualquier pantalla del panel saldría marcada como
+ * «Resumen» y el menú dejaría de decir dónde está uno, que es su único
+ * trabajo. Así que la raíz se marca sólo cuando se está exactamente en ella.
+ */
+export function moduloActivo(ruta: string): ClaveModulo | null {
+  const encontrado = MODULOS_ENTREGADOS.find(
+    (modulo) =>
+      ruta === modulo.ruta ||
+      (modulo.ruta !== RUTA_PANEL && ruta.startsWith(`${modulo.ruta}/`)),
+  );
+
+  return encontrado?.clave ?? null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -73,7 +73,24 @@ export async function middleware(peticion: NextRequest) {
 
   if (!usuario && esDelPanel(peticion.nextUrl.pathname)) return aLaPuerta(peticion);
 
+  if (esDelPanel(peticion.nextUrl.pathname)) sinGuardarEnCache(respuesta);
+
   return respuesta;
+}
+
+/**
+ * Que el panel no se quede guardado en el navegador.
+ *
+ * Sin esto, cerrar sesión y darle a «atrás» devuelve la pantalla anterior tal
+ * cual: el navegador la tiene en su caché de historial y no vuelve a pedirla,
+ * así que ni el middleware ni RLS llegan a enterarse. Los datos que se ven son
+ * viejos y ya no se pueden refrescar, pero están ahí — en un portátil
+ * compartido, eso es la lista de invitados a la vista de quien lo coja después.
+ *
+ * `no-store` obliga a pedirla otra vez, y esa petición sí pasa por aquí.
+ */
+function sinGuardarEnCache(respuesta: NextResponse): void {
+  respuesta.headers.set("Cache-Control", "no-store, max-age=0, must-revalidate");
 }
 
 /**
@@ -92,7 +109,9 @@ function aLaPuerta(peticion: NextRequest): NextResponse {
     `${peticion.nextUrl.pathname}${peticion.nextUrl.search}`,
   );
 
-  return NextResponse.redirect(destino);
+  const respuesta = NextResponse.redirect(destino);
+  sinGuardarEnCache(respuesta);
+  return respuesta;
 }
 
 export const config = {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -140,6 +140,11 @@
   /* Un solo token da `h-cabecera`, `pt-cabecera` y `scroll-mt-cabecera`. */
   --spacing-cabecera: var(--alto-cabecera);
 
+  /* Igual que arriba: el mismo token da el ancho del lateral y el hueco que
+   * deja a su lado, y el alto de la barra de móvil y el que deja debajo. */
+  --spacing-lateral: var(--ancho-lateral);
+  --spacing-barra-movil: var(--alto-barra-movil);
+
   /* Forma */
   --radius-boton: var(--radio-boton);
   --radius-campo: var(--radio-campo);
@@ -192,6 +197,31 @@
  */
 @utility capa-cabecera {
   z-index: var(--capa-cabecera);
+}
+
+/** La misma razón, para la navegación fija del panel. */
+@utility capa-lateral {
+  z-index: var(--capa-pegajosa);
+}
+
+/**
+ * La barra inferior del panel y el hueco que deja bajo el contenido.
+ *
+ * `env(safe-area-inset-bottom)` no puede ser un token: no es un valor nuestro,
+ * lo pone el dispositivo y vale cero en casi todos. En un iPhone sin botón es
+ * la franja del indicador de inicio, y sin contar con ella la última fila de
+ * la barra queda debajo de él, medio tapada y difícil de acertar.
+ *
+ * Las dos utilidades van juntas a propósito: si el alto de la barra y el hueco
+ * que deja se calcularan por separado, cualquier cambio en uno dejaría al otro
+ * desfasado y el contenido acabaría escondido detrás de la barra.
+ */
+@utility barra-inferior {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+@utility hueco-barra-inferior {
+  padding-bottom: calc(var(--alto-barra-movil) + env(safe-area-inset-bottom));
 }
 
 /**

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -164,6 +164,19 @@
    */
   --size-cabecera: 4.25rem;
 
+  /**
+   * Ancho del lateral del panel. Cabe el rótulo más largo («Presupuesto») sin
+   * partirse y deja el contenido con sitio de sobra en un portátil de 13".
+   */
+  --size-lateral: 15rem;
+
+  /**
+   * Alto de la barra inferior del panel en móvil. Es más que un control porque
+   * lleva rótulo bajo el icono: sin él, seis destinos iguales se distinguen
+   * sólo por un dibujo pequeño.
+   */
+  --size-barra-movil: 4rem;
+
   /* ---------------------------------------------------------------------
    * Forma
    * ------------------------------------------------------------------- */

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -119,6 +119,8 @@
   --alto-campo: var(--size-campo);
   --ancho-cifra: var(--size-cifra);
   --alto-cabecera: var(--size-cabecera);
+  --ancho-lateral: var(--size-lateral);
+  --alto-barra-movil: var(--size-barra-movil);
 
   /* --- Forma --------------------------------------------------------- */
   --radio-boton: var(--radius-redondo);

--- a/tests/e2e/panel.spec.ts
+++ b/tests/e2e/panel.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+
+import copy from "../../content/copy.es.json";
+import { RUTA_ACCESO, RUTA_CUENTA, RUTA_PANEL } from "../../src/config/constants";
+import { MODULOS } from "../../src/config/modulos";
+
+/**
+ * BODA-42 · El esqueleto del panel
+ *
+ * El recorrido de verdad —entrar, navegar, cerrar sesión— necesita GoTrue, así
+ * que vive en el trabajo de CI que levanta el Supabase local y se salta en
+ * cualquier otro sitio.
+ *
+ * Lo que sí se prueba en todas partes está más abajo: que las pantallas del
+ * panel no se guardan en la caché del navegador. Esa es la que muerde de
+ * verdad, y no hace falta sesión para comprobarla.
+ */
+
+const CORREO_CON_ACCESO = process.env.CORREO_CON_ACCESO;
+const CONTRASENA = process.env.CONTRASENA_PRUEBAS;
+
+test.describe("Dentro del panel", () => {
+  test.skip(
+    !CORREO_CON_ACCESO || !CONTRASENA,
+    "Necesita el Supabase local: solo corre en el trabajo de CI que lo levanta.",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(RUTA_ACCESO);
+    await page.getByLabel(copy.acceso.correo).fill(CORREO_CON_ACCESO!);
+    await page.getByLabel(copy.acceso.contrasena).fill(CONTRASENA!);
+    await page.getByRole("button", { name: copy.acceso.entrar }).click();
+    await expect(page).toHaveURL(new RegExp(RUTA_PANEL));
+  });
+
+  test("se navega entre módulos y el menú dice dónde estás", async ({ page }) => {
+    const menu = page.getByRole("navigation", { name: copy.panel.navegacion }).first();
+
+    await expect(menu.getByRole("link", { name: copy.panel.modulos.resumen })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    await menu.getByRole("link", { name: copy.panel.modulos.cuenta }).click();
+
+    await expect(page).toHaveURL(new RegExp(RUTA_CUENTA));
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(copy.panel.cuenta.titulo);
+    await expect(menu.getByRole("link", { name: copy.panel.modulos.cuenta })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  test("el nombre que se guarda es el que aparece arriba", async ({ page }) => {
+    // Escribe de verdad en `perfiles`: si esto pasa, la pantalla está cableada.
+    const nombre = "(PRUEBA) Nombre cambiado";
+
+    await page.goto(RUTA_CUENTA);
+    await page.getByLabel(copy.panel.cuenta.nombre).fill(nombre);
+    await page.getByRole("button", { name: copy.panel.cuenta.guardar }).click();
+
+    await expect(page.getByRole("main").getByRole("status")).toHaveText(
+      copy.panel.cuenta.guardado,
+    );
+    await expect(page.getByRole("banner")).toContainText(nombre);
+
+    // Y sigue ahí al recargar, que es lo que separa guardar de aparentarlo.
+    await page.reload();
+    await expect(page.getByLabel(copy.panel.cuenta.nombre)).toHaveValue(nombre);
+  });
+
+  test("un nombre vacío no se guarda", async ({ page }) => {
+    await page.goto(RUTA_CUENTA);
+    const campo = page.getByLabel(copy.panel.cuenta.nombre);
+    const original = await campo.inputValue();
+
+    await campo.fill(" ");
+    await page.getByRole("button", { name: copy.panel.cuenta.guardar }).click();
+
+    await expect(page.getByRole("main").getByRole("alert")).toHaveText(
+      copy.panel.cuenta.nombreCorto,
+    );
+
+    await page.goto(RUTA_CUENTA);
+    await expect(campo).toHaveValue(original);
+  });
+
+  test("los módulos sin terminar no están en el menú", async ({ page }) => {
+    // Un menú que enseña ocho módulos cuando funcionan dos no es una promesa:
+    // es una trampa.
+    const menu = page.getByRole("navigation", { name: copy.panel.navegacion }).first();
+
+    for (const modulo of MODULOS.filter((cada) => !cada.entregado)) {
+      await expect(
+        menu.getByRole("link", { name: copy.panel.modulos[modulo.clave] }),
+      ).toHaveCount(0);
+    }
+  });
+
+  // --- El caso que de verdad importa -----------------------------------
+
+  test("tras cerrar sesión, «atrás» no devuelve al panel", async ({ page }) => {
+    await page.goto(RUTA_CUENTA);
+    await page.getByRole("button", { name: copy.acceso.cerrarSesion }).click();
+    await expect(page).toHaveURL(new RegExp(RUTA_ACCESO));
+
+    await page.goBack();
+
+    // En un portátil compartido, esto es la diferencia entre haber salido y
+    // dejar la lista de invitados a la vista de quien lo coja después.
+    await expect(page).toHaveURL(new RegExp(RUTA_ACCESO));
+    await expect(page.getByRole("button", { name: copy.acceso.cerrarSesion })).toHaveCount(0);
+  });
+});
+
+test.describe("La caché del panel", () => {
+  test("las pantallas del panel no se guardan en el navegador", async ({ request }) => {
+    // Sin `no-store`, el navegador devuelve la pantalla desde su historial sin
+    // volver a pedirla: ni el middleware ni RLS llegan a enterarse de que la
+    // sesión ya no vale.
+    //
+    // Se pide sin seguir la redirección a propósito: lo que no puede quedarse
+    // guardada es también la respuesta que echa a la puerta.
+    for (const ruta of [RUTA_PANEL, RUTA_CUENTA]) {
+      const respuesta = await request.get(ruta, { maxRedirects: 0 });
+      expect(respuesta.headers()["cache-control"] ?? "", ruta).toContain("no-store");
+    }
+  });
+});
+
+/*
+ * No hay aquí el test contrario —«la landing sí se cachea»— porque hoy sería
+ * falso: la landing se sirve con `force-dynamic` y también sin caché. Fue una
+ * decisión meditada y está explicada en `src/app/page.tsx`: cuando se cacheaba
+ * una hora, un fallo puntual de la base dejaba la pantalla de «estamos
+ * preparando la web» servida durante esa hora entera, y pasó en producción.
+ */

--- a/tests/e2e/panel.spec.ts
+++ b/tests/e2e/panel.spec.ts
@@ -69,12 +69,17 @@ test.describe("Dentro del panel", () => {
     await expect(page.getByLabel(copy.panel.cuenta.nombre)).toHaveValue(nombre);
   });
 
-  test("un nombre vacío no se guarda", async ({ page }) => {
+  test("un nombre de sólo espacios no se guarda", async ({ page }) => {
     await page.goto(RUTA_CUENTA);
     const campo = page.getByLabel(copy.panel.cuenta.nombre);
     const original = await campo.inputValue();
 
-    await campo.fill(" ");
+    // DOS espacios, y no uno, a propósito. Con uno el navegador ni siquiera
+    // envía el formulario —lo para su propio `minlength`— y lo que se estaría
+    // probando es el navegador, no nuestro código. Con dos pasa esa criba y
+    // llega al servidor, que es quien tiene que darse cuenta de que un nombre
+    // que al recortarlo se queda en nada no es un nombre.
+    await campo.fill("  ");
     await page.getByRole("button", { name: copy.panel.cuenta.guardar }).click();
 
     await expect(page.getByRole("main").getByRole("alert")).toHaveText(

--- a/tests/unidad/modulos.test.ts
+++ b/tests/unidad/modulos.test.ts
@@ -1,0 +1,86 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { MODULOS, MODULOS_ENTREGADOS, moduloActivo } from "../../src/config/modulos";
+import { RUTA_PANEL } from "../../src/config/constants";
+import copy from "../../content/copy.es.json";
+
+/**
+ * EL MENÚ NO PUEDE PROMETER LO QUE NO HAY
+ *
+ * `entregado: true` es lo único que separa un módulo de aparecer en la
+ * navegación. Es una palabra, se cambia en un segundo y es facilísimo
+ * cambiarla de más —al empezar el ticket en lugar de al acabarlo— y no
+ * enterarse hasta que alguien pincha y encuentra un 404.
+ *
+ * Estas comprobaciones son baratas y cierran esa puerta: marcar un módulo como
+ * terminado sin su página pone el CI en rojo.
+ */
+
+const RAIZ_APP = join(process.cwd(), "src/app");
+
+/** `/panel/cuenta` → `src/app/panel/cuenta/page.tsx` */
+function ficheroDe(ruta: string): string {
+  return join(RAIZ_APP, ruta, "page.tsx");
+}
+
+describe("Módulos del panel", () => {
+  it("todo lo marcado como entregado tiene su página", () => {
+    const sinPagina = MODULOS_ENTREGADOS.filter(
+      (modulo) => !existsSync(ficheroDe(modulo.ruta)),
+    );
+
+    expect(sinPagina.map((modulo) => modulo.clave)).toEqual([]);
+  });
+
+  it("lo que no está entregado tampoco tiene página suelta por ahí", () => {
+    // El caso contrario: una pantalla terminada que nadie ve porque se olvidó
+    // el `true`. Trabajo hecho y escondido.
+    const olvidados = MODULOS.filter(
+      (modulo) => !modulo.entregado && existsSync(ficheroDe(modulo.ruta)),
+    );
+
+    expect(olvidados.map((modulo) => modulo.clave)).toEqual([]);
+  });
+
+  it("cada módulo tiene su rótulo en castellano", () => {
+    for (const modulo of MODULOS) {
+      expect(copy.panel.modulos, `falta el rótulo de "${modulo.clave}"`).toHaveProperty(
+        modulo.clave,
+      );
+    }
+  });
+
+  it("no hay dos módulos en la misma ruta", () => {
+    const rutas = MODULOS.map((modulo) => modulo.ruta);
+    expect(new Set(rutas).size).toBe(rutas.length);
+  });
+
+  it("todos cuelgan del panel", () => {
+    for (const modulo of MODULOS) {
+      expect(modulo.ruta === RUTA_PANEL || modulo.ruta.startsWith(`${RUTA_PANEL}/`)).toBe(true);
+    }
+  });
+});
+
+describe("Qué módulo está activo", () => {
+  it("una ruta interna no se marca como el resumen", () => {
+    // `/panel` encaja con todo lo que cuelga de él. Sin buscar la coincidencia
+    // más larga, el menú señalaría siempre «Resumen» y dejaría de decir dónde
+    // está uno, que es su único trabajo.
+    expect(moduloActivo("/panel/cuenta")).toBe("cuenta");
+    expect(moduloActivo("/panel")).toBe("resumen");
+  });
+
+  it("una subruta hereda el módulo de su padre", () => {
+    expect(moduloActivo("/panel/cuenta/lo-que-venga")).toBe("cuenta");
+  });
+
+  it("lo que no es de nadie no marca nada", () => {
+    expect(moduloActivo("/acceso")).toBeNull();
+    // Un módulo sin entregar no puede salir marcado: no está en el menú.
+    expect(moduloActivo("/panel/invitados")).toBeNull();
+  });
+});


### PR DESCRIPTION
El marco donde van a vivir los ocho módulos del panel.

## Dos sitios muy distintos

En el portátil se planifica: sesiones largas saltando entre módulos, y el **lateral fijo** permite hacerlo sin perder de vista dónde está uno. En el móvil se consulta el día de la boda, con una mano y a menudo de pie, así que los destinos **bajan al alcance del pulgar** en lugar de esconderse tras un menú que hay que abrir.

Es la misma lista pintada dos veces con CSS, no dos componentes: un solo sitio donde añadir un módulo, y ningún riesgo de que el móvil se quede atrás.

La barra de móvil cuenta con `env(safe-area-inset-bottom)`. En un iPhone sin botón esa franja es el indicador de inicio, y sin contar con ella la última fila queda medio tapada por él.

## El menú enseña sólo lo terminado

Un menú con ocho módulos cuando funcionan dos no es una promesa: es una trampa. Se pincha en «Mesas», sale un hueco, y a partir de ahí ya no se sabe si lo que falla es la aplicación o la conexión.

`src/config/modulos.ts` lleva la lista con un `entregado` por módulo. Cada ticket cambia su `false` por `true` **en la misma PR que entrega su pantalla**, y `tests/unidad/modulos.test.ts` comprueba las dos direcciones: que lo marcado tiene página de verdad, y que no hay una pantalla terminada escondida por olvidar el `true`.

## «Mi cuenta» no es relleno

Escribe de verdad en `perfiles` y la cabecera del panel recoge el cambio en el momento. Quien decide si puede es RLS —`perfiles_propio_actualizar` deja tocar el nombre y sólo el nombre—, así que ni siquiera hace falta comprobar aquí de quién es la fila.

El rol se enseña pero no se toca. Un formulario que dejara ascenderse no sería un formulario, sería un agujero; la base ya lo impide con `perfiles_proteger_privilegios` y esto es simplemente no ofrecerlo.

## Carga y error, con pantalla propia

Sin `loading.tsx`, Next deja la pantalla anterior congelada mientras trae la siguiente: se pincha, no pasa nada visible, y se vuelve a pinchar. Sin `error.tsx`, un fallo dentro del panel sube hasta la raíz y se lleva por delante la navegación y la sesión.

El error **no enseña `error.message`**: puede llevar dentro una consulta, un nombre de tabla o el dato de un invitado. Eso va al registro, donde se puede investigar; a la pantalla va lo único que le sirve a quien mira.

## Lo que de verdad importa: el botón «atrás»

El panel se sirve con `Cache-Control: no-store`. Sin eso, cerrar sesión y darle a «atrás» devolvía la pantalla anterior tal cual — el navegador la tiene en su caché de historial y no vuelve a pedirla, así que ni el middleware ni RLS llegan a enterarse. Los datos ya no se pueden refrescar, pero están ahí. **En un portátil compartido, eso es la lista de invitados a la vista de quien lo coja después.**

Es el caso de error del ticket, y tiene su test.

## Dos cosas que conviene que sepas

**El menú tendrá dos entradas hasta que lleguen los módulos.** «Resumen» y «Mi cuenta». Es corto a propósito: es lo que hay terminado, y crecerá solo según entren los tickets.

**El resumen todavía no tiene números.** Los KPI son BODA-43 y llegan con su propia consulta. Ahora dice qué va a haber ahí, en lugar de enseñar unas cifras de mentira que habría que acordarse de quitar.

## Verificado

En local, contra PostgreSQL real: 51 unitarios y 85 E2E en Chromium, incluidos los nuevos. Lo que **no** he podido comprobar aquí es el aspecto del panel con sesión abierta —hace falta GoTrue, y la política de red de este entorno bloquea las imágenes de contenedor—, así que el repaso visual queda para el deploy preview. Los tests con sesión sí corren en el trabajo de CI que levanta el Supabase local, al que se añaden en esta PR.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks
- [x] Cero hardcode
- [x] Test E2E incluido: camino feliz **y** caso de error
- [ ] CI verde entero
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion`
- [ ] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

Closes #35

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_