### PR TITLE
feat(BODA-15): la marca pasa a la versión azul marino

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@ playwright-report
 test-results
 .claude/skills
 src/config/tokens.generado.ts
+
+# Entrega del estudio de marca: material de referencia, se versiona tal cual llegó.
+Sistema completo de boda

--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -137,7 +137,7 @@
     "seccionComponentes": "Componentes",
     "grupoSuperficies": "Superficies",
     "grupoTinta": "Texto",
-    "grupoMarca": "Marca y acento",
+    "grupoMarca": "Marca, acción y acento",
     "grupoBordes": "Bordes",
     "grupoEstado": "Estado",
     "temaClaro": "Claro",

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -25,20 +25,24 @@ de aviso.
 **Épicas** — las decenas del código `BODA-XX` coinciden con la épica, así que el
 número ya dice de qué va:
 
-| Etiqueta              | Códigos          | Qué agrupa                                   |
-| --------------------- | ---------------- | -------------------------------------------- |
-| `e1-cimientos`        | `BODA-01` → `06` | Proyecto, tokens, copys, calidad, despliegue |
-| `e2-base-de-datos`    | `BODA-10` → `14` | Esquema, RLS y funciones públicas            |
-| `e3-landing`          | `BODA-20` → `29` | La web que ven los invitados                 |
-| `e4-save-the-date`    | `BODA-30` → `32` | Reserva de fecha y calendario                |
-| `e5-auth-y-panel`     | `BODA-40` → `43` | Acceso privado y esqueleto del panel         |
-| `e6-invitados-y-rsvp` | `BODA-50` → `58` | Invitados y confirmaciones                   |
-| `e7-presupuesto`      | `BODA-60` → `64` | Partidas, pagos y desvíos                    |
-| `e8-proveedores`      | `BODA-70` → `74` | Proveedores, contratos y servicios           |
-| `e9-tareas-y-mesas`   | `BODA-80` → `84` | Tareas y plano de mesas                      |
-| `e10-produccion`      | `BODA-90` → `95` | Rendimiento, accesibilidad, SEO y respaldos  |
-| `e11-dia-de-la-boda`  | `BODA-100`→`104` | Lo que se usa el día D, desde el móvil       |
-| `e12-comunicacion`    | `BODA-110`→`113` | Envíos, recordatorios y mensajes             |
+| Etiqueta              | Códigos                       | Qué agrupa                                   |
+| --------------------- | ----------------------------- | -------------------------------------------- |
+| `e1-cimientos`        | `BODA-01` → `08`, `15` → `19` | Proyecto, tokens, copys, calidad, despliegue |
+| `e2-base-de-datos`    | `BODA-10` → `14`              | Esquema, RLS y funciones públicas            |
+| `e3-landing`          | `BODA-20` → `29`              | La web que ven los invitados                 |
+| `e4-save-the-date`    | `BODA-30` → `32`              | Reserva de fecha y calendario                |
+| `e5-auth-y-panel`     | `BODA-40` → `43`              | Acceso privado y esqueleto del panel         |
+| `e6-invitados-y-rsvp` | `BODA-50` → `58`              | Invitados y confirmaciones                   |
+| `e7-presupuesto`      | `BODA-60` → `64`              | Partidas, pagos y desvíos                    |
+| `e8-proveedores`      | `BODA-70` → `74`              | Proveedores, contratos y servicios           |
+| `e9-tareas-y-mesas`   | `BODA-80` → `84`              | Tareas y plano de mesas                      |
+| `e10-produccion`      | `BODA-90` → `95`              | Rendimiento, accesibilidad, SEO y respaldos  |
+| `e11-dia-de-la-boda`  | `BODA-100`→`104`              | Lo que se usa el día D, desde el móvil       |
+| `e12-comunicacion`    | `BODA-110`→`113`              | Envíos, recordatorios y mensajes             |
+
+La decena de E1 se llenó (`BODA-09` se lo quedó un ticket de landing), así que
+los cimientos continúan en `15` → `19`, que es el hueco libre que dejó E2. La
+etiqueta manda sobre el número: si los dos discrepan, se mira la etiqueta.
 
 **Tallas** — `talla-s` medio día · `talla-m` un día · `talla-l` dos días.
 

--- a/docs/PLAN-MAESTRO.md
+++ b/docs/PLAN-MAESTRO.md
@@ -42,13 +42,13 @@ Arquitectura de tres capas. Una capa solo consume la anterior; nunca se salta ni
 
 ```
 ┌─ Capa 1 — Primitivos ────────────────────────────────┐
-│  --color-sage-500, --font-size-8, --space-6          │  Valores crudos. Sin semántica.
+│  --color-marino-500, --color-bronce-600, --space-6   │  Valores crudos. Sin semántica.
 │  Fuente única de verdad. Solo aquí hay literales.    │  No se usan en componentes.
 └───────────────────────┬──────────────────────────────┘
                         ▼
 ┌─ Capa 2 — Semánticos ────────────────────────────────┐
-│  --color-surface, --color-text-muted,                │  Qué significa el valor.
-│  --color-accent, --space-section, --radius-card      │  Aquí vive el tema claro/oscuro.
+│  --superficie, --tinta-tenue, --acento,              │  Qué significa el valor.
+│  --espacio-seccion, --radio-tarjeta                  │  Aquí vive el tema claro/oscuro.
 └───────────────────────┬──────────────────────────────┘
                         ▼
 ┌─ Capa 3 — Componente ────────────────────────────────┐
@@ -57,7 +57,22 @@ Arquitectura de tres capas. Una capa solo consume la anterior; nunca se salta ni
 └──────────────────────────────────────────────────────┘
 ```
 
-- Los tokens se definen en `src/styles/tokens/` y se exponen a Tailwind vía `@theme` (Tailwind v4), de modo que `bg-surface` y `var(--color-surface)` son el mismo token. **Una sola fuente, dos sintaxis.**
+**La paleta es la versión azul marino del sistema de marca.** El estudio entregó
+la identidad en dos versiones —verde oliva y azul marino— y se monta la azul;
+la entrega completa está en `Sistema completo de boda/`, y de su tabla de tokens
+salen uno a uno los valores de `primitives.css`. Cambiar de versión es reescribir
+ese fichero y nada más: ningún componente nombra un color.
+`tests/unidad/paleta.test.ts` compara las dos capas contra esa tabla, así que la
+web no puede separarse de la cartelería impresa sin que el CI lo diga.
+
+**Marca, acción y acento son tres cosas distintas.** La marca (marino) es el
+color de la identidad; la acción (`--accion`) es el relleno del botón primario;
+el acento (`--acento`) es el bronce, el único color cálido, y aparece a gotas —la
+versalita de la portada, el conector «y», las citas, las horas del programa y el
+aro de foco—. Mezclar acción y acento en un solo token, como estaba, hace que el
+acento deje de existir: el botón se lo come.
+
+- Los tokens se definen en `src/styles/tokens/` y se exponen a Tailwind vía `@theme` (Tailwind v4), de modo que `bg-superficie` y `var(--superficie)` son el mismo token. **Una sola fuente, dos sintaxis.**
 - Prohibido en componentes: `#hex`, `rgb()`, `px` sueltos (salvo `1px` de borde), `text-[14px]`, `bg-[#fff]`.
 - Tema claro/oscuro y variantes estacionales se resuelven **reasignando semánticos**, nunca tocando componentes.
 - Movimiento: duraciones y easings también son tokens (`--duration-slow`, `--ease-out-expo`), y todo respeta `prefers-reduced-motion`.
@@ -361,7 +376,7 @@ Variables de entorno (Vercel, nunca en git): `DATABASE_URL` (cadena del pooler d
 Ninguna bloquea la Fase 0; se resuelven antes de la fase indicada.
 
 1. **Dominio** — ¿comprado ya? Necesario en Fase 3 (Save the Date). _Vercel o Cloudflare como registrador._
-2. **Dirección de arte** — paleta, tipografías y tono. Determina los valores de los tokens primitivos (no su estructura), así que la Fase 0 puede arrancar con una paleta provisional.
+2. ~~**Dirección de arte**~~ — _resuelta._ El estudio entregó la identidad completa (`Sistema completo de boda/`) en dos versiones, y se monta la **azul marino**: marino `#1F2B44`, acento bronce `#8A6224`, Cormorant Infant y Jost. Los valores están transcritos en `primitives.css`; ver §2.2.
 3. **Fotos** — ¿hay sesión de preboda? Condiciona el diseño del hero y la galería.
 4. **Regalo** — ¿cuenta bancaria, Bizum, lista? Afecta a una sección de la landing.
 5. **Colaboradores** — ¿acceso para wedding planner o familiares? El rol `viewer` ya lo contempla.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,6 +105,16 @@ const eslintConfig = defineConfig([
     "test-results/**",
     // Skills de diseño de terceros: se versionan tal cual llegan del origen.
     ".claude/skills/**",
+    /**
+     * La entrega del estudio de marca: las piezas en HTML, sus SVG y el runtime
+     * de la herramienta con la que se hicieron. Es material de referencia, no
+     * código del proyecto — de ahí salen los valores de `primitives.css`, pero
+     * nada de esto se compila ni se despliega.
+     *
+     * Se versiona tal cual llegó: reformatearlo o "arreglarlo" rompería la
+     * única copia fiel del diseño que tenemos.
+     */
+    "Sistema completo de boda/**",
   ]),
 ]);
 

--- a/scripts/generar-tokens.mjs
+++ b/scripts/generar-tokens.mjs
@@ -8,7 +8,7 @@
  * valores literales.
  *
  * La tentación es escribirlos a mano y ya. Eso es exactamente lo que prohíbe la
- * regla 1: al día siguiente la web es oliva y la imagen que sale en WhatsApp
+ * regla 1: al día siguiente la web es marino y la imagen que sale en WhatsApp
  * sigue siendo del color de antes, sin que nadie se entere.
  *
  * Así que se leen del propio CSS y se resuelven las dos capas —semántico →
@@ -37,7 +37,7 @@ function sinComentarios(css) {
   return css.replace(/\/\*[\s\S]*?\*\//g, "");
 }
 
-/** `--color-oliva-700: #3c4233;` → { "color-oliva-700": "#3c4233" } */
+/** `--color-marino-700: #1f2b44;` → { "color-marino-700": "#1f2b44" } */
 function declaracionesDe(bloque) {
   const mapa = new Map();
   for (const [, nombre, valor] of bloque.matchAll(/--([\w-]+)\s*:\s*([^;]+);/g)) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -207,14 +207,14 @@ function Portada({ configuracion }: { configuracion: ConfiguracionBoda }) {
     >
       <div className="mx-auto w-full max-w-contenido">
         {procedencia ? (
-          <p className="animacion-aparecer text-etiqueta uppercase tracking-marcado text-tinta-tenue">
+          <p className="animacion-aparecer text-etiqueta uppercase tracking-marcado text-acento">
             {procedencia}
           </p>
         ) : null}
 
         <Display className="animacion-subir mt-pila">{configuracion.nombreNovia}</Display>
         <div className="animacion-subir flex flex-wrap items-baseline gap-elemento">
-          <span className="font-titulo text-titulo-1 italic text-marca">
+          <span className="font-titulo text-titulo-1 italic text-acento">
             {t("portada.conjuncion")}
           </span>
           <Display como="p">{configuracion.nombreNovio}</Display>
@@ -322,7 +322,7 @@ function Programa({
             key={hito.id}
             className="animacion-subir-al-ver rejilla-dato gap-elemento border-b border-borde py-elemento"
           >
-            <span className="font-titulo text-titulo-3 text-marca tabular-nums">
+            <span className="font-titulo text-titulo-3 text-acento tabular-nums">
               {hito.hora}
             </span>
             <div>

--- a/src/app/reserva-la-fecha/page.tsx
+++ b/src/app/reserva-la-fecha/page.tsx
@@ -96,7 +96,7 @@ export default async function PaginaReservaLaFecha() {
             lector de pantalla partirlo en dos encabezados no significa nada. */}
         <h1 className="mt-pila font-titulo text-display leading-display tracking-display">
           {configuracion.nombreNovia}
-          <span className="block text-titulo-1 italic text-marca">
+          <span className="block text-titulo-1 italic text-acento">
             {t("portada.conjuncion")}
           </span>
           {configuracion.nombreNovio}

--- a/src/components/ui/boton.tsx
+++ b/src/components/ui/boton.tsx
@@ -4,9 +4,13 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react";
 /**
  * BOTÓN
  *
- * Tres jerarquías, como manda el sistema de marca: primario (relleno oliva),
+ * Tres jerarquías, como manda el sistema de marca: primario (relleno marino),
  * secundario (contorno) y terciario (texto subrayado). Nada más — un cuarto
  * estilo sería ruido.
+ *
+ * El relleno del primario sale de `--accion`, no de `--acento`: el acento es
+ * el bronce, y un botón entero de bronce convertiría el único color cálido del
+ * sistema en el elemento más ruidoso de la página.
  *
  * Solo usa tokens semánticos: en un bloque `[data-seccion="inversa"]` los
  * mismos colores se reasignan y el botón se adapta sin tocar una clase.
@@ -22,7 +26,7 @@ const BASE =
 
 const JERARQUIAS: Record<JerarquiaBoton, string> = {
   primario:
-    "min-h-control rounded-boton bg-acento px-elemento text-tinta-sobre-acento hover:bg-acento-hover",
+    "min-h-control rounded-boton bg-accion px-elemento text-tinta-sobre-accion hover:bg-accion-hover",
   secundario:
     "min-h-control rounded-boton border border-borde-fuerte px-elemento text-tinta-marca hover:border-borde-marca hover:bg-superficie-hundida",
   terciario:

--- a/src/components/ui/tipografia.tsx
+++ b/src/components/ui/tipografia.tsx
@@ -97,7 +97,14 @@ export function Etiqueta({
   );
 }
 
-/** Cursiva serif: las frases que respiran, nunca para información esencial. */
+/**
+ * Cursiva serif: las frases que respiran, nunca para información esencial.
+ *
+ * Va en el acento, como manda la escala tipográfica de la entrega
+ * (`--texto-cita · color acento`). Es de los pocos sitios donde el bronce
+ * aparece, y por eso la cita se lee como una voz distinta y no como un párrafo
+ * más en cursiva.
+ */
 export function Cita({
   children,
   className = "",
@@ -106,7 +113,7 @@ export function Cita({
   className?: string;
 }) {
   return (
-    <p className={`font-titulo text-cita italic leading-cita text-tinta-suave ${className}`}>
+    <p className={`font-titulo text-cita italic leading-cita text-acento ${className}`}>
       {children}
     </p>
   );

--- a/src/config/tokens.generado.ts
+++ b/src/config/tokens.generado.ts
@@ -12,20 +12,20 @@
 
 export const PALETAS = {
   "claro": {
-    "fondo": "#fbfaf8",
+    "fondo": "#f8f9fc",
     "superficie": "#fff",
-    "tinta": "#14140f",
-    "tinta-suave": "#4a4a45",
-    "marca": "#6b7060",
-    "borde": "#e6e4df"
+    "tinta": "#121722",
+    "tinta-suave": "#434e63",
+    "marca": "#3f4f70",
+    "borde": "#dfe4ec"
   },
   "inversa": {
-    "fondo": "#3c4233",
-    "superficie": "#2e3327",
-    "tinta": "#f1efe7",
-    "tinta-suave": "#c9cdbc",
-    "marca": "#a9af98",
-    "borde": "#454a3c"
+    "fondo": "#1f2b44",
+    "superficie": "#16213a",
+    "tinta": "#eef2f8",
+    "tinta-suave": "#c3cee1",
+    "marca": "#9db0ce",
+    "borde": "#2c3a56"
   }
 } as const;
 

--- a/src/config/tokens.ts
+++ b/src/config/tokens.ts
@@ -42,9 +42,10 @@ export const GRUPOS_COLOR: readonly GrupoTokens[] = [
       "marca-hover",
       "marca-activo",
       "marca-tenue",
+      "accion",
+      "accion-hover",
       "acento",
       "acento-hover",
-      "acento-tenue",
     ],
   },
   {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,9 +4,11 @@
 @import "./tokens/motion.css";
 
 /**
- * Las carpetas de skills son documentación de terceros con ejemplos de código.
- * Sin excluirlas, Tailwind las escanea y mete en el CSS de producción
- * utilidades que ningún componente nuestro usa.
+ * Las carpetas de skills son documentación de terceros con ejemplos de código,
+ * y la del estudio de marca son las piezas del diseño en HTML, con sus estilos
+ * escritos a mano. Sin excluirlas, Tailwind las escanea y mete en el CSS de
+ * producción utilidades que ningún componente nuestro usa: casi un megabyte de
+ * HTML ajeno decidiendo lo que descarga cada invitado.
  *
  * Ojo con la notación de los `@import` de arriba: deben ir entre comillas.
  * Tailwind no resuelve `@import url(...)`, y si alguien los reescribe a esa
@@ -14,6 +16,7 @@
  */
 @source not "../../.claude";
 @source not "../../.agents";
+@source not "../../Sistema completo de boda";
 
 /**
  * PUENTE CON TAILWIND
@@ -59,16 +62,18 @@
   --color-tinta-inversa: var(--tinta-inversa);
   --color-tinta-marca: var(--tinta-marca);
   --color-tinta-sobre-marca: var(--tinta-sobre-marca);
+  --color-tinta-sobre-accion: var(--tinta-sobre-accion);
   --color-tinta-sobre-acento: var(--tinta-sobre-acento);
 
-  /* Marca */
+  /* Marca, acción y acento */
   --color-marca: var(--marca);
   --color-marca-hover: var(--marca-hover);
   --color-marca-activo: var(--marca-activo);
   --color-marca-tenue: var(--marca-tenue);
+  --color-accion: var(--accion);
+  --color-accion-hover: var(--accion-hover);
   --color-acento: var(--acento);
   --color-acento-hover: var(--acento-hover);
-  --color-acento-tenue: var(--acento-tenue);
 
   /* Bordes */
   --color-borde: var(--borde);

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -8,56 +8,77 @@
  * semántica (semantic.css). Si necesitas un valor de aquí en un componente,
  * significa que falta un token semántico.
  *
- * Fuente: sistema de marca de Paloma y David. Los valores son los del diseño,
- * transcritos uno a uno — no aproximaciones. Editorial minimalista: el color
- * casi desaparece, el peso lo llevan la tipografía, el aire y las fotos.
+ * Fuente: sistema de marca de Paloma y David, **versión azul marino**
+ * (`Sistema de marca azul.dc.html` y la hoja de entrega para Figma). Los
+ * valores son los del diseño, transcritos uno a uno — no aproximaciones.
+ * Editorial minimalista: el color casi desaparece, el peso lo llevan la
+ * tipografía, el aire y las fotos.
+ *
+ * La marca tiene dos versiones entregadas, verde oliva y azul marino. Se monta
+ * la azul. Volver a la otra es reescribir ESTE fichero y nada más: ni un
+ * componente nombra un color.
  *
  * Escalas ordenadas de claro (número bajo) a oscuro (número alto).
  */
 
 :root {
   /* ---------------------------------------------------------------------
-   * Color — oliva: el color de la marca
+   * Color — marino: el color de la marca
+   *
+   * `500` es el trazo («marca media» en la entrega) y `700` la superficie
+   * oscura que llevan la portada, el bloque de confirmación y los botones
+   * primarios.
    * ------------------------------------------------------------------- */
 
-  --color-oliva-100: #eceee8;
-  --color-oliva-200: #c9cdbc;
-  --color-oliva-300: #b4b9a4;
-  --color-oliva-350: #a9af98;
-  --color-oliva-400: #9aa089;
-  --color-oliva-420: #9ba08c;
-  --color-oliva-450: #8b917c;
-  --color-oliva-500: #6b7060;
-  --color-oliva-600: #454a3c;
-  --color-oliva-700: #3c4233;
-  --color-oliva-750: #2e3327;
-  --color-oliva-800: #2a2f23;
-  --color-oliva-850: #23271e;
-  --color-oliva-875: #1f2318;
-  --color-oliva-900: #1b1e17;
-  --color-oliva-950: #14170f;
-  --color-oliva-975: #101309;
+  --color-marino-100: #e7ecf3;
+  --color-marino-200: #c3cee1;
+  --color-marino-300: #aec0da;
+  --color-marino-350: #9db0ce;
+  --color-marino-400: #8fa0bc;
+  --color-marino-420: #8b97ac;
+  --color-marino-450: #7e8aa0;
+  --color-marino-500: #3f4f70;
+  --color-marino-600: #2c3a56;
+  --color-marino-700: #1f2b44;
+  --color-marino-750: #1c2434;
+  --color-marino-775: #16213a;
+  --color-marino-800: #141e33;
+  --color-marino-850: #151c2b;
+  --color-marino-900: #101623;
+  --color-marino-950: #0b1120;
 
   /* ---------------------------------------------------------------------
-   * Color — crema y hueso: el aire
+   * Color — bronce: el acento
+   *
+   * El único color cálido del sistema y lo que distingue de verdad a la
+   * versión azul: sobre tanto marino, un acento frío no se despega. Se usa con
+   * cuentagotas — la versalita de la portada, el conector, las citas y el aro
+   * de foco— y nunca como relleno de un botón.
    * ------------------------------------------------------------------- */
 
-  --color-crema-50: #fbfaf8;
-  --color-crema-100: #f4f3f0;
-  --color-crema-150: #f1efe7;
-  --color-crema-200: #e9e4d8;
-  --color-hueso-300: #e6e4df;
-  --color-hueso-350: #dedacb;
-  --color-hueso-400: #c9c5b8;
+  --color-bronce-200: #f0d6ac;
+  --color-bronce-300: #e3be86;
+  --color-bronce-500: #a97634;
+  --color-bronce-600: #8a6224;
 
   /* ---------------------------------------------------------------------
-   * Color — carbón: texto y superficies inversas
+   * Color — nieve y bruma: el aire
    * ------------------------------------------------------------------- */
 
-  --color-carbon-400: #8a8a84;
-  --color-carbon-600: #4a4a45;
-  --color-carbon-900: #14140f;
-  --color-carbon-950: #121210;
+  --color-nieve-50: #f8f9fc;
+  --color-nieve-100: #eef2f8;
+  --color-nieve-150: #eef1f6;
+  --color-bruma-300: #dfe4ec;
+  --color-bruma-400: #b7c0d0;
+
+  /* ---------------------------------------------------------------------
+   * Color — pizarra: texto y superficies inversas
+   * ------------------------------------------------------------------- */
+
+  --color-pizarra-400: #78839a;
+  --color-pizarra-600: #434e63;
+  --color-pizarra-900: #121722;
+  --color-pizarra-950: #0d1220;
 
   /* ---------------------------------------------------------------------
    * Color — estado. Nunca decorativo: solo comunica.
@@ -78,6 +99,13 @@
 
   --color-blanco: #fff;
   --color-negro: #000;
+
+  /**
+   * Los velos y las sombras van en un negro neutro, no en tinta marino. Es
+   * decisión de la entrega, que da una sola receta de sombra para las dos
+   * versiones de la marca: una sombra teñida del color de la paleta delata el
+   * truco en cuanto cae sobre una foto, porque la foto no está teñida.
+   */
   --color-velo-suave: rgb(20 20 15 / 25%);
   --color-velo-medio: rgb(20 20 15 / 55%);
   --color-velo-fuerte: rgb(20 20 15 / 72%);
@@ -88,12 +116,12 @@
    * como una barra fija sobre una portada a pantalla completa. El alfa es alto
    * a propósito: por debajo, el texto encima deja de cumplir contraste.
    *
-   * Mismos valores que `--color-crema-50` y `--color-oliva-950`, que son los
+   * Mismos valores que `--color-nieve-50` y `--color-marino-900`, que son los
    * dos fondos de página. Van escritos porque `rgb(from …)` todavía no llega a
    * todos los navegadores que abre un invitado desde WhatsApp.
    */
-  --color-velado-crema: rgb(251 250 248 / 86%);
-  --color-velado-oliva: rgb(20 23 15 / 86%);
+  --color-velado-nieve: rgb(248 249 252 / 86%);
+  --color-velado-marino: rgb(16 22 35 / 86%);
 
   /* ---------------------------------------------------------------------
    * Tipografía — Cormorant Garamond para titulares, Jost para cuerpo

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -7,66 +7,85 @@
  * REGLA: aquí no hay literales, solo referencias a primitivos. Si aparece un
  * valor literal en este fichero, es que falta un primitivo.
  *
- * Los nombres y la asignación vienen del sistema de marca de Paloma y David.
- * El tema oscuro se resuelve reasignando estos tokens: ningún componente sabe
- * qué tema está activo, ni le hace falta.
+ * Los nombres y la asignación vienen de la tabla de tokens del sistema de
+ * marca de Paloma y David, versión azul marino. El tema oscuro se resuelve
+ * reasignando estos tokens: ningún componente sabe qué tema está activo, ni le
+ * hace falta.
  *
  * Nomenclatura: los colores de texto se llaman `tinta` para no confundirse con
  * los tamaños de texto (`--texto-titulo-1`, que es una escala tipográfica).
+ *
+ * ACENTO Y ACCIÓN son dos cosas distintas, y conviene no repetir el error de
+ * mezclarlas. El acento es el bronce: aparece en gotas —la versalita de la
+ * portada, el conector, las citas, el aro de foco— y nunca rellena nada. La
+ * acción es el marino a plena potencia: el relleno del botón primario. Cuando
+ * un solo token hacía las dos cosas, el acento sencillamente no existía.
  */
 
 :root {
   /* --- Superficies --------------------------------------------------- */
-  --fondo: var(--color-crema-50);
+  --fondo: var(--color-nieve-50);
   --superficie: var(--color-blanco);
   --superficie-elevada: var(--color-blanco);
-  --superficie-hundida: var(--color-crema-100);
-  --superficie-tenue: var(--color-oliva-100);
-  --superficie-inversa: var(--color-carbon-950);
+  --superficie-hundida: var(--color-nieve-150);
+  --superficie-tenue: var(--color-marino-100);
+  --superficie-inversa: var(--color-pizarra-950);
 
   /**
    * Fondo de la barra de navegación. Translúcido porque se apoya sobre la
    * portada a pantalla completa: opaco, cortaría la foto con una franja.
    */
-  --superficie-cabecera: var(--color-velado-crema);
+  --superficie-cabecera: var(--color-velado-nieve);
 
   /* --- Texto --------------------------------------------------------- */
-  --tinta: var(--color-carbon-900);
-  --tinta-suave: var(--color-carbon-600);
-  --tinta-tenue: var(--color-carbon-400);
-  --tinta-inversa: var(--color-crema-50);
-  --tinta-marca: var(--color-oliva-700);
-  --tinta-sobre-marca: var(--color-crema-50);
-  --tinta-sobre-acento: var(--color-crema-50);
+  --tinta: var(--color-pizarra-900);
+  --tinta-suave: var(--color-pizarra-600);
+  --tinta-tenue: var(--color-pizarra-400);
+  --tinta-inversa: var(--color-nieve-50);
+  --tinta-marca: var(--color-marino-700);
+  --tinta-sobre-marca: var(--color-nieve-50);
+  --tinta-sobre-accion: var(--color-nieve-50);
+  --tinta-sobre-acento: var(--color-nieve-50);
 
-  /* --- Marca y acento ------------------------------------------------ */
-  --marca: var(--color-oliva-500);
-  --marca-hover: var(--color-oliva-600);
-  --marca-activo: var(--color-oliva-750);
-  --marca-tenue: var(--color-oliva-100);
-  --acento: var(--color-oliva-700);
-  --acento-hover: var(--color-oliva-875);
-  --acento-tenue: var(--color-oliva-100);
+  /* --- Marca --------------------------------------------------------- */
+  --marca: var(--color-marino-500);
+  --marca-hover: var(--color-marino-600);
+  --marca-activo: var(--color-marino-775);
+  --marca-tenue: var(--color-marino-100);
+
+  /* --- Acción (relleno del botón primario) ---------------------------- */
+  --accion: var(--color-marino-700);
+  --accion-hover: var(--color-pizarra-900);
+
+  /* --- Acento (el bronce, a gotas) ------------------------------------ */
+  --acento: var(--color-bronce-600);
+  --acento-hover: var(--color-bronce-500);
 
   /* --- Bordes -------------------------------------------------------- */
-  --borde: var(--color-hueso-300);
-  --borde-fuerte: var(--color-hueso-400);
-  --borde-tenue: var(--color-crema-100);
-  --borde-marca: var(--color-oliva-420);
+  --borde: var(--color-bruma-300);
+  --borde-fuerte: var(--color-bruma-400);
+  --borde-tenue: var(--color-nieve-150);
+  --borde-marca: var(--color-marino-420);
 
   /* --- Estado -------------------------------------------------------- */
   --exito: var(--color-exito-claro);
   --exito-fondo: var(--color-exito-fondo-claro);
   --exito-tinta: var(--color-exito-claro);
   --aviso: var(--color-aviso-claro);
-  --aviso-fondo: var(--color-crema-100);
+  --aviso-fondo: var(--color-nieve-150);
   --aviso-tinta: var(--color-aviso-claro);
   --error: var(--color-error-claro);
   --error-fondo: var(--color-error-fondo-claro);
   --error-tinta: var(--color-error-claro);
 
-  /* --- Foco (accesibilidad) ------------------------------------------ */
-  --foco: var(--color-oliva-500);
+  /**
+   * --- Foco (accesibilidad) -------------------------------------------
+   *
+   * El aro va en bronce, como en la entrega. No es capricho: en marino sobre
+   * marino el aro se confunde con el propio botón, y el acento es el único
+   * color del sistema que se despega de los dos fondos, el claro y el oscuro.
+   */
+  --foco: var(--color-bronce-600);
   --foco-ancho: var(--border-width-2);
   --foco-separacion: var(--space-linea);
 
@@ -164,139 +183,148 @@
  * Solo reasigna semánticos. Ningún componente se entera del cambio.
  * Sin atributo se respeta la preferencia del sistema; `[data-tema]` la fuerza.
  *
- * Ojo: en oscuro el acento se invierte — pasa a ser el crema, porque sobre
- * fondo oliva oscuro el propio oliva ya no destaca.
+ * Sobre fondo marino oscuro, el marino de la marca ya no destaca: la acción se
+ * invierte y pasa a rellenarse con el tono más pálido de la escala, con tinta
+ * oscura encima. El acento sube de bronce oscuro a bronce claro por lo mismo.
  */
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-tema="claro"]) {
-    --fondo: var(--color-oliva-950);
-    --superficie: var(--color-oliva-900);
-    --superficie-elevada: var(--color-oliva-850);
-    --superficie-hundida: var(--color-oliva-975);
-    --superficie-tenue: var(--color-oliva-750);
-    --superficie-inversa: var(--color-crema-50);
-    --superficie-cabecera: var(--color-velado-oliva);
-    --tinta: var(--color-crema-150);
-    --tinta-suave: var(--color-oliva-200);
-    --tinta-tenue: var(--color-oliva-450);
-    --tinta-inversa: var(--color-carbon-900);
-    --tinta-marca: var(--color-oliva-350);
-    --tinta-sobre-marca: var(--color-carbon-900);
-    --tinta-sobre-acento: var(--color-carbon-900);
-    --marca: var(--color-oliva-400);
-    --marca-hover: var(--color-oliva-300);
-    --marca-activo: var(--color-oliva-200);
-    --marca-tenue: var(--color-oliva-800);
-    --acento: var(--color-crema-200);
-    --acento-hover: var(--color-crema-50);
-    --acento-tenue: var(--color-oliva-800);
-    --borde: var(--color-oliva-750);
-    --borde-fuerte: var(--color-oliva-600);
-    --borde-tenue: var(--color-oliva-850);
-    --borde-marca: var(--color-oliva-500);
+    --fondo: var(--color-marino-900);
+    --superficie: var(--color-marino-850);
+    --superficie-elevada: var(--color-marino-750);
+    --superficie-hundida: var(--color-marino-950);
+    --superficie-tenue: var(--color-marino-775);
+    --superficie-inversa: var(--color-nieve-50);
+    --superficie-cabecera: var(--color-velado-marino);
+    --tinta: var(--color-nieve-100);
+    --tinta-suave: var(--color-marino-200);
+    --tinta-tenue: var(--color-marino-450);
+    --tinta-inversa: var(--color-pizarra-900);
+    --tinta-marca: var(--color-marino-350);
+    --tinta-sobre-marca: var(--color-pizarra-900);
+    --tinta-sobre-accion: var(--color-pizarra-900);
+    --tinta-sobre-acento: var(--color-pizarra-900);
+    --marca: var(--color-marino-400);
+    --marca-hover: var(--color-marino-300);
+    --marca-activo: var(--color-marino-200);
+    --marca-tenue: var(--color-marino-800);
+    --accion: var(--color-marino-100);
+    --accion-hover: var(--color-blanco);
+    --acento: var(--color-bronce-300);
+    --acento-hover: var(--color-bronce-200);
+    --borde: var(--color-marino-775);
+    --borde-fuerte: var(--color-marino-600);
+    --borde-tenue: var(--color-marino-850);
+    --borde-marca: var(--color-marino-500);
     --exito: var(--color-exito-oscuro);
-    --exito-fondo: var(--color-oliva-800);
+    --exito-fondo: var(--color-marino-800);
     --exito-tinta: var(--color-exito-oscuro);
     --aviso: var(--color-aviso-oscuro);
-    --aviso-fondo: var(--color-oliva-800);
+    --aviso-fondo: var(--color-marino-800);
     --aviso-tinta: var(--color-aviso-oscuro);
     --error: var(--color-error-oscuro);
-    --error-fondo: var(--color-oliva-800);
+    --error-fondo: var(--color-marino-800);
     --error-tinta: var(--color-error-oscuro);
-    --foco: var(--color-oliva-400);
+    --foco: var(--color-bronce-300);
     --velo: var(--color-velo-fuerte);
   }
 }
 
 :root[data-tema="oscuro"] {
-  --fondo: var(--color-oliva-950);
-  --superficie: var(--color-oliva-900);
-  --superficie-elevada: var(--color-oliva-850);
-  --superficie-hundida: var(--color-oliva-975);
-  --superficie-tenue: var(--color-oliva-750);
-  --superficie-inversa: var(--color-crema-50);
-  --superficie-cabecera: var(--color-velado-oliva);
-  --tinta: var(--color-crema-150);
-  --tinta-suave: var(--color-oliva-200);
-  --tinta-tenue: var(--color-oliva-450);
-  --tinta-inversa: var(--color-carbon-900);
-  --tinta-marca: var(--color-oliva-350);
-  --tinta-sobre-marca: var(--color-carbon-900);
-  --tinta-sobre-acento: var(--color-carbon-900);
-  --marca: var(--color-oliva-400);
-  --marca-hover: var(--color-oliva-300);
-  --marca-activo: var(--color-oliva-200);
-  --marca-tenue: var(--color-oliva-800);
-  --acento: var(--color-crema-200);
-  --acento-hover: var(--color-crema-50);
-  --acento-tenue: var(--color-oliva-800);
-  --borde: var(--color-oliva-750);
-  --borde-fuerte: var(--color-oliva-600);
-  --borde-tenue: var(--color-oliva-850);
-  --borde-marca: var(--color-oliva-500);
+  --fondo: var(--color-marino-900);
+  --superficie: var(--color-marino-850);
+  --superficie-elevada: var(--color-marino-750);
+  --superficie-hundida: var(--color-marino-950);
+  --superficie-tenue: var(--color-marino-775);
+  --superficie-inversa: var(--color-nieve-50);
+  --superficie-cabecera: var(--color-velado-marino);
+  --tinta: var(--color-nieve-100);
+  --tinta-suave: var(--color-marino-200);
+  --tinta-tenue: var(--color-marino-450);
+  --tinta-inversa: var(--color-pizarra-900);
+  --tinta-marca: var(--color-marino-350);
+  --tinta-sobre-marca: var(--color-pizarra-900);
+  --tinta-sobre-accion: var(--color-pizarra-900);
+  --tinta-sobre-acento: var(--color-pizarra-900);
+  --marca: var(--color-marino-400);
+  --marca-hover: var(--color-marino-300);
+  --marca-activo: var(--color-marino-200);
+  --marca-tenue: var(--color-marino-800);
+  --accion: var(--color-marino-100);
+  --accion-hover: var(--color-blanco);
+  --acento: var(--color-bronce-300);
+  --acento-hover: var(--color-bronce-200);
+  --borde: var(--color-marino-775);
+  --borde-fuerte: var(--color-marino-600);
+  --borde-tenue: var(--color-marino-850);
+  --borde-marca: var(--color-marino-500);
   --exito: var(--color-exito-oscuro);
-  --exito-fondo: var(--color-oliva-800);
+  --exito-fondo: var(--color-marino-800);
   --exito-tinta: var(--color-exito-oscuro);
   --aviso: var(--color-aviso-oscuro);
-  --aviso-fondo: var(--color-oliva-800);
+  --aviso-fondo: var(--color-marino-800);
   --aviso-tinta: var(--color-aviso-oscuro);
   --error: var(--color-error-oscuro);
-  --error-fondo: var(--color-oliva-800);
+  --error-fondo: var(--color-marino-800);
   --error-tinta: var(--color-error-oscuro);
-  --foco: var(--color-oliva-400);
+  --foco: var(--color-bronce-300);
   --velo: var(--color-velo-fuerte);
 }
 
 /**
  * SECCIÓN INVERSA
  *
- * El diseño alterna bloques crema con bloques oliva oscuro (cuenta atrás,
- * RSVP, pie). En lugar de que cada componente sepa "aquí voy en claro sobre
- * oscuro", se reasignan los mismos semánticos dentro del bloque: los
- * componentes de dentro no cambian ni una clase.
+ * El diseño alterna bloques claros con bloques marino (cuenta atrás, RSVP,
+ * pie). En lugar de que cada componente sepa "aquí voy en claro sobre oscuro",
+ * se reasignan los mismos semánticos dentro del bloque: los componentes de
+ * dentro no cambian ni una clase.
  */
 
 [data-seccion="inversa"] {
-  --fondo: var(--color-oliva-700);
-  --superficie: var(--color-oliva-750);
-  --superficie-elevada: var(--color-crema-50);
-  --superficie-tenue: var(--color-oliva-800);
-  --tinta: var(--color-crema-150);
-  --tinta-suave: var(--color-oliva-200);
-  --tinta-tenue: var(--color-oliva-350);
-  --tinta-inversa: var(--color-carbon-900);
-  --tinta-marca: var(--color-oliva-350);
-  --marca: var(--color-oliva-350);
-  --marca-hover: var(--color-oliva-200);
+  --fondo: var(--color-marino-700);
+  --superficie: var(--color-marino-775);
+  --superficie-elevada: var(--color-nieve-50);
+  --superficie-tenue: var(--color-marino-800);
+  --tinta: var(--color-nieve-100);
+  --tinta-suave: var(--color-marino-200);
+  --tinta-tenue: var(--color-marino-350);
+  --tinta-inversa: var(--color-pizarra-900);
+  --tinta-marca: var(--color-marino-350);
+  --marca: var(--color-marino-350);
+  --marca-hover: var(--color-marino-200);
 
   /**
-   * El acento se invierte, por la misma razón que en el tema oscuro: sobre
-   * fondo oliva, un botón oliva no se ve. Faltaba, y el resultado era un botón
-   * primario invisible dentro de cualquier bloque inverso.
+   * La acción se invierte, por la misma razón que en el tema oscuro: sobre
+   * fondo marino, un botón marino no se ve. Faltaba, y el resultado era un
+   * botón primario invisible dentro de cualquier bloque inverso.
    */
-  --acento: var(--color-crema-200);
-  --acento-hover: var(--color-crema-50);
-  --acento-tenue: var(--color-oliva-800);
-  --tinta-sobre-acento: var(--color-oliva-875);
-  --borde: var(--color-oliva-600);
-  --borde-fuerte: var(--color-oliva-500);
-  --borde-tenue: var(--color-oliva-750);
-  --foco: var(--color-oliva-200);
+  --accion: var(--color-marino-100);
+  --accion-hover: var(--color-blanco);
+  --tinta-sobre-accion: var(--color-pizarra-900);
+  --acento: var(--color-bronce-300);
+  --acento-hover: var(--color-bronce-200);
+  --tinta-sobre-acento: var(--color-pizarra-900);
+  --borde: var(--color-marino-600);
+  --borde-fuerte: var(--color-marino-500);
+  --borde-tenue: var(--color-marino-775);
+  --foco: var(--color-bronce-300);
 }
 
 [data-seccion="pie"] {
-  --fondo: var(--color-carbon-950);
-  --superficie: var(--color-carbon-950);
-  --tinta: var(--color-crema-150);
-  --tinta-suave: var(--color-oliva-450);
-  --tinta-tenue: var(--color-oliva-450);
-  --tinta-marca: var(--color-oliva-350);
-  --marca: var(--color-oliva-350);
-  --acento: var(--color-crema-200);
-  --acento-hover: var(--color-crema-50);
-  --acento-tenue: var(--color-oliva-800);
-  --tinta-sobre-acento: var(--color-carbon-900);
-  --borde: var(--color-oliva-800);
-  --foco: var(--color-oliva-350);
+  --fondo: var(--color-pizarra-950);
+  --superficie: var(--color-pizarra-950);
+  --tinta: var(--color-nieve-100);
+  --tinta-suave: var(--color-marino-450);
+  --tinta-tenue: var(--color-marino-450);
+  --tinta-marca: var(--color-marino-350);
+  --marca: var(--color-marino-350);
+  --accion: var(--color-marino-100);
+  --accion-hover: var(--color-blanco);
+  --tinta-sobre-accion: var(--color-pizarra-900);
+  --acento: var(--color-bronce-300);
+  --acento-hover: var(--color-bronce-200);
+  --tinta-sobre-acento: var(--color-pizarra-900);
+  --borde: var(--color-marino-800);
+  --foco: var(--color-bronce-300);
 }

--- a/tests/unidad/estilos.test.ts
+++ b/tests/unidad/estilos.test.ts
@@ -43,11 +43,12 @@ describe("globals.css", () => {
     }
   });
 
-  it("excluye del escaneo las carpetas de skills", () => {
-    // Sin esto, la documentación de terceros mete utilidades que nadie usa
-    // en el CSS que descarga cada invitado.
+  it("excluye del escaneo las carpetas que no son código nuestro", () => {
+    // Sin esto, la documentación de terceros y las piezas del estudio de marca
+    // meten utilidades que nadie usa en el CSS que descarga cada invitado.
     expect(css).toMatch(/@source not ".*\.claude"/);
     expect(css).toMatch(/@source not ".*\.agents"/);
+    expect(css).toMatch(/@source not ".*Sistema completo de boda"/);
   });
 
   it("borra las escalas por defecto de Tailwind", () => {
@@ -73,8 +74,24 @@ describe("capa de primitivos", () => {
   const css = leer("src/styles/tokens/primitives.css");
 
   it("define las escalas de la marca", () => {
-    for (const escala of ["--color-oliva-500", "--color-crema-50", "--color-carbon-900"]) {
+    for (const escala of [
+      "--color-marino-500",
+      "--color-bronce-600",
+      "--color-nieve-50",
+      "--color-pizarra-900",
+    ]) {
       expect(css).toContain(escala);
+    }
+  });
+
+  it("no queda ni rastro de la paleta verde oliva", () => {
+    // La marca tiene dos versiones entregadas y se monta la azul. Un primitivo
+    // oliva superviviente sería un color que ya no está en ninguna pieza del
+    // sistema, esperando a que alguien lo use sin saberlo.
+    for (const escala of ["oliva", "crema", "hueso", "carbon"]) {
+      expect(css, `Queda un primitivo de la paleta anterior: --color-${escala}-*`).not.toMatch(
+        new RegExp(`--color-${escala}-`),
+      );
     }
   });
 });

--- a/tests/unidad/paleta.test.ts
+++ b/tests/unidad/paleta.test.ts
@@ -1,0 +1,220 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Integridad de la paleta contra la entrega de marca
+ *
+ * El sistema de marca de Paloma y David se entregó en dos versiones, verde
+ * oliva y azul marino, y cada una trae su tabla de tokens ya resuelta a hex
+ * (`Sistema completo de boda/Sistema de marca azul.dc.html`). Se monta la azul.
+ *
+ * Estos tests recorren las dos capas —semántico → primitivo— y comparan el
+ * literal final con esa tabla. No comprueban que los colores "queden bien":
+ * comprueban que son EXACTAMENTE los entregados.
+ *
+ * Existe porque una paleta se degrada sin que salte ninguna alarma. Alguien
+ * ajusta un borde "que se veía duro", otro aclara un gris, y al cabo de unas
+ * semanas la web y la cartelería impresa ya no son la misma marca — con la
+ * diferencia de que la cartelería no se puede volver a desplegar.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+
+/** Tabla de la entrega, tema claro. Copiada de la pieza, no deducida. */
+const CLARO: Record<string, string> = {
+  fondo: "#f8f9fc",
+  superficie: "#ffffff",
+  "superficie-elevada": "#ffffff",
+  "superficie-hundida": "#eef1f6",
+  "superficie-tenue": "#e7ecf3",
+  "superficie-inversa": "#0d1220",
+  tinta: "#121722",
+  "tinta-suave": "#434e63",
+  "tinta-tenue": "#78839a",
+  "tinta-inversa": "#f8f9fc",
+  "tinta-marca": "#1f2b44",
+  marca: "#3f4f70",
+  "marca-hover": "#2c3a56",
+  "marca-activo": "#16213a",
+  "marca-tenue": "#e7ecf3",
+  acento: "#8a6224",
+  "acento-hover": "#a97634",
+  borde: "#dfe4ec",
+  "borde-fuerte": "#b7c0d0",
+  "borde-marca": "#8b97ac",
+  exito: "#1f7a4c",
+  aviso: "#b8860b",
+  error: "#d14545",
+};
+
+/** La misma tabla, tema oscuro. */
+const OSCURO: Record<string, string> = {
+  fondo: "#101623",
+  superficie: "#151c2b",
+  "superficie-elevada": "#1c2434",
+  "superficie-hundida": "#0b1120",
+  "superficie-tenue": "#16213a",
+  "superficie-inversa": "#f8f9fc",
+  tinta: "#eef2f8",
+  "tinta-suave": "#c3cee1",
+  "tinta-tenue": "#7e8aa0",
+  "tinta-inversa": "#121722",
+  "tinta-marca": "#9db0ce",
+  marca: "#8fa0bc",
+  "marca-hover": "#aec0da",
+  "marca-activo": "#c3cee1",
+  "marca-tenue": "#141e33",
+  acento: "#e3be86",
+  "acento-hover": "#f0d6ac",
+  borde: "#16213a",
+  "borde-fuerte": "#2c3a56",
+  "borde-marca": "#3f4f70",
+  exito: "#4fae7b",
+  aviso: "#d9a425",
+  error: "#e06a6a",
+};
+
+function leer(ruta: string) {
+  return readFileSync(join(RAIZ, ruta), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+function declaracionesDe(bloque: string) {
+  const mapa = new Map<string, string>();
+  for (const [, nombre, valor] of bloque.matchAll(/--([\w-]+)\s*:\s*([^;]+);/g)) {
+    mapa.set(nombre, valor.trim());
+  }
+  return mapa;
+}
+
+/** Cuerpo del primer bloque que abre con `selector`. */
+function bloqueDe(css: string, selector: string) {
+  const inicio = css.indexOf(selector);
+  expect(inicio, `No se encontró el selector ${selector}`).toBeGreaterThan(-1);
+  const abre = css.indexOf("{", inicio);
+  return css.slice(abre + 1, css.indexOf("}", abre));
+}
+
+/** `#fff` y `#FFFFFF` son el mismo color: se comparan en la forma larga. */
+function normalizar(hex: string) {
+  const n = hex.trim().toLowerCase().replace("#", "");
+  return `#${n.length === 3 ? [...n].map((c) => c + c).join("") : n}`;
+}
+
+const primitivos = declaracionesDe(leer("src/styles/tokens/primitives.css"));
+const semanticoCss = leer("src/styles/tokens/semantic.css");
+const claro = declaracionesDe(bloqueDe(semanticoCss, ":root"));
+const oscuro = declaracionesDe(bloqueDe(semanticoCss, ':root[data-tema="oscuro"]'));
+
+/** Resuelve un semántico hasta su literal, heredando de `:root` como el CSS. */
+function resolver(nombre: string, propias: Map<string, string>) {
+  const valor = propias.get(nombre) ?? claro.get(nombre);
+  expect(valor, `Token semántico desconocido: --${nombre}`).toBeDefined();
+
+  const referencia = valor!.match(/^var\(--([\w-]+)\)$/);
+  expect(
+    referencia,
+    `--${nombre} vale "${valor}", que no referencia un primitivo`,
+  ).not.toBeNull();
+
+  const literal = primitivos.get(referencia![1]);
+  expect(literal, `Primitivo desconocido: --${referencia![1]}`).toBeDefined();
+  return normalizar(literal!);
+}
+
+describe("paleta azul marino", () => {
+  it.each(Object.entries(CLARO))(
+    "--%s resuelve al valor entregado en tema claro",
+    (token, esperado) => {
+      expect(resolver(token, claro)).toBe(esperado);
+    },
+  );
+
+  it.each(Object.entries(OSCURO))(
+    "--%s resuelve al valor entregado en tema oscuro",
+    (token, esperado) => {
+      expect(resolver(token, oscuro)).toBe(esperado);
+    },
+  );
+
+  it("el acento es cálido: es lo que distingue a esta versión de la marca", () => {
+    // Sobre tanto azul, un acento frío desaparece. Si alguien reasigna el
+    // acento a un tono de la escala marino, el sistema pierde su único
+    // contraste de temperatura y nadie lo nota mirando un swatch aislado.
+    const temas: [string, Map<string, string>][] = [
+      ["claro", claro],
+      ["oscuro", oscuro],
+    ];
+
+    for (const [tema, propias] of temas) {
+      const hex = resolver("acento", propias).slice(1);
+      const [r, , b] = [0, 2, 4].map((i) => parseInt(hex.slice(i, i + 2), 16));
+      expect(r, `El acento del tema ${tema} no es cálido`).toBeGreaterThan(b);
+    }
+  });
+
+  it("la acción y el acento son colores distintos", () => {
+    // El fallo que arrastraba el sistema: un solo token hacía de relleno de
+    // botón y de acento, así que el acento de la entrega no existía en la web.
+    for (const propias of [claro, oscuro]) {
+      expect(resolver("accion", propias)).not.toBe(resolver("acento", propias));
+    }
+  });
+});
+
+/**
+ * Contraste. La entrega da los colores; que se lean es responsabilidad de quien
+ * los monta. Se comprueban los pares que de verdad se pintan juntos, en los
+ * cuatro fondos del sistema: página clara, página oscura, bloque inverso y pie.
+ */
+describe("contraste de la paleta", () => {
+  const inversa = declaracionesDe(bloqueDe(semanticoCss, '[data-seccion="inversa"]'));
+  const pie = declaracionesDe(bloqueDe(semanticoCss, '[data-seccion="pie"]'));
+
+  function luminancia(hex: string) {
+    const canales = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255);
+    const lineal = canales.map((v) =>
+      v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4,
+    );
+    return 0.2126 * lineal[0] + 0.7152 * lineal[1] + 0.0722 * lineal[2];
+  }
+
+  function contraste(a: string, b: string) {
+    const [claroL, oscuroL] = [luminancia(a), luminancia(b)].sort((x, y) => y - x);
+    return (claroL + 0.05) / (oscuroL + 0.05);
+  }
+
+  const FONDOS: [string, Map<string, string>][] = [
+    ["tema claro", claro],
+    ["tema oscuro", oscuro],
+    ["bloque inverso", inversa],
+    ["pie", pie],
+  ];
+
+  for (const [nombre, propias] of FONDOS) {
+    it(`en ${nombre} el texto cumple AA sobre su fondo`, () => {
+      const fondo = resolver("fondo", propias);
+      // 4.5:1 es el umbral AA para texto normal.
+      expect(contraste(resolver("tinta", propias), fondo)).toBeGreaterThanOrEqual(4.5);
+      expect(contraste(resolver("tinta-suave", propias), fondo)).toBeGreaterThanOrEqual(4.5);
+    });
+
+    it(`en ${nombre} el botón primario se ve y se lee`, () => {
+      const relleno = resolver("accion", propias);
+      // 3:1 para el relleno contra la página (elemento de interfaz), 4.5:1
+      // para el rótulo contra el relleno (texto).
+      expect(contraste(relleno, resolver("fondo", propias))).toBeGreaterThanOrEqual(3);
+      expect(
+        contraste(resolver("tinta-sobre-accion", propias), relleno),
+      ).toBeGreaterThanOrEqual(4.5);
+    });
+
+    it(`en ${nombre} el acento y el aro de foco se despegan del fondo`, () => {
+      const fondo = resolver("fondo", propias);
+      // El acento solo se usa en tamaños grandes (cita, conector, cifras) y el
+      // aro de foco es un elemento de interfaz: 3:1 en ambos casos.
+      expect(contraste(resolver("acento", propias), fondo)).toBeGreaterThanOrEqual(3);
+      expect(contraste(resolver("foco", propias), fondo)).toBeGreaterThanOrEqual(3);
+    });
+  }
+});


### PR DESCRIPTION
## Qué cambia

La web pasa a la **versión azul marino** del sistema de marca, transcrita una a una de la entrega del estudio que ya está en el repositorio (`Sistema completo de boda/`).

Closes #89

De paso arregla el CI, que estaba en rojo: la carpeta de la entrega se estaba tratando como código fuente.

### La paleta

Cada pieza de la entrega trae su tabla de tokens ya resuelta a hex, y con los mismos nombres que usa `semantic.css`. Así que no hay ojímetro: se transcriben. Entran las escalas `marino`, `bronce`, `nieve`/`bruma` y `pizarra`, y sale la paleta oliva entera. Cambiar de versión vuelve a ser reescribir `primitives.css` y nada más.

### El acento existía y no estaba

Al transcribir sale a la luz un fallo que el sistema arrastraba: **`--acento` hacía de relleno del botón primario**. En las dos versiones de la entrega el acento es un color aparte que nunca rellena nada — el teal en la oliva, el bronce en la azul. Con esa mezcla, el bronce (el único color cálido, y lo que de verdad distingue a la versión azul) no habría aparecido en ninguna parte de la web.

Se separan en dos tokens:

| Token | Qué es | Claro | Oscuro |
| --- | --- | --- | --- |
| `--accion` | Relleno del botón primario | `#1f2b44` | se invierte al tono más pálido |
| `--acento` | El bronce, a gotas | `#8a6224` | `#e3be86` |

El acento sale exactamente donde lo pone la entrega: la versalita de la portada, el conector «y», las citas, las horas del programa y el aro de foco. Se retira `--acento-tenue`, que no está en la tabla de la entrega y no usaba ningún componente.

### Por qué el aro de foco va en bronce

Porque lo dice la entrega (`outline: 2px solid #8A6224`), y porque es el único color del sistema que se despega de los dos fondos. En marino sobre marino, el aro se confundía con el propio botón.

## Cómo probarlo en el preview

1. **`/cocina`** — los grupos de color. «Marca, acción y acento» ahora enseña las dos cosas por separado: la fila marino y la fila bronce.
2. Cambia a **oscuro** con el selector. El acento sube a bronce claro y el botón primario se invierte a tono pálido con tinta oscura.
3. Baja al **bloque inverso** del final: los mismos componentes, sin una clase distinta, y la cita en bronce.
4. **`/`** — la portada. La versalita de arriba y la «y» van en bronce; el botón «Confirmar asistencia», en marino.
5. **Tabula** por la portada: el aro de foco es bronce y se ve sobre los dos fondos.
6. Baja a la **cuenta atrás** (bloque marino) y al **pie** (casi negro azulado).

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: colores y espaciados son tokens, los textos salen de `content/copy.es.json`, los datos de la boda de la BBDD y los límites de `src/config/constants.ts`
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error
- [x] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion`
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

### Sobre las pruebas

`tests/unidad/paleta.test.ts` (nuevo, 60 comprobaciones) recorre las dos capas y compara el literal final con la tabla de la entrega, token a token y en los dos temas. Y mide contraste en los **cuatro** fondos del sistema —claro, oscuro, bloque inverso y pie—: AA en texto, 3:1 en el relleno del botón y en el aro de foco.

Existe porque una paleta se degrada sin que salte ninguna alarma. Alguien aclara un gris «que se veía duro», y semanas después la web y la cartelería impresa ya no son la misma marca — con la diferencia de que la cartelería no se puede volver a desplegar.

El caso de error del E2E es el que ya pilló una vez un botón invisible: dentro de un bloque inverso, el relleno tiene que separarse del fondo (≥ 3:1) y el rótulo leerse encima (≥ 4.5:1).

Verificado en local contra una BBDD real con migraciones y seed: **117 unitarios** y **78 E2E de escritorio**, todo en verde. El proyecto `movil` no se pudo ejecutar aquí porque WebKit no se puede descargar en este contenedor; en CI sí se instala.

## Base de datos

- [x] No la toca
- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [ ] No hace falta
- [x] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR

§2.2 recoge la paleta elegida y la distinción marca / acción / acento, y la dirección de arte pasa de decisión pendiente a resuelta. En `docs/BACKLOG.md` queda anotado por qué este ticket es `BODA-15` y no un número de la decena de E1: estaba llena.

---

### Nota aparte: el CI estaba roto

La entrega del estudio se subió a la raíz del repositorio y las herramientas la trataban como código nuestro:

- **ESLint**: 2 errores y 11 avisos, todos del runtime de la herramienta de diseño (`support.js`, `image-slot.js`).
- **Prettier**: los `.dc.html` ni siquiera se pueden parsear (`SyntaxError: Unexpected closing tag "x-dc"`), así que `format:check` fallaba.
- **Tailwind**: escaneaba casi un megabyte de HTML ajeno para decidir qué CSS descarga cada invitado.

Ahora la ignoran las tres, igual que se hace con las skills de terceros. Es material de referencia y se versiona tal cual llegó: reformatearlo rompería la única copia fiel del diseño que hay.

### Para más adelante

Dos cosas de la entrega que este ticket no toca, porque son de tipografía y no de color, y le pasan igual a la versión oliva:

- **Italianno** para el conector «y» y el ampersand. Hoy se pinta con la serif en cursiva.
- **`--tinta-dato`** (`#5c6678`, «cifras y tablas»). Está en la tabla de la entrega pero decidir qué números son «dato» es una decisión de diseño, no de transcripción.


---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_