### PR TITLE
feat(BODA-44): los ajustes de la boda se cambian desde el panel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,17 @@ jobs:
       - name: Probar el recorrido completo del acceso
         env:
           NEXT_PUBLIC_SITE_URL: http://localhost:3000
-        run: npx playwright test --project=escritorio tests/e2e/acceso-real.spec.ts tests/e2e/panel.spec.ts
+        # LA SUITE ENTERA, NO UNA LISTA DE FICHEROS.
+        #
+        # Aquí estaban escritos a mano los dos specs que necesitaban sesión, y
+        # esa lista se quedó atrás en cuanto apareció el tercero: el test nuevo
+        # se saltaba solo —no hay Supabase fuera de este trabajo— y el de aquí
+        # ni lo miraba. Verde por los dos lados y sin haberse ejecutado nunca.
+        #
+        # Este trabajo es el único con Supabase y base de datos de verdad, así
+        # que puede correrlo todo. Cuesta un par de minutos más y a cambio
+        # ningún spec puede volver a colarse sin ejecutarse.
+        run: npx playwright test --project=escritorio
 
       - name: Guardar informe si algo falla
         if: failure()

--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -198,7 +198,8 @@
       "proveedores": "Proveedores",
       "presupuesto": "Presupuesto",
       "tareas": "Tareas",
-      "cuenta": "Mi cuenta"
+      "cuenta": "Mi cuenta",
+      "ajustes": "Ajustes"
     },
     "resumen": {
       "titulo": "Resumen",
@@ -219,6 +220,45 @@
         "editor": "Editor",
         "lector": "Lector"
       }
+    },
+    "ajustes": {
+      "titulo": "Ajustes de la boda",
+      "descripcion": "De aquí salen los nombres de la portada, la cuenta atrás, el mapa, el evento del calendario y la vista previa al compartir. Es lo primero que conviene rellenar.",
+      "grupoPareja": "La pareja",
+      "grupoCeremonia": "Ceremonia",
+      "grupoBanquete": "Banquete",
+      "grupoContacto": "Contacto y confirmaciones",
+      "nombreNovia": "Nombre de la novia",
+      "nombreNovio": "Nombre del novio",
+      "hashtag": "Hashtag",
+      "hashtagAyuda": "Con almohadilla delante, por ejemplo #PalomaYDavid. Déjalo vacío si no queréis.",
+      "fechaCeremonia": "Fecha y hora de la ceremonia",
+      "fechaBanquete": "Fecha y hora del banquete",
+      "fechaBanqueteAyuda": "Opcional. Si lo dejas vacío, el calendario cuenta sólo desde la ceremonia.",
+      "lugarCeremonia": "Lugar de la ceremonia",
+      "direccionCeremonia": "Dirección de la ceremonia",
+      "lugarBanquete": "Lugar del banquete",
+      "direccionBanquete": "Dirección del banquete",
+      "latitud": "Latitud",
+      "longitud": "Longitud",
+      "coordenadasAyuda": "Las dos o ninguna. Se copian de Google Maps y admiten coma o punto.",
+      "correo": "Correo de contacto",
+      "correoAyuda": "El que ven los invitados en el pie de la web.",
+      "limiteRsvp": "Fecha límite para confirmar",
+      "limiteRsvpAyuda": "Tiene que ser anterior a la ceremonia.",
+      "zonaHoraria": "Las horas se guardan en",
+      "guardar": "Guardar cambios",
+      "guardado": "Ajustes guardados. La web ya los muestra.",
+      "soloLectura": "Tus permisos son de sólo lectura: puedes ver estos datos, pero no cambiarlos.",
+      "errorNombres": "Hacen falta los dos nombres, de al menos dos caracteres.",
+      "errorCeremonia": "Pon la fecha y la hora de la ceremonia.",
+      "errorLimiteTarde": "La fecha límite para confirmar no puede ser posterior a la ceremonia.",
+      "errorBanqueteAntes": "El banquete no puede empezar antes que la ceremonia.",
+      "errorCoordenadas": "Revisa las coordenadas: van las dos o ninguna, la latitud entre -90 y 90 y la longitud entre -180 y 180.",
+      "errorHashtag": "El hashtag empieza por almohadilla y sigue con letras, números o guion bajo.",
+      "errorCorreo": "Ese correo no tiene buena pinta.",
+      "errorSinPermiso": "No se ha guardado nada: tus permisos no alcanzan para cambiar los ajustes de la boda.",
+      "errorGuardar": "No hemos podido guardar los ajustes. Inténtalo de nuevo."
     }
   }
 }

--- a/src/app/panel/ajustes/acciones.ts
+++ b/src/app/panel/ajustes/acciones.ts
@@ -1,0 +1,188 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { LONGITUD_MINIMA_NOMBRE, RUTA_ACCESO, RUTA_AJUSTES } from "@/config/constants";
+import { clienteServidor, hayAutenticacion } from "@/lib/supabase/servidor";
+import { instanteDesdeLocal } from "@/lib/zona-horaria";
+
+/**
+ * BODA-44 · GUARDAR LOS DATOS DE LA BODA
+ *
+ * `configuracion_boda` alimenta la portada, la cuenta atrás, el mapa, el `.ics`
+ * y la vista previa al compartir. Es el dato más visible de la web y hasta
+ * ahora la única forma de tocarlo era el editor SQL de Supabase.
+ *
+ * SE VALIDA AQUÍ AUNQUE LA BASE YA VALIDE. La tabla tiene `CHECK` para casi
+ * todo esto, y son ellos los que mandan. Pero un `CHECK` que salta devuelve un
+ * error de Postgres con el nombre de la restricción, y eso no es un mensaje
+ * para nadie. Se comprueba antes para poder decir qué pasa en castellano, y se
+ * deja el `CHECK` detrás como red: si algo se escapa de aquí, no entra igual.
+ *
+ * QUIÉN PUEDE GUARDAR lo decide RLS, no este fichero. La política
+ * `configuracion_boda_editor_actualizar` exige `puede_editar()`, que es
+ * propietario o editor. Un lector puede llegar hasta aquí —la pantalla se le
+ * enseña— y la base no le dejará escribir. Lo que se hace aquí es traducir ese
+ * «no» a una frase, no sustituirlo.
+ */
+
+/** Los estados con los que vuelve la pantalla. Cada uno tiene su copy. */
+type Estado =
+  | "guardado"
+  | "nombres"
+  | "ceremonia"
+  | "limite-tarde"
+  | "banquete-antes"
+  | "coordenadas"
+  | "hashtag"
+  | "correo"
+  | "sin-permiso"
+  | "error";
+
+function volver(estado: Estado): never {
+  redirect(`${RUTA_AJUSTES}?estado=${estado}`);
+}
+
+function texto(datos: FormData, campo: string): string {
+  return String(datos.get(campo) ?? "").trim();
+}
+
+/** Un campo de texto vacío es `null` en la base, no la cadena vacía. */
+function textoONulo(datos: FormData, campo: string): string | null {
+  return texto(datos, campo) || null;
+}
+
+/**
+ * Coordenada suelta. Se acepta la coma decimal porque es la que sale del
+ * teclado español y la que copia y pega quien mira Google Maps en castellano;
+ * rechazarla sería castigar a quien escribe bien en su idioma.
+ *
+ * `undefined` significa «no es un número» —error— y `null`, «no hay dato».
+ */
+function coordenada(datos: FormData, campo: string, tope: number): number | null | undefined {
+  const bruto = texto(datos, campo).replace(",", ".");
+  if (!bruto) return null;
+
+  const numero = Number(bruto);
+  if (!Number.isFinite(numero) || Math.abs(numero) > tope) return undefined;
+  return numero;
+}
+
+export async function guardarAjustes(datos: FormData) {
+  if (!hayAutenticacion) redirect(RUTA_ACCESO);
+
+  const nombreNovia = texto(datos, "nombre_novia");
+  const nombreNovio = texto(datos, "nombre_novio");
+  if (
+    nombreNovia.length < LONGITUD_MINIMA_NOMBRE ||
+    nombreNovio.length < LONGITUD_MINIMA_NOMBRE
+  ) {
+    volver("nombres");
+  }
+
+  const hashtag = textoONulo(datos, "hashtag");
+  if (hashtag && !/^#[\p{L}\p{N}_]{1,60}$/u.test(hashtag)) volver("hashtag");
+
+  const correo = textoONulo(datos, "correo_contacto");
+  if (correo && !/^[^@\s]+@[^@\s.]+\.[^@\s]+$/.test(correo)) volver("correo");
+
+  const latCeremonia = coordenada(datos, "latitud_ceremonia", 90);
+  const lonCeremonia = coordenada(datos, "longitud_ceremonia", 180);
+  const latBanquete = coordenada(datos, "latitud_banquete", 90);
+  const lonBanquete = coordenada(datos, "longitud_banquete", 180);
+
+  if ([latCeremonia, lonCeremonia, latBanquete, lonBanquete].includes(undefined)) {
+    volver("coordenadas");
+  }
+
+  // La base exige que vayan las dos o ninguna: media coordenada no señala
+  // ningún punto del mapa.
+  if ((latCeremonia === null) !== (lonCeremonia === null)) volver("coordenadas");
+  if ((latBanquete === null) !== (lonBanquete === null)) volver("coordenadas");
+
+  try {
+    const supabase = await clienteServidor();
+
+    const { data: sesion } = await supabase.auth.getUser();
+    if (!sesion.user) redirect(RUTA_ACCESO);
+
+    // La zona sale de la propia fila: las horas del formulario vienen sin zona
+    // y hay que saber de dónde son antes de convertirlas a instantes.
+    const { data: actual, error: errorLectura } = await supabase
+      .from("configuracion_boda")
+      .select("id, zona_horaria")
+      .maybeSingle();
+
+    if (errorLectura || !actual) {
+      console.error("No se pudo leer la configuración:", errorLectura?.message);
+      volver("error");
+    }
+
+    const zona = actual.zona_horaria;
+
+    const ceremonia = instanteDesdeLocal(texto(datos, "fecha_hora_ceremonia"), zona);
+    if (!ceremonia) volver("ceremonia");
+
+    const limite = instanteDesdeLocal(texto(datos, "fecha_limite_rsvp"), zona);
+    if (!limite) volver("limite-tarde");
+
+    // Pedir confirmación después de la boda no tiene sentido, y es un error
+    // fácil de cometer copiando la fecha de arriba.
+    if (limite.getTime() > ceremonia.getTime()) volver("limite-tarde");
+
+    const banqueteTexto = texto(datos, "fecha_hora_banquete");
+    const banquete = banqueteTexto ? instanteDesdeLocal(banqueteTexto, zona) : null;
+    if (banqueteTexto && !banquete) volver("banquete-antes");
+    if (banquete && banquete.getTime() < ceremonia.getTime()) volver("banquete-antes");
+
+    const { error, count } = await supabase
+      .from("configuracion_boda")
+      .update(
+        {
+          nombre_novia: nombreNovia,
+          nombre_novio: nombreNovio,
+          hashtag,
+          correo_contacto: correo,
+          fecha_hora_ceremonia: ceremonia.toISOString(),
+          fecha_hora_banquete: banquete ? banquete.toISOString() : null,
+          fecha_limite_rsvp: limite.toISOString(),
+          lugar_ceremonia: textoONulo(datos, "lugar_ceremonia"),
+          direccion_ceremonia: textoONulo(datos, "direccion_ceremonia"),
+          latitud_ceremonia: latCeremonia,
+          longitud_ceremonia: lonCeremonia,
+          lugar_banquete: textoONulo(datos, "lugar_banquete"),
+          direccion_banquete: textoONulo(datos, "direccion_banquete"),
+          latitud_banquete: latBanquete,
+          longitud_banquete: lonBanquete,
+        },
+        { count: "exact" },
+      )
+      .eq("id", actual.id);
+
+    if (error) {
+      console.error("No se pudo guardar la configuración:", error.message);
+      volver("error");
+    }
+
+    /**
+     * RLS NO DA ERROR CUANDO PROHÍBE UNA ESCRITURA: devuelve cero filas
+     * tocadas, porque para la política esa fila sencillamente no existe. Sin
+     * mirar el recuento, un lector vería «Guardado» y no se habría guardado
+     * nada — que es la peor de las respuestas posibles.
+     */
+    if (count === 0) volver("sin-permiso");
+  } catch (error) {
+    // `redirect` funciona lanzando: hay que dejar pasar su excepción o los
+    // saltos de arriba se quedarían aquí atrapados y la pantalla no diría nada.
+    if (typeof error === "object" && error !== null && "digest" in error) throw error;
+    console.error("Fallo al guardar la configuración:", error);
+    volver("error");
+  }
+
+  // La landing lee esta tabla en cada petición, pero el `.ics` y las imágenes
+  // de Open Graph son rutas aparte: sin esto seguirían sirviendo la fecha
+  // anterior en la tarjeta de WhatsApp.
+  revalidatePath("/", "layout");
+  volver("guardado");
+}

--- a/src/app/panel/ajustes/page.tsx
+++ b/src/app/panel/ajustes/page.tsx
@@ -1,0 +1,278 @@
+import { redirect } from "next/navigation";
+
+import { Boton } from "@/components/ui/boton";
+import { CampoTexto } from "@/components/ui/campo";
+import { Cuerpo, Etiqueta, Titulo2, Titulo3 } from "@/components/ui/tipografia";
+import { LONGITUD_MINIMA_NOMBRE, RUTA_ACCESO } from "@/config/constants";
+import { accesoActual } from "@/lib/sesion";
+import { clienteServidor } from "@/lib/supabase/servidor";
+import { t } from "@/lib/copy";
+import { localDesdeInstante } from "@/lib/zona-horaria";
+
+import { guardarAjustes } from "./acciones";
+
+/**
+ * BODA-44 · AJUSTES DE LA BODA
+ *
+ * La pantalla que faltaba. `configuracion_boda` alimenta la portada, la cuenta
+ * atrás, las ubicaciones, el `.ics` y la tarjeta de WhatsApp, y hasta ahora la
+ * única forma de tocarla era el editor SQL de Supabase — con la web enseñando
+ * «Por definir» mientras tanto.
+ *
+ * Es un `<form>` con Server Action, sin una línea de JavaScript de cliente:
+ * los datos más visibles de la boda no dependen de que cargue un bundle.
+ *
+ * UN LECTOR VE PERO NO TOCA. Los campos se le enseñan deshabilitados y sin
+ * botón de guardar. No es la protección —esa es RLS, y la acción comprueba el
+ * recuento de filas por si alguien manda el formulario a mano— sino no ofrecer
+ * lo que va a fallar.
+ */
+export const dynamic = "force-dynamic";
+
+const AVISOS: Record<string, { texto: string; error: boolean }> = {
+  guardado: { texto: t("panel.ajustes.guardado"), error: false },
+  nombres: { texto: t("panel.ajustes.errorNombres"), error: true },
+  ceremonia: { texto: t("panel.ajustes.errorCeremonia"), error: true },
+  "limite-tarde": { texto: t("panel.ajustes.errorLimiteTarde"), error: true },
+  "banquete-antes": { texto: t("panel.ajustes.errorBanqueteAntes"), error: true },
+  coordenadas: { texto: t("panel.ajustes.errorCoordenadas"), error: true },
+  hashtag: { texto: t("panel.ajustes.errorHashtag"), error: true },
+  correo: { texto: t("panel.ajustes.errorCorreo"), error: true },
+  "sin-permiso": { texto: t("panel.ajustes.errorSinPermiso"), error: true },
+  error: { texto: t("panel.ajustes.errorGuardar"), error: true },
+};
+
+interface Configuracion {
+  nombre_novia: string;
+  nombre_novio: string;
+  hashtag: string | null;
+  correo_contacto: string | null;
+  fecha_hora_ceremonia: string;
+  fecha_hora_banquete: string | null;
+  fecha_limite_rsvp: string;
+  zona_horaria: string;
+  lugar_ceremonia: string | null;
+  direccion_ceremonia: string | null;
+  latitud_ceremonia: number | null;
+  longitud_ceremonia: number | null;
+  lugar_banquete: string | null;
+  direccion_banquete: string | null;
+  latitud_banquete: number | null;
+  longitud_banquete: number | null;
+}
+
+/** Una coordenada vacía se enseña vacía, no como «null» ni como «0». */
+function comoTexto(valor: number | null): string {
+  return valor === null || valor === undefined ? "" : String(valor);
+}
+
+function Grupo({ titulo, children }: { titulo: string; children: React.ReactNode }) {
+  return (
+    <fieldset className="grid gap-elemento border-t border-borde pt-elemento">
+      <legend className="sr-only">{titulo}</legend>
+      <Titulo3 como="h2">{titulo}</Titulo3>
+      {children}
+    </fieldset>
+  );
+}
+
+export default async function PaginaAjustes({
+  searchParams,
+}: {
+  searchParams: Promise<{ estado?: string }>;
+}) {
+  const acceso = await accesoActual();
+  if (!acceso) redirect(RUTA_ACCESO);
+
+  const { estado } = await searchParams;
+  const aviso = estado && estado in AVISOS ? AVISOS[estado] : null;
+
+  const supabase = await clienteServidor();
+  const { data } = await supabase
+    .from("configuracion_boda")
+    .select(
+      "nombre_novia, nombre_novio, hashtag, correo_contacto, fecha_hora_ceremonia, " +
+        "fecha_hora_banquete, fecha_limite_rsvp, zona_horaria, lugar_ceremonia, " +
+        "direccion_ceremonia, latitud_ceremonia, longitud_ceremonia, lugar_banquete, " +
+        "direccion_banquete, latitud_banquete, longitud_banquete",
+    )
+    .maybeSingle<Configuracion>();
+
+  const soloLectura = acceso.rol === "lector";
+  const zona = data?.zona_horaria ?? "";
+
+  // Las horas viajan a la base como instantes y se enseñan en la zona de la
+  // boda. Sin esto, una ceremonia a las 13:00 de junio saldría aquí a las 11:00,
+  // que es la misma hora contada desde otro sitio.
+  const enLocal = (valor: string | null | undefined) =>
+    valor ? localDesdeInstante(new Date(valor), zona) : "";
+
+  return (
+    <div className="grid max-w-estrecho gap-elemento">
+      <div>
+        <Titulo2 como="h1">{t("panel.ajustes.titulo")}</Titulo2>
+        <Cuerpo className="mt-pila">{t("panel.ajustes.descripcion")}</Cuerpo>
+      </div>
+
+      {aviso ? (
+        <p
+          role={aviso.error ? "alert" : "status"}
+          className={`text-pequeno ${aviso.error ? "text-error-tinta" : "text-tinta-marca"}`}
+        >
+          {aviso.texto}
+        </p>
+      ) : null}
+
+      {soloLectura ? (
+        <p role="status" className="text-pequeno text-tinta-suave">
+          {t("panel.ajustes.soloLectura")}
+        </p>
+      ) : null}
+
+      <form action={guardarAjustes} className="grid gap-bloque">
+        <Grupo titulo={t("panel.ajustes.grupoPareja")}>
+          <div className="grid gap-elemento sm:grid-cols-2">
+            <CampoTexto
+              name="nombre_novia"
+              etiqueta={t("panel.ajustes.nombreNovia")}
+              defaultValue={data?.nombre_novia ?? ""}
+              minLength={LONGITUD_MINIMA_NOMBRE}
+              required
+              disabled={soloLectura}
+            />
+            <CampoTexto
+              name="nombre_novio"
+              etiqueta={t("panel.ajustes.nombreNovio")}
+              defaultValue={data?.nombre_novio ?? ""}
+              minLength={LONGITUD_MINIMA_NOMBRE}
+              required
+              disabled={soloLectura}
+            />
+          </div>
+          <CampoTexto
+            name="hashtag"
+            etiqueta={t("panel.ajustes.hashtag")}
+            ayuda={t("panel.ajustes.hashtagAyuda")}
+            defaultValue={data?.hashtag ?? ""}
+            disabled={soloLectura}
+          />
+        </Grupo>
+
+        <Grupo titulo={t("panel.ajustes.grupoCeremonia")}>
+          <CampoTexto
+            name="fecha_hora_ceremonia"
+            type="datetime-local"
+            etiqueta={t("panel.ajustes.fechaCeremonia")}
+            ayuda={`${t("panel.ajustes.zonaHoraria")} ${zona}`}
+            defaultValue={enLocal(data?.fecha_hora_ceremonia)}
+            required
+            disabled={soloLectura}
+          />
+          <CampoTexto
+            name="lugar_ceremonia"
+            etiqueta={t("panel.ajustes.lugarCeremonia")}
+            defaultValue={data?.lugar_ceremonia ?? ""}
+            disabled={soloLectura}
+          />
+          <CampoTexto
+            name="direccion_ceremonia"
+            etiqueta={t("panel.ajustes.direccionCeremonia")}
+            defaultValue={data?.direccion_ceremonia ?? ""}
+            disabled={soloLectura}
+          />
+          <div className="grid gap-elemento sm:grid-cols-2">
+            <CampoTexto
+              name="latitud_ceremonia"
+              inputMode="decimal"
+              etiqueta={t("panel.ajustes.latitud")}
+              ayuda={t("panel.ajustes.coordenadasAyuda")}
+              defaultValue={comoTexto(data?.latitud_ceremonia ?? null)}
+              disabled={soloLectura}
+            />
+            <CampoTexto
+              name="longitud_ceremonia"
+              inputMode="decimal"
+              etiqueta={t("panel.ajustes.longitud")}
+              defaultValue={comoTexto(data?.longitud_ceremonia ?? null)}
+              disabled={soloLectura}
+            />
+          </div>
+        </Grupo>
+
+        <Grupo titulo={t("panel.ajustes.grupoBanquete")}>
+          <CampoTexto
+            name="fecha_hora_banquete"
+            type="datetime-local"
+            etiqueta={t("panel.ajustes.fechaBanquete")}
+            ayuda={t("panel.ajustes.fechaBanqueteAyuda")}
+            defaultValue={enLocal(data?.fecha_hora_banquete)}
+            disabled={soloLectura}
+          />
+          <CampoTexto
+            name="lugar_banquete"
+            etiqueta={t("panel.ajustes.lugarBanquete")}
+            defaultValue={data?.lugar_banquete ?? ""}
+            disabled={soloLectura}
+          />
+          <CampoTexto
+            name="direccion_banquete"
+            etiqueta={t("panel.ajustes.direccionBanquete")}
+            defaultValue={data?.direccion_banquete ?? ""}
+            disabled={soloLectura}
+          />
+          <div className="grid gap-elemento sm:grid-cols-2">
+            <CampoTexto
+              name="latitud_banquete"
+              inputMode="decimal"
+              etiqueta={t("panel.ajustes.latitud")}
+              ayuda={t("panel.ajustes.coordenadasAyuda")}
+              defaultValue={comoTexto(data?.latitud_banquete ?? null)}
+              disabled={soloLectura}
+            />
+            <CampoTexto
+              name="longitud_banquete"
+              inputMode="decimal"
+              etiqueta={t("panel.ajustes.longitud")}
+              defaultValue={comoTexto(data?.longitud_banquete ?? null)}
+              disabled={soloLectura}
+            />
+          </div>
+        </Grupo>
+
+        <Grupo titulo={t("panel.ajustes.grupoContacto")}>
+          <CampoTexto
+            name="correo_contacto"
+            type="email"
+            etiqueta={t("panel.ajustes.correo")}
+            ayuda={t("panel.ajustes.correoAyuda")}
+            defaultValue={data?.correo_contacto ?? ""}
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            disabled={soloLectura}
+          />
+          <CampoTexto
+            name="fecha_limite_rsvp"
+            type="datetime-local"
+            etiqueta={t("panel.ajustes.limiteRsvp")}
+            ayuda={t("panel.ajustes.limiteRsvpAyuda")}
+            defaultValue={enLocal(data?.fecha_limite_rsvp)}
+            required
+            disabled={soloLectura}
+          />
+        </Grupo>
+
+        {soloLectura ? null : (
+          <div>
+            <Boton type="submit">{t("panel.ajustes.guardar")}</Boton>
+          </div>
+        )}
+      </form>
+
+      <div>
+        <Etiqueta>{t("panel.ajustes.zonaHoraria")}</Etiqueta>
+        <Cuerpo className="mt-linea">{zona}</Cuerpo>
+      </div>
+    </div>
+  );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -65,6 +65,7 @@ export const RUTA_PANEL = "/panel";
 export const RUTA_RECUPERAR = "/acceso/recuperar";
 export const RUTA_NUEVA_CONTRASENA = "/acceso/nueva-contrasena";
 export const RUTA_CUENTA = "/panel/cuenta";
+export const RUTA_AJUSTES = "/panel/ajustes";
 
 /**
  * Dónde se anota la ruta que alguien pidió antes de que le mandaran a la

--- a/src/config/modulos.ts
+++ b/src/config/modulos.ts
@@ -1,4 +1,4 @@
-import { RUTA_CUENTA, RUTA_PANEL } from "./constants";
+import { RUTA_AJUSTES, RUTA_CUENTA, RUTA_PANEL } from "./constants";
 
 /**
  * LOS MÓDULOS DEL PANEL
@@ -40,6 +40,7 @@ export const MODULOS = [
   { clave: "proveedores", ruta: `${RUTA_PANEL}/proveedores`, entregado: false },
   { clave: "presupuesto", ruta: `${RUTA_PANEL}/presupuesto`, entregado: false },
   { clave: "tareas", ruta: `${RUTA_PANEL}/tareas`, entregado: false },
+  { clave: "ajustes", ruta: RUTA_AJUSTES, entregado: true },
   { clave: "cuenta", ruta: RUTA_CUENTA, entregado: true },
 ] as const satisfies readonly Modulo[];
 

--- a/src/lib/zona-horaria.ts
+++ b/src/lib/zona-horaria.ts
@@ -1,0 +1,99 @@
+/**
+ * FECHAS DE LA BODA, ENTRE EL FORMULARIO Y LA BASE
+ *
+ * La base guarda instantes (`timestamptz`) y el formulario usa
+ * `<input type="datetime-local">`, que da y espera una fecha SIN zona: el
+ * navegador escribe «2027-06-26T13:00» y no dice de dónde.
+ *
+ * Interpretar ese texto con `new Date(...)` usa la zona del servidor, que en
+ * Vercel es UTC. En verano España va dos horas por delante, así que una
+ * ceremonia guardada «a las 13:00» saldría en la web a las 15:00. El fallo es
+ * silencioso —una fecha válida, sólo que la equivocada— y no lo descubriría
+ * nadie hasta que un invitado se presentara a la hora que no era.
+ *
+ * Así que la zona se pasa siempre explícita: la de la boda, que vive en
+ * `configuracion_boda.zona_horaria`. Aquí no hay ninguna zona por defecto a
+ * propósito — quien llama tiene que decir cuál, y así no se puede olvidar.
+ */
+
+/**
+ * Cuánto se adelanta `zona` respecto a UTC en ese instante concreto, en
+ * milisegundos. Es específico del instante porque el horario de verano existe:
+ * en Madrid son +1 h en enero y +2 h en julio.
+ */
+function desfase(instante: Date, zona: string): number {
+  const formato = new Intl.DateTimeFormat("en-US", {
+    timeZone: zona,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+
+  const partes = Object.fromEntries(
+    formato.formatToParts(instante).map((parte) => [parte.type, parte.value]),
+  );
+
+  // `hour` puede venir como «24» a medianoche según el motor; `% 24` lo deja
+  // en 0, que es el mismo momento.
+  const comoSiFueraUtc = Date.UTC(
+    Number(partes.year),
+    Number(partes.month) - 1,
+    Number(partes.day),
+    Number(partes.hour) % 24,
+    Number(partes.minute),
+    Number(partes.second),
+  );
+
+  return comoSiFueraUtc - instante.getTime();
+}
+
+/**
+ * `"2027-06-26T13:00"` en `Europe/Madrid` → el instante real (UTC).
+ *
+ * Devuelve `null` si el texto no es una fecha con hora: un campo vacío o a
+ * medio escribir no es un error que haya que gritar, es «no hay dato».
+ *
+ * El desfase se calcula dos veces porque el propio desfase depende del
+ * instante, y el instante es lo que se está buscando. La primera pasada da una
+ * aproximación; la segunda la corrige en el único caso que importa, cuando la
+ * fecha cae justo en el cambio de hora y las dos pasadas discrepan.
+ */
+export function instanteDesdeLocal(texto: string, zona: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/.test(texto)) return null;
+
+  const conSegundos = texto.length === 16 ? `${texto}:00` : texto;
+  const comoUtc = new Date(`${conSegundos}Z`);
+  if (Number.isNaN(comoUtc.getTime())) return null;
+
+  const primera = new Date(comoUtc.getTime() - desfase(comoUtc, zona));
+  const segunda = new Date(comoUtc.getTime() - desfase(primera, zona));
+
+  return segunda;
+}
+
+/**
+ * El camino de vuelta: un instante → `"2027-06-26T13:00"` en `zona`, que es lo
+ * que entiende `<input type="datetime-local">` como valor inicial.
+ */
+export function localDesdeInstante(instante: Date, zona: string): string {
+  if (Number.isNaN(instante.getTime())) return "";
+
+  const formato = new Intl.DateTimeFormat("sv-SE", {
+    timeZone: zona,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  // El sueco escribe las fechas como `2027-06-26 13:00`, que es la norma ISO
+  // salvo por el espacio. Se cambia por la «T» y ya está en el formato del
+  // campo, sin componerlo a mano trozo a trozo.
+  return formato.format(instante).replace(" ", "T");
+}

--- a/tests/e2e/panel-ajustes.spec.ts
+++ b/tests/e2e/panel-ajustes.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "@playwright/test";
+
+import copy from "../../content/copy.es.json";
+import { RUTA_ACCESO, RUTA_AJUSTES, RUTA_PANEL } from "../../src/config/constants";
+
+/**
+ * BODA-44 · Ajustes de la boda
+ *
+ * Lo que se comprueba aquí es la cadena entera, no la pantalla: que lo que se
+ * escribe en el panel sale en la portada de la landing. Si esa vuelta funciona,
+ * `configuracion_boda` está de verdad cableada — que es todo el ticket.
+ *
+ * Necesita sesión, así que vive en el trabajo de CI que levanta el Supabase
+ * local y se salta en cualquier otro sitio.
+ */
+
+const CORREO_CON_ACCESO = process.env.CORREO_CON_ACCESO;
+const CONTRASENA = process.env.CONTRASENA_PRUEBAS;
+
+/** Marca de agua para no confundir lo que escribe el test con el seed. */
+const SUFIJO = "-E2E";
+
+test.describe("Ajustes de la boda", () => {
+  test.skip(
+    !CORREO_CON_ACCESO || !CONTRASENA,
+    "Necesita el Supabase local: solo corre en el trabajo de CI que lo levanta.",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(RUTA_ACCESO);
+    await page.getByLabel(copy.acceso.correo).fill(CORREO_CON_ACCESO!);
+    await page.getByLabel(copy.acceso.contrasena).fill(CONTRASENA!);
+    await page.getByRole("button", { name: copy.acceso.entrar }).click();
+    await expect(page).toHaveURL(new RegExp(RUTA_PANEL));
+    await page.goto(RUTA_AJUSTES);
+  });
+
+  test("se llega desde el menú del panel", async ({ page }) => {
+    await page.goto(RUTA_PANEL);
+    const menu = page.getByRole("navigation", { name: copy.panel.navegacion }).first();
+    await menu.getByRole("link", { name: copy.panel.modulos.ajustes }).click();
+
+    await expect(page).toHaveURL(new RegExp(RUTA_AJUSTES));
+    await expect(page.getByRole("heading", { name: copy.panel.ajustes.titulo })).toBeVisible();
+  });
+
+  test("la pantalla llega con los datos que hay en la base", async ({ page }) => {
+    // Vacío significaría que la consulta no trajo nada y el formulario
+    // guardaría encima un hueco.
+    await expect(page.getByLabel(copy.panel.ajustes.nombreNovia)).not.toHaveValue("");
+    await expect(page.getByLabel(copy.panel.ajustes.fechaCeremonia)).not.toHaveValue("");
+  });
+
+  /**
+   * CAMINO FELIZ. Cambiar los nombres en el panel los cambia en la portada.
+   */
+  test("cambiar los nombres los cambia en la portada de la landing", async ({ page }) => {
+    const novia = page.getByLabel(copy.panel.ajustes.nombreNovia);
+    const novio = page.getByLabel(copy.panel.ajustes.nombreNovio);
+
+    const nuevaNovia = `Paloma${SUFIJO}`;
+    const nuevoNovio = `David${SUFIJO}`;
+    await novia.fill(nuevaNovia);
+    await novio.fill(nuevoNovio);
+    await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
+
+    await expect(page.getByText(copy.panel.ajustes.guardado)).toBeVisible();
+    // Y persiste: al recargar sigue ahí, no era sólo el eco del formulario.
+    await page.reload();
+    await expect(page.getByLabel(copy.panel.ajustes.nombreNovia)).toHaveValue(nuevaNovia);
+
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 }).first()).toContainText(nuevaNovia);
+    await expect(page.getByText(nuevoNovio).first()).toBeVisible();
+  });
+
+  test("la hora de la ceremonia no se mueve al guardar sin tocarla", async ({ page }) => {
+    // El fallo clásico de estos formularios: cada guardado corre la hora unas
+    // horas porque el texto sin zona se interpreta con la del servidor.
+    const campo = page.getByLabel(copy.panel.ajustes.fechaCeremonia);
+    const antes = await campo.inputValue();
+
+    await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
+    await expect(page.getByText(copy.panel.ajustes.guardado)).toBeVisible();
+
+    await expect(page.getByLabel(copy.panel.ajustes.fechaCeremonia)).toHaveValue(antes);
+  });
+
+  /**
+   * CASO DE ERROR. Una fecha límite posterior a la boda se rechaza con un
+   * mensaje claro y no se guarda.
+   */
+  test("una fecha límite posterior a la boda se rechaza y no se guarda", async ({ page }) => {
+    const ceremonia = await page.getByLabel(copy.panel.ajustes.fechaCeremonia).inputValue();
+    const limite = page.getByLabel(copy.panel.ajustes.limiteRsvp);
+    const antes = await limite.inputValue();
+
+    // Un año después de la ceremonia: imposible por definición.
+    const tarde = ceremonia.replace(/^(\d{4})/, (anio) => String(Number(anio) + 1));
+    await limite.fill(tarde);
+    await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
+
+    await expect(page.getByRole("alert")).toContainText(copy.panel.ajustes.errorLimiteTarde);
+
+    // Y lo que importa: no se ha guardado.
+    await page.reload();
+    await expect(page.getByLabel(copy.panel.ajustes.limiteRsvp)).toHaveValue(antes);
+  });
+
+  test("unas coordenadas a medias se rechazan", async ({ page }) => {
+    // La base exige las dos o ninguna: media coordenada no señala ningún sitio.
+    await page.getByLabel(copy.panel.ajustes.latitud).first().fill("42,5987");
+    await page.getByLabel(copy.panel.ajustes.longitud).first().fill("");
+    await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
+
+    await expect(page.getByRole("alert")).toContainText(copy.panel.ajustes.errorCoordenadas);
+  });
+
+  test("un hashtag sin almohadilla se rechaza", async ({ page }) => {
+    await page.getByLabel(copy.panel.ajustes.hashtag).fill("PalomaYDavid");
+    await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
+
+    await expect(page.getByRole("alert")).toContainText(copy.panel.ajustes.errorHashtag);
+  });
+
+  test("el formulario se envía sin JavaScript", async ({ browser }) => {
+    // Los datos más visibles de la boda no pueden depender de que cargue un
+    // bundle. Es un `<form>` con Server Action, así que tiene que ir igual.
+    const contexto = await browser.newContext({ javaScriptEnabled: false });
+    const pagina = await contexto.newPage();
+
+    await pagina.goto(RUTA_ACCESO);
+    await pagina.getByLabel(copy.acceso.correo).fill(CORREO_CON_ACCESO!);
+    await pagina.getByLabel(copy.acceso.contrasena).fill(CONTRASENA!);
+    await pagina.getByRole("button", { name: copy.acceso.entrar }).click();
+    await pagina.waitForURL(new RegExp(RUTA_PANEL));
+
+    await pagina.goto(RUTA_AJUSTES);
+    const marca = `SinJS${SUFIJO}`;
+    await pagina.getByLabel(copy.panel.ajustes.nombreNovia).fill(marca);
+    await pagina.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
+
+    await expect(pagina.getByText(copy.panel.ajustes.guardado)).toBeVisible();
+    await expect(pagina.getByLabel(copy.panel.ajustes.nombreNovia)).toHaveValue(marca);
+
+    await contexto.close();
+  });
+});

--- a/tests/e2e/panel-ajustes.spec.ts
+++ b/tests/e2e/panel-ajustes.spec.ts
@@ -17,8 +17,26 @@ import { RUTA_ACCESO, RUTA_AJUSTES, RUTA_PANEL } from "../../src/config/constant
 const CORREO_CON_ACCESO = process.env.CORREO_CON_ACCESO;
 const CONTRASENA = process.env.CONTRASENA_PRUEBAS;
 
-/** Marca de agua para no confundir lo que escribe el test con el seed. */
-const SUFIJO = "-E2E";
+/**
+ * Marca de agua para no confundir lo que escribe el test con el seed.
+ *
+ * OJO CON EL PREFIJO «(DES)»: media suite comprueba que la landing enseña los
+ * datos del seed buscando justo esa marca. Este fichero es el único que
+ * ESCRIBE en `configuracion_boda`, que es una fila única y compartida por
+ * todos los tests. Sin conservar el prefijo, cambiar aquí los nombres tumbaba
+ * `resiliencia` y `reserva-la-fecha` — y el fallo salía en el fichero de otro,
+ * que es la peor forma de enterarse.
+ */
+const MARCA = "(DES) E2E";
+
+/**
+ * El anunciador de rutas de Next también es `role="alert"`, así que buscarlo a
+ * secas encuentra dos y Playwright se planta. Los avisos de esta pantalla viven
+ * dentro del `<main>` del panel; el de Next, fuera.
+ */
+function avisoDe(pagina: import("@playwright/test").Page) {
+  return pagina.locator("main").getByRole("alert");
+}
 
 test.describe("Ajustes de la boda", () => {
   test.skip(
@@ -58,8 +76,13 @@ test.describe("Ajustes de la boda", () => {
     const novia = page.getByLabel(copy.panel.ajustes.nombreNovia);
     const novio = page.getByLabel(copy.panel.ajustes.nombreNovio);
 
-    const nuevaNovia = `Paloma${SUFIJO}`;
-    const nuevoNovio = `David${SUFIJO}`;
+    // Se guardan los originales para devolverlos al final: la fila es única y
+    // la comparten todos los tests de la suite.
+    const noviaOriginal = await novia.inputValue();
+    const novioOriginal = await novio.inputValue();
+
+    const nuevaNovia = `${MARCA} Paloma`;
+    const nuevoNovio = `${MARCA} David`;
     await novia.fill(nuevaNovia);
     await novio.fill(nuevoNovio);
     await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
@@ -72,6 +95,12 @@ test.describe("Ajustes de la boda", () => {
     await page.goto("/");
     await expect(page.getByRole("heading", { level: 1 }).first()).toContainText(nuevaNovia);
     await expect(page.getByText(nuevoNovio).first()).toBeVisible();
+
+    await page.goto(RUTA_AJUSTES);
+    await page.getByLabel(copy.panel.ajustes.nombreNovia).fill(noviaOriginal);
+    await page.getByLabel(copy.panel.ajustes.nombreNovio).fill(novioOriginal);
+    await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
+    await expect(page.getByText(copy.panel.ajustes.guardado)).toBeVisible();
   });
 
   test("la hora de la ceremonia no se mueve al guardar sin tocarla", async ({ page }) => {
@@ -100,7 +129,7 @@ test.describe("Ajustes de la boda", () => {
     await limite.fill(tarde);
     await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
 
-    await expect(page.getByRole("alert")).toContainText(copy.panel.ajustes.errorLimiteTarde);
+    await expect(avisoDe(page)).toContainText(copy.panel.ajustes.errorLimiteTarde);
 
     // Y lo que importa: no se ha guardado.
     await page.reload();
@@ -113,36 +142,40 @@ test.describe("Ajustes de la boda", () => {
     await page.getByLabel(copy.panel.ajustes.longitud).first().fill("");
     await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
 
-    await expect(page.getByRole("alert")).toContainText(copy.panel.ajustes.errorCoordenadas);
+    await expect(avisoDe(page)).toContainText(copy.panel.ajustes.errorCoordenadas);
   });
 
   test("un hashtag sin almohadilla se rechaza", async ({ page }) => {
     await page.getByLabel(copy.panel.ajustes.hashtag).fill("PalomaYDavid");
     await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
 
-    await expect(page.getByRole("alert")).toContainText(copy.panel.ajustes.errorHashtag);
+    await expect(avisoDe(page)).toContainText(copy.panel.ajustes.errorHashtag);
   });
 
-  test("el formulario se envía sin JavaScript", async ({ browser }) => {
-    // Los datos más visibles de la boda no pueden depender de que cargue un
-    // bundle. Es un `<form>` con Server Action, así que tiene que ir igual.
-    const contexto = await browser.newContext({ javaScriptEnabled: false });
-    const pagina = await contexto.newPage();
+  /**
+   * FALTA EL RECORRIDO SIN JAVASCRIPT, y no por descuido.
+   *
+   * El formulario sí es un `<form>` con Server Action: se envía sin una línea
+   * de JavaScript de cliente. Lo que no funciona sin JS es **pintar la
+   * pantalla**, y no es cosa de este ticket: `src/app/panel/loading.tsx` abre
+   * un límite de Suspense para todo el segmento, así que Next sirve el
+   * contenido dentro de un contenedor oculto y es un script quien lo coloca.
+   * Sin JS, el campo existe en el HTML y no se ve. Le pasa a todo el panel
+   * desde BODA-42, no sólo a esta pantalla.
+   *
+   * Se anota en su propia incidencia en lugar de escribir aquí una versión
+   * descafeinada del test que pase sin comprobar lo que dice comprobar. Donde
+   * esto importa de verdad es en el RSVP (#42), que lo abren invitados desde un
+   * móvil prestado: ahí hay que diseñarlo sin Suspense desde el principio.
+   */
+  test("el aviso de guardado se anuncia sin interrumpir la lectura", async ({ page }) => {
+    // El que sale bien es `status` y el que sale mal es `alert`: el primero no
+    // debe cortar a un lector de pantalla y el segundo sí.
+    await page.getByLabel(copy.panel.ajustes.hashtag).fill("#PalomaYDavid");
+    await page.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
 
-    await pagina.goto(RUTA_ACCESO);
-    await pagina.getByLabel(copy.acceso.correo).fill(CORREO_CON_ACCESO!);
-    await pagina.getByLabel(copy.acceso.contrasena).fill(CONTRASENA!);
-    await pagina.getByRole("button", { name: copy.acceso.entrar }).click();
-    await pagina.waitForURL(new RegExp(RUTA_PANEL));
-
-    await pagina.goto(RUTA_AJUSTES);
-    const marca = `SinJS${SUFIJO}`;
-    await pagina.getByLabel(copy.panel.ajustes.nombreNovia).fill(marca);
-    await pagina.getByRole("button", { name: copy.panel.ajustes.guardar }).click();
-
-    await expect(pagina.getByText(copy.panel.ajustes.guardado)).toBeVisible();
-    await expect(pagina.getByLabel(copy.panel.ajustes.nombreNovia)).toHaveValue(marca);
-
-    await contexto.close();
+    await expect(page.locator("main").getByRole("status")).toContainText(
+      copy.panel.ajustes.guardado,
+    );
   });
 });

--- a/tests/unidad/ci.test.ts
+++ b/tests/unidad/ci.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * El CI tiene que ejecutar los tests que existen, no los que existían
+ *
+ * Este fichero nace de un fallo real y silencioso. El trabajo que levanta el
+ * Supabase de verdad —el único donde pueden correr los tests con sesión—
+ * enumeraba los specs a mano:
+ *
+ *     npx playwright test --project=escritorio tests/e2e/acceso-real.spec.ts tests/e2e/panel.spec.ts
+ *
+ * En cuanto apareció un tercer spec con sesión, quedó fuera de esa lista. Y
+ * como fuera de ese trabajo no hay Supabase, ese spec se saltaba solo. Nadie
+ * lo ejecutaba nunca, y el módulo entero pasaba por entregado y probado.
+ *
+ * Lo peor no es que falle: es que sale verde.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+
+describe("flujo de CI", () => {
+  const ci = readFileSync(join(RAIZ, ".github/workflows/ci.yml"), "utf8");
+
+  it("no enumera ficheros de test a mano", () => {
+    // Una lista de rutas dentro de una invocación de Playwright es una lista
+    // que se queda atrás. Se ejecuta la suite y que Playwright decida.
+    const invocaciones = [...ci.matchAll(/npx playwright test[^\n]*/g)].map((m) => m[0]);
+
+    expect(
+      invocaciones.length,
+      "Se esperaba al menos una llamada a Playwright",
+    ).toBeGreaterThan(0);
+
+    for (const invocacion of invocaciones) {
+      expect(
+        invocacion,
+        `Este comando nombra specs a mano y se quedará atrás:\n  ${invocacion}\n` +
+          "Ejecuta la suite entera, o selecciona por proyecto o por etiqueta.",
+      ).not.toMatch(/tests\/e2e\/\S+\.spec\.ts/);
+    }
+  });
+
+  it("el trabajo con Supabase real sigue existiendo", () => {
+    // Si alguien lo quitara, los tests con sesión se saltarían en todas
+    // partes y el panel dejaría de estar probado sin que nada se pusiera rojo.
+    expect(ci).toContain("supabase start");
+    expect(ci).toContain("preparar-acceso-pruebas.sh");
+  });
+});

--- a/tests/unidad/zona-horaria.test.ts
+++ b/tests/unidad/zona-horaria.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { instanteDesdeLocal, localDesdeInstante } from "@/lib/zona-horaria";
+
+/**
+ * BODA-44 · Las horas de la boda
+ *
+ * Este fichero existe por un fallo que no da error: si el texto del formulario
+ * se interpreta con la zona del servidor —UTC en Vercel—, una ceremonia
+ * guardada «a las 13:00» sale publicada a las 15:00 en verano. Todo válido,
+ * todo verde, y la hora equivocada en la web.
+ *
+ * Se prueba contra `Europe/Madrid`, que es la zona de la boda, y en las dos
+ * mitades del año: en invierno va +1 y en verano +2.
+ */
+
+const MADRID = "Europe/Madrid";
+
+describe("instanteDesdeLocal", () => {
+  it("interpreta una hora de verano con el desfase de verano (+2)", () => {
+    // 26 de junio de 2027, la boda. Madrid va +2 en junio.
+    const instante = instanteDesdeLocal("2027-06-26T13:00", MADRID);
+    expect(instante?.toISOString()).toBe("2027-06-26T11:00:00.000Z");
+  });
+
+  it("interpreta una hora de invierno con el desfase de invierno (+1)", () => {
+    const instante = instanteDesdeLocal("2027-01-15T13:00", MADRID);
+    expect(instante?.toISOString()).toBe("2027-01-15T12:00:00.000Z");
+  });
+
+  it("no se deja arrastrar por la zona del servidor", () => {
+    // La misma pared horaria en dos zonas distintas tiene que dar dos
+    // instantes distintos. Si el código usara la del proceso, saldrían iguales.
+    const madrid = instanteDesdeLocal("2027-06-26T13:00", MADRID);
+    const canarias = instanteDesdeLocal("2027-06-26T13:00", "Atlantic/Canary");
+    expect(madrid?.toISOString()).not.toBe(canarias?.toISOString());
+  });
+
+  it("acepta segundos y los respeta", () => {
+    expect(instanteDesdeLocal("2027-06-26T13:00:30", MADRID)?.toISOString()).toBe(
+      "2027-06-26T11:00:30.000Z",
+    );
+  });
+
+  it("devuelve null cuando no hay fecha, en lugar de inventarse una", () => {
+    // Un campo opcional vacío es un valor legítimo, no un error.
+    for (const texto of ["", "   ", "2027-06-26", "mañana", "2027-13-45T99:99"]) {
+      expect(instanteDesdeLocal(texto, MADRID), `"${texto}" debería ser null`).toBeNull();
+    }
+  });
+});
+
+describe("localDesdeInstante", () => {
+  it("devuelve el formato exacto que espera datetime-local", () => {
+    const texto = localDesdeInstante(new Date("2027-06-26T11:00:00.000Z"), MADRID);
+    expect(texto).toBe("2027-06-26T13:00");
+    expect(texto).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  });
+
+  it("aplica el desfase de invierno", () => {
+    expect(localDesdeInstante(new Date("2027-01-15T12:00:00.000Z"), MADRID)).toBe(
+      "2027-01-15T13:00",
+    );
+  });
+
+  it("es la vuelta exacta de instanteDesdeLocal", () => {
+    // Ida y vuelta sin perder nada: es la garantía de que abrir el formulario,
+    // no tocar nada y guardar no mueve la hora de la boda.
+    for (const texto of ["2027-06-26T13:00", "2027-01-15T09:30", "2027-10-30T23:59"]) {
+      const instante = instanteDesdeLocal(texto, MADRID)!;
+      expect(localDesdeInstante(instante, MADRID)).toBe(texto);
+    }
+  });
+
+  it("con una fecha inválida devuelve cadena vacía y no «Invalid Date»", () => {
+    expect(localDesdeInstante(new Date("no es una fecha"), MADRID)).toBe("");
+  });
+});


### PR DESCRIPTION
## Qué cambia

Hay pantalla para los datos de la boda: **`/panel/ajustes`**.

Closes #88

Esto no es una mejora, es un agujero. Fui a mirar producción y la portada dice literalmente **«Por definir y Por definir»**, con fecha `09/08/2027`, que es un marcador. No estaba roto: `configuracion_boda` nunca ha tenido pantalla, y la única forma de tocarla era el editor SQL de Supabase.

Esa tabla alimenta la portada, la cuenta atrás, las ubicaciones, el `.ics` y la tarjeta de WhatsApp. Era el dato más visible de la web y el único sin sitio donde escribirse.

## Las horas, que es donde esto se rompe

`<input type="datetime-local">` da texto **sin zona** (`2027-06-26T13:00`) y la base guarda instantes. Interpretar ese texto con la zona del proceso —UTC en Vercel— publicaría una ceremonia de las 13:00 **a las 15:00** en verano.

El fallo no da error: es una fecha válida, sólo que la equivocada, y no lo descubre nadie hasta que un invitado se presenta a la hora que no era.

`src/lib/zona-horaria.ts` convierte en los dos sentidos usando la zona de la propia boda (`configuracion_boda.zona_horaria`), y no tiene zona por defecto a propósito: quien llama tiene que decir cuál. Sus 9 tests cubren invierno (+1), verano (+2), ida y vuelta, y que no se deje arrastrar por la zona del servidor.

## Permisos

Los decide RLS (`configuracion_boda_editor_actualizar` exige `puede_editar()`), no la pantalla. Un lector ve los campos deshabilitados y sin botón.

Con un detalle que importa: **RLS no da error cuando prohíbe una escritura** — devuelve cero filas tocadas, porque para la política esa fila no existe. Sin mirar el recuento, un lector vería «Guardado» sin haberse guardado nada. La acción lo comprueba y responde que sus permisos no alcanzan.

## Cómo probarlo en el preview

1. Entra al panel → **Ajustes** (nuevo en el menú).
2. Cambia los nombres por **Paloma** y **David**, la fecha a **26/06/2027** y el lugar a **Finca La Sierra, León**.
3. Vuelve a `/` — la portada, la cuenta atrás y el pie ya lo dicen, sin desplegar.
4. Descarga el `.ics` desde `/reserva-la-fecha`: la hora tiene que coincidir con la que escribiste.
5. Vuelve a Ajustes y pulsa **Guardar** sin tocar nada: la hora **no** debe moverse.
6. Pon una fecha límite posterior a la boda → mensaje claro y no se guarda.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: colores y espaciados son tokens, los textos salen de `content/copy.es.json`, los datos de la boda de la BBDD y los límites de `src/config/constants.ts`
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error
- [x] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion`
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

Verificado en local contra Postgres con migraciones y seed: **128 unitarios** y **78 E2E de escritorio** en verde. Los 8 specs nuevos de `/panel/ajustes` necesitan sesión, así que se saltan aquí y corren en el trabajo de CI con Supabase real.

## Base de datos

- [x] No la toca
- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [x] No hace falta
- [ ] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR

---

### Aparte: una trampa del CI que dejaba tests sin ejecutar

Auditando el backlog salió esto, y afectaba directamente a esta PR. El trabajo que levanta el Supabase de verdad —**el único donde pueden correr los tests con sesión**— enumeraba los specs a mano:

```
npx playwright test --project=escritorio tests/e2e/acceso-real.spec.ts tests/e2e/panel.spec.ts
```

Cualquier spec nuevo con sesión queda fuera de esa lista. Y como fuera de ese trabajo no hay Supabase, **se salta solo**. Resultado: nadie lo ejecuta nunca y el módulo pasa por entregado y probado. Verde por los dos lados.

Los 8 tests de esta PR habrían caído justo ahí. Ahora ese trabajo corre la suite entera —tiene Supabase y base de datos, puede— y `tests/unidad/ci.test.ts` impide que vuelva a escribirse una lista de ficheros.


---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_