### PR TITLE
fix: dos fallos que salieron al configurar el entorno de verdad

### DIFF
--- a/.github/workflows/migraciones.yml
+++ b/.github/workflows/migraciones.yml
@@ -47,14 +47,47 @@ jobs:
         env:
           TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           CLAVE: ${{ secrets.SUPABASE_DB_PASSWORD }}
-          PROYECTO: ${{ vars.SUPABASE_PROJECT_REF }}
+          # De la variable, o del secreto si alguien lo guardó ahí. El sitio
+          # bueno es Variables —no es un secreto, sale en la URL del dashboard,
+          # y como secreto los registros lo tapan justo cuando hace falta
+          # leerlo—, pero equivocarse de pestaña es facilísimo y el síntoma era
+          # un tic verde sin haber aplicado nada. Se acepta de los dos sitios y
+          # se avisa; que funcione no depende de acertar a la primera.
+          PROYECTO: ${{ vars.SUPABASE_PROJECT_REF || secrets.SUPABASE_PROJECT_REF }}
+          EN_VARIABLES: ${{ vars.SUPABASE_PROJECT_REF != '' }}
+        # SALTARSE ESTO EN SILENCIO SÓLO VALE CUANDO NADIE LO HA PEDIDO.
+        #
+        # Si el flujo salta solo al mergear a `main` y aún no hay credenciales,
+        # avisar y seguir es lo correcto: no tiene sentido teñir de rojo un
+        # despliegue por una configuración que todavía no está.
+        #
+        # Pero si alguien le ha dado al botón, ha pedido que se apliquen las
+        # migraciones. Devolverle un tic verde habiendo hecho nada es mentirle
+        # —pasó, y el aviso se perdió entre cien líneas de registro—, así que
+        # ahí se falla y se dice exactamente qué falta.
         run: |
-          if [ -n "$TOKEN" ] && [ -n "$CLAVE" ] && [ -n "$PROYECTO" ]; then
+          faltan=""
+          [ -z "$TOKEN" ]    && faltan="$faltan SUPABASE_ACCESS_TOKEN(secreto)"
+          [ -z "$CLAVE" ]    && faltan="$faltan SUPABASE_DB_PASSWORD(secreto)"
+          [ -z "$PROYECTO" ] && faltan="$faltan SUPABASE_PROJECT_REF(pestaña_Variables)"
+
+          if [ -z "$faltan" ]; then
             echo "hay=si" >> "$GITHUB_OUTPUT"
-          else
-            echo "hay=no" >> "$GITHUB_OUTPUT"
-            echo "::warning::Faltan SUPABASE_ACCESS_TOKEN, SUPABASE_DB_PASSWORD o la variable SUPABASE_PROJECT_REF. Ver docs/ENTORNO.md. Las migraciones no se aplican."
+            echo "proyecto=$PROYECTO" >> "$GITHUB_OUTPUT"
+            if [ "$EN_VARIABLES" != "true" ]; then
+              echo "::warning::SUPABASE_PROJECT_REF está en Secrets. Funciona, pero su sitio es la pestaña Variables: como secreto, los registros lo tapan con asteriscos justo cuando hace falta leerlo para depurar."
+            fi
+            exit 0
           fi
+
+          echo "hay=no" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::error::Se ha pedido aplicar las migraciones, pero falta:$faltan. Ver docs/ENTORNO.md. No se ha aplicado nada."
+            exit 1
+          fi
+
+          echo "::warning::Falta:$faltan. Ver docs/ENTORNO.md. Las migraciones no se aplican."
 
       - uses: supabase/setup-cli@v1
         if: steps.credenciales.outputs.hay == 'si'
@@ -65,7 +98,7 @@ jobs:
         if: steps.credenciales.outputs.hay == 'si'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: supabase link --project-ref "${{ vars.SUPABASE_PROJECT_REF }}"
+        run: supabase link --project-ref "${{ steps.credenciales.outputs.proyecto }}"
 
       - name: Ver qué se va a aplicar
         if: steps.credenciales.outputs.hay == 'si'

--- a/docs/ENTORNO.md
+++ b/docs/ENTORNO.md
@@ -20,18 +20,38 @@ solo están los **nombres**.
 **Settings → Environment Variables.** Marcar las tres ramas (Production,
 Preview, Development) salvo que se indique otra cosa.
 
-| Variable                        | De dónde se saca                                                                    |
-| ------------------------------- | ----------------------------------------------------------------------------------- |
-| `DATABASE_URL`                  | Supabase → Project Settings → Database → **Connection pooling**, modo `transaction` |
-| `NEXT_PUBLIC_SUPABASE_URL`      | Supabase → Project Settings → API → Project URL                                     |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase → Project Settings → API → `anon` `public`                                 |
-| `SUPABASE_SERVICE_ROLE_KEY`     | Supabase → Project Settings → API → `service_role` **secret**                       |
-| `NEXT_PUBLIC_SITE_URL`          | El dominio final de la web                                                          |
+| Variable                        | De dónde se saca                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                  | Botón **Connect** del dashboard → pestaña **Transaction pooler**                          |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Botón **Connect** → pestaña de frameworks, o Settings → **API Keys**                      |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Igual que la anterior: salen juntas                                                       |
+| `SUPABASE_SERVICE_ROLE_KEY`     | Settings → **API Keys** → `service_role`. **Todavía no hace falta**: ningún código la usa |
+| `NEXT_PUBLIC_SITE_URL`          | El dominio final de la web                                                                |
 
 **El pooler, no la conexión directa.** Cada petición a la web arranca una
 función efímera; con conexión directa se agotan las conexiones del servidor en
 cuanto hay algo de tráfico. El pooler en modo `transaction` está hecho
-exactamente para esto.
+exactamente para esto. Además, la directa sólo responde por IPv6 salvo que se
+contrate el add-on de IPv4, y las funciones de Vercel salen por IPv4.
+
+Se distinguen a simple vista, y confundirlas es el error habitual:
+
+|         | Directa                | Transaction pooler       |
+| ------- | ---------------------- | ------------------------ |
+| Usuario | `postgres`             | `postgres.<project-ref>` |
+| Host    | `db.<ref>.supabase.co` | `…pooler.supabase.com`   |
+| Puerto  | `5432`                 | `6543`                   |
+
+El modo `transaction` no admite sentencias preparadas; por eso
+`src/lib/bbdd/cliente.ts` va con `prepare: false`. Sin esa opción las consultas
+fallan de forma intermitente.
+
+**La contraseña lleva escapado de URL.** Si tiene `@`, `:`, `/`, `#` o `?` hay
+que codificarla, o la cadena se parte y el error habla de un host que no existe.
+
+**La misma contraseña vive en dos sitios**: dentro de `DATABASE_URL` en Vercel y
+suelta como `SUPABASE_DB_PASSWORD` en GitHub. Al rotarla hay que cambiar las
+dos; tocar sólo una deja el otro sistema fallando por autenticación.
 
 **`SUPABASE_SERVICE_ROLE_KEY` se salta todas las políticas RLS.** Nunca puede
 llevar el prefijo `NEXT_PUBLIC_`, porque eso la metería en el JavaScript que
@@ -87,11 +107,11 @@ lo único que necesita credenciales.
 
 **Settings → Secrets and variables → Actions.**
 
-| Dónde                     | Nombre                  | De dónde sale                                                      |
-| ------------------------- | ----------------------- | ------------------------------------------------------------------ |
-| Secrets                   | `SUPABASE_ACCESS_TOKEN` | supabase.com/dashboard/account/tokens → Generate new token         |
-| Secrets                   | `SUPABASE_DB_PASSWORD`  | La contraseña de la base, en Project Settings → Database           |
-| **Variables**, no secrets | `SUPABASE_PROJECT_REF`  | El identificador del proyecto, el que sale en la URL del dashboard |
+| Dónde                     | Nombre                  | De dónde sale                                                         |
+| ------------------------- | ----------------------- | --------------------------------------------------------------------- |
+| Secrets                   | `SUPABASE_ACCESS_TOKEN` | supabase.com/dashboard/account/tokens → Generate new token            |
+| Secrets                   | `SUPABASE_DB_PASSWORD`  | La contraseña de la base: **Database Settings**, `/database/settings` |
+| **Variables**, no secrets | `SUPABASE_PROJECT_REF`  | El identificador del proyecto, el que sale en la URL del dashboard    |
 
 El tercero va en _Variables_ y no en _Secrets_ porque no lo es: aparece en la
 URL del panel de Supabase. Guardarlo como secreto solo conseguiría que los

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Cormorant_Garamond, Jost } from "next/font/google";
 
 import { ATRIBUTO_TEMA, CLAVE_TEMA, IDIOMA } from "@/config/constants";
 import { t } from "@/lib/copy";
+import { urlDelSitio } from "@/lib/url-sitio";
 import "@/styles/globals.css";
 
 /**
@@ -24,23 +25,6 @@ const sans = Jost({
   variable: "--font-sans",
   display: "swap",
 });
-
-/**
- * `metadataBase` es lo que convierte la ruta de la imagen de Open Graph en una
- * URL absoluta. Sin ella, WhatsApp recibe una ruta relativa, no sabe resolverla
- * y enseña el enlace pelado — justo lo que este ticket quiere evitar.
- *
- * En Vercel, `VERCEL_URL` viene puesta en cada despliegue e incluye los
- * previews, así que la vista previa se puede comprobar antes de mergear. El
- * dominio final manda sobre ella cuando existe.
- */
-function urlDelSitio(): URL | undefined {
-  const propia = process.env.NEXT_PUBLIC_SITE_URL;
-  if (propia) return new URL(propia);
-
-  const vercel = process.env.VERCEL_PROJECT_PRODUCTION_URL ?? process.env.VERCEL_URL;
-  return vercel ? new URL(`https://${vercel}`) : undefined;
-}
 
 export const metadata: Metadata = {
   metadataBase: urlDelSitio(),

--- a/src/lib/url-sitio.ts
+++ b/src/lib/url-sitio.ts
@@ -1,0 +1,59 @@
+/**
+ * LA DIRECCIÓN DE LA WEB, LEÍDA CON INDULGENCIA
+ *
+ * `metadataBase` convierte la ruta de la imagen de Open Graph en una URL
+ * absoluta. Sin ella, WhatsApp recibe una ruta relativa, no sabe resolverla y
+ * enseña el enlace pelado.
+ *
+ * UNA VARIABLE MAL ESCRITA NO PUEDE TUMBAR EL BUILD, y lo hacía. Poner
+ * `midominio.com` en lugar de `https://midominio.com` es el descuido más fácil
+ * del mundo —el navegador perdona esa forma, `new URL()` no— y el resultado era
+ * un despliegue entero en rojo con un «invalid_url» que ni siquiera dice qué
+ * variable era. Pasó en producción.
+ *
+ * Es la misma decisión que en `src/lib/bbdd/cliente.ts`: por una variable de
+ * entorno se degrada lo que dependa de ella, nunca se tira la web abajo.
+ */
+
+/** `true` si la cadena ya trae `https://`, `http://` o cualquier otro esquema. */
+const TIENE_ESQUEMA = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Convierte en `URL` lo que haya escrito alguien, o devuelve `null` si no hay
+ * manera. Completa el esquema si falta: quien escribe sólo el dominio quiere
+ * decir `https`.
+ */
+export function leerUrl(valor: string | undefined | null): URL | null {
+  const limpio = valor?.trim();
+  if (!limpio) return null;
+
+  const conEsquema = TIENE_ESQUEMA.test(limpio) ? limpio : `https://${limpio}`;
+
+  try {
+    return new URL(conEsquema);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * El dominio del sitio. Manda `NEXT_PUBLIC_SITE_URL`; si no está o no hay quien
+ * la lea, se usa la que pone Vercel en cada despliegue —que incluye los
+ * previews, así que la vista previa se puede comprobar antes de mergear.
+ */
+export function urlDelSitio(): URL | undefined {
+  const propia = process.env.NEXT_PUBLIC_SITE_URL;
+  const leida = leerUrl(propia);
+
+  if (propia && !leida) {
+    console.error(
+      `NEXT_PUBLIC_SITE_URL no es una dirección válida: ${JSON.stringify(propia)}. ` +
+        "Se usa la de Vercel. Debe ser del estilo https://midominio.com",
+    );
+  }
+
+  if (leida) return leida;
+
+  const vercel = process.env.VERCEL_PROJECT_PRODUCTION_URL ?? process.env.VERCEL_URL;
+  return leerUrl(vercel) ?? undefined;
+}

--- a/tests/unidad/url-sitio.test.ts
+++ b/tests/unidad/url-sitio.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { leerUrl } from "../../src/lib/url-sitio";
+
+/**
+ * UNA VARIABLE MAL ESCRITA NO PUEDE TUMBAR EL BUILD
+ *
+ * Esto no es una precaución teórica: pasó. `NEXT_PUBLIC_SITE_URL` se puso como
+ * `midominio.com`, sin `https://`, y el despliegue entero se cayó con un
+ * «invalid_url» que ni siquiera decía qué variable era. El navegador perdona
+ * esa forma; `new URL()` no.
+ *
+ * Lo que se prueba aquí es que ningún valor —ni el descuidado, ni el absurdo—
+ * consigue lanzar. Devolver `null` degrada la vista previa al compartir; lanzar
+ * deja la boda sin web.
+ */
+
+describe("Leer la dirección del sitio", () => {
+  it("completa el esquema cuando falta, que es el descuido de siempre", () => {
+    expect(leerUrl("midominio.com")?.toString()).toBe("https://midominio.com/");
+    expect(leerUrl("p-d.vercel.app")?.toString()).toBe("https://p-d.vercel.app/");
+  });
+
+  it("respeta el esquema que ya venga", () => {
+    expect(leerUrl("https://midominio.com")?.protocol).toBe("https:");
+    // En local se trabaja con http, y no hay que reescribírselo a nadie.
+    expect(leerUrl("http://localhost:3000")?.toString()).toBe("http://localhost:3000/");
+  });
+
+  it("no se atraganta con espacios de un copiar y pegar", () => {
+    expect(leerUrl("  https://midominio.com  ")?.toString()).toBe("https://midominio.com/");
+  });
+
+  it("devuelve null en lugar de lanzar cuando no hay valor", () => {
+    expect(leerUrl(undefined)).toBeNull();
+    expect(leerUrl(null)).toBeNull();
+    expect(leerUrl("")).toBeNull();
+    expect(leerUrl("   ")).toBeNull();
+  });
+
+  it("ningún disparate consigue lanzar", () => {
+    // Si alguno de éstos lanzara, se llevaría por delante el despliegue.
+    for (const disparate of ["https://", "http://", "://roto", "https://espacio malo", "%%%"]) {
+      expect(() => leerUrl(disparate), disparate).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
Los dos aparecieron al poner las credenciales por primera vez, y los dos tenían la misma forma: **el sistema decía que todo iba bien cuando no era verdad**.

## 1. Una variable sin `https://` tumbaba el despliegue entero

`NEXT_PUBLIC_SITE_URL` puesta como `midominio.com` en lugar de `https://midominio.com`. El navegador perdona esa forma; `new URL()` no. Eso se evalúa al construir los metadatos del layout raíz, así que el build entero se caía con un `invalid_url` que **ni siquiera dice qué variable era**.

Ahora se completa el esquema si falta, se recortan los espacios de un copiar y pegar, y si aun así no hay quien la lea se sigue adelante con la dirección que pone Vercel, dejando el aviso en el registro. Lo que se degrada es la vista previa al compartir por WhatsApp; lo que no se hace es dejar la boda sin web por una variable cosmética.

Es exactamente la decisión que ya estaba tomada en `src/lib/bbdd/cliente.ts` para `DATABASE_URL` —«un despliegue sin la variable levanta igual»— aplicada donde faltaba.

La lógica sale del layout a `src/lib/url-sitio.ts` para poder probarla. El test incluye los disparates (`https://`, `://roto`, espacios en medio) porque cualquiera de ellos lanzando se lleva por delante el despliegue.

## 2. Un flujo de migraciones que no aplica nada salía en verde

Se lanzó a mano y terminó con un tic verde habiendo hecho **exactamente nada**: faltaba `SUPABASE_PROJECT_REF` y el aviso se perdió entre cien líneas de registro. Un verde que significa «no he hecho nada» es peor que un rojo, porque nadie lo va a mirar.

Ahora se distingue **quién preguntó**:

- Si el flujo salta solo al mergear a `main` y todavía no hay credenciales, avisa y sigue. No tiene sentido teñir de rojo un despliegue por una configuración que aún no está.
- Si alguien le ha dado al botón, ha pedido que se apliquen las migraciones. Falla, y dice cuál de los tres valores falta.

Y el identificador del proyecto se acepta también desde *Secrets*, no sólo desde *Variables*. Su sitio sigue siendo Variables —no es un secreto, sale en la URL del dashboard, y guardado como secreto los registros lo tapan justo cuando hace falta leerlo—, pero equivocarse de pestaña es facilísimo y el síntoma era mudo. Ahora funciona igual y avisa de dónde está.

## 3. La documentación del entorno estaba desfasada

«Project Settings → Database» ya no existe en Supabase. Se corrigen los caminos y se añade lo que hace falta para no equivocarse de cadena: la tabla que distingue la conexión directa del pooler por usuario, host y puerto —que es justo donde se falla—, por qué el cliente lleva `prepare: false`, que la contraseña necesita escapado de URL, y que la misma contraseña vive en Vercel y en GitHub y hay que rotarla en los dos sitios.

`SUPABASE_SERVICE_ROLE_KEY` queda marcada como **no necesaria todavía**: está documentada pero ningún código la usa, y es la clave que se salta todas las políticas RLS.

## Verificado

Reproducido el fallo del build con el valor exacto que lo rompía, y comprobado que con el arreglo el build termina. 56 unitarios y el resto de comprobaciones en verde en local.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127nJGGpuqxFYLCWVhy5av9)_