### PR TITLE
feat(BODA-19): la portada se reconstruye según la entrega

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -54,7 +54,8 @@
     "altHero": "Paloma y David",
     "conjuncion": "y",
     "enPreparacion": "Estamos preparando la web",
-    "enPreparacionTexto": "Vuelve en un rato y aquí estará todo."
+    "enPreparacionTexto": "Vuelve en un rato y aquí estará todo.",
+    "bajad": "Bajad"
   },
   "cuentaAtras": {
     "titulo": "Nos vemos en",

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,7 +24,40 @@ const CABECERAS_SEGURIDAD = [
   },
 ];
 
+/**
+ * De dónde se aceptan imágenes remotas.
+ *
+ * `next/image` rechaza cualquier origen que no esté declarado, y con razón: sin
+ * esa lista, quien pudiera escribir una URL en la base convertiría nuestro
+ * optimizador en un servicio gratuito para redimensionar imágenes ajenas.
+ *
+ * El host sale de la variable de entorno, no escrito a mano: es el mismo
+ * proyecto de Supabase que ya usa el resto de la aplicación, y así no hay dos
+ * sitios que puedan discrepar. Si la variable falta, la lista queda vacía y no
+ * se acepta ninguna imagen remota, que es lo seguro.
+ */
+function origenesDeImagen() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) return [];
+
+  try {
+    const { protocol, hostname } = new URL(url);
+    return [
+      {
+        protocol: protocol.replace(":", "") as "http" | "https",
+        hostname,
+        pathname: "/storage/v1/object/public/**",
+      },
+    ];
+  } catch {
+    console.warn("NEXT_PUBLIC_SUPABASE_URL no es una URL válida: no se servirán fotos.");
+    return [];
+  }
+}
+
 const nextConfig: NextConfig = {
+  images: { remotePatterns: origenesDeImagen() },
+
   async headers() {
     return [
       {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Fragment, type ReactNode } from "react";
 
 import { EnPreparacion } from "@/components/marketing/en-preparacion";
+import { HuecoFoto } from "@/components/marketing/hueco-foto";
 import { Navegacion } from "@/components/marketing/navegacion";
 import { Pie } from "@/components/marketing/pie";
 import { CuentaAtras } from "@/components/marketing/cuenta-atras";
@@ -24,8 +25,10 @@ import {
   obtenerPreguntasFrecuentes,
   obtenerPrograma,
   obtenerRutas,
+  obtenerMedios,
   obtenerSecciones,
   type ConfiguracionBoda,
+  type Medio,
 } from "@/lib/bbdd/landing";
 import { t } from "@/lib/copy";
 
@@ -79,6 +82,20 @@ const formatoFechaCorta = new Intl.DateTimeFormat(IDIOMA, {
   timeZone: ZONA_HORARIA,
 });
 
+/**
+ * `26 · 06 · 2027`, como en la entrega.
+ *
+ * Se compone a partir de las partes que da `Intl`, no cortando la cadena
+ * formateada: el orden de día y mes depende del idioma, y trocear texto
+ * formateado es la forma clásica de acabar publicando el mes como día.
+ */
+function fechaEnPuntos(fecha: Date): string {
+  const partes = Object.fromEntries(
+    formatoFechaCorta.formatToParts(fecha).map((parte) => [parte.type, parte.value]),
+  );
+  return [partes.day, partes.month, partes.year].join(" · ");
+}
+
 export default async function PaginaInicio() {
   let datos;
   try {
@@ -98,6 +115,7 @@ export default async function PaginaInicio() {
     rutas,
     preguntas,
     canciones,
+    fotosPortada,
   } = datos;
 
   // Sin configuración no hay boda que enseñar: la base respondió, pero el panel
@@ -108,7 +126,13 @@ export default async function PaginaInicio() {
   const nombres = `${configuracion.nombreNovia} ${t("portada.conjuncion")} ${configuracion.nombreNovio}`;
 
   const contenido: Partial<Record<Seccion, ReactNode>> = {
-    portada: <Portada configuracion={configuracion} />,
+    portada: (
+      <Portada
+        configuracion={configuracion}
+        foto={fotosPortada[0] ?? null}
+        urlBase={process.env.NEXT_PUBLIC_SUPABASE_URL}
+      />
+    ),
     cuenta_atras: <CuentaAtrasSeccion configuracion={configuracion} />,
     historia: historia.length > 0 ? <Historia hitos={historia} /> : undefined,
     programa:
@@ -177,6 +201,7 @@ async function cargarLanding() {
     rutas,
     preguntas,
     canciones,
+    fotosPortada,
   ] = await Promise.all([
     obtenerSecciones(),
     obtenerConfiguracion(),
@@ -186,6 +211,7 @@ async function cargarLanding() {
     obtenerRutas(),
     obtenerPreguntasFrecuentes(),
     obtenerCanciones(),
+    obtenerMedios("portada"),
   ]);
 
   return {
@@ -197,6 +223,7 @@ async function cargarLanding() {
     rutas,
     preguntas,
     canciones,
+    fotosPortada,
   };
 }
 
@@ -204,16 +231,44 @@ async function cargarLanding() {
 /* Secciones                                                                 */
 /* ------------------------------------------------------------------------ */
 
-function Portada({ configuracion }: { configuracion: ConfiguracionBoda }) {
+/**
+ * LA PORTADA
+ *
+ * La pantalla partida de la entrega: el texto ocupa una mitad y la foto la
+ * otra, y en cuanto no caben dos columnas —móvil, o una ventana estrecha— se
+ * apilan solas. No hay `breakpoint` escrito: lo resuelve `auto-fit` con un
+ * ancho mínimo de columna, así que el corte pasa cuando de verdad estorba y no
+ * a un número redondo.
+ *
+ * LA PARTICIÓN SÓLO EXISTE SI HAY FOTO. Todavía no las hay —la sesión de
+ * preboda ni siquiera está decidida— y media pantalla en blanco no se lee como
+ * una decisión de diseño, se lee como algo que no ha cargado. Sin foto, el
+ * texto se queda en una columna centrada y la portada se sostiene sola; el día
+ * que se publique una imagen, `auto-fit` abre la segunda columna sin que haya
+ * que tocar nada.
+ *
+ * El bloque de datos usa `--texto-titulo-2` y la fecha va en `26 · 06 · 2027`,
+ * que es como la escribe la marca en todas las piezas.
+ */
+function Portada({
+  configuracion,
+  foto,
+  urlBase,
+}: {
+  configuracion: ConfiguracionBoda;
+  foto: Medio | null;
+  urlBase: string | undefined;
+}) {
   const lugar = configuracion.lugarCeremonia ?? configuracion.lugarBanquete;
   const procedencia = configuracion.direccionCeremonia;
 
   return (
-    <section
-      id={anclaDe("portada")}
-      className="grid min-h-dvh items-center px-interno py-seccion-compacta"
-    >
-      <div className="mx-auto w-full max-w-contenido">
+    <section id={anclaDe("portada")} className="rejilla-partida min-h-dvh items-stretch">
+      <div
+        className={`flex w-full flex-col justify-center px-interno py-seccion-compacta sm:px-bloque ${
+          foto ? "" : "mx-auto max-w-contenido"
+        }`}
+      >
         {procedencia ? (
           <p className="animacion-aparecer text-etiqueta uppercase tracking-marcado text-acento">
             {procedencia}
@@ -233,9 +288,9 @@ function Portada({ configuracion }: { configuracion: ConfiguracionBoda }) {
             <dt className="text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">
               {t("portada.etiquetaFecha")}
             </dt>
-            <dd className="mt-linea font-titulo text-titulo-2">
+            <dd className="mt-linea font-titulo text-titulo-2 text-tinta-marca tabular-nums">
               <time dateTime={configuracion.fechaCeremonia.toISOString()}>
-                {formatoFechaCorta.format(configuracion.fechaCeremonia)}
+                {fechaEnPuntos(configuracion.fechaCeremonia)}
               </time>
             </dd>
           </div>
@@ -244,7 +299,7 @@ function Portada({ configuracion }: { configuracion: ConfiguracionBoda }) {
               <dt className="text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">
                 {t("portada.etiquetaLugar")}
               </dt>
-              <dd className="mt-linea font-titulo text-titulo-2">{lugar}</dd>
+              <dd className="mt-linea font-titulo text-titulo-2 text-tinta-marca">{lugar}</dd>
             </div>
           ) : null}
         </dl>
@@ -257,7 +312,35 @@ function Portada({ configuracion }: { configuracion: ConfiguracionBoda }) {
             {t("portada.verElDia")}
           </BotonEnlace>
         </div>
+
+        {/*
+          El aviso de que la página sigue hacia abajo. Con una portada a
+          pantalla completa hay quien se queda ahí sin saber que hay más, y
+          este es el trabajo que hace la entrega con dos elementos y ningún
+          icono: una versalita y una raya que respira.
+
+          `aria-hidden` porque para quien navega con lector de pantalla no
+          significa nada: el documento ya continúa, y anunciar «bajad» sería
+          ruido. La animación es de las que se apagan con movimiento reducido.
+        */}
+        <p
+          aria-hidden
+          className="animacion-aparecer mt-elemento flex items-center gap-interno-compacto text-diminuto uppercase tracking-marcado text-tinta-tenue"
+        >
+          {t("portada.bajad")}
+          <span className="animacion-flotar block h-elemento w-px bg-gradient-to-b from-borde-fuerte to-transparent" />
+        </p>
       </div>
+
+      {foto ? (
+        <HuecoFoto
+          medio={foto}
+          urlBase={urlBase}
+          prioritaria
+          medidas="(min-width: 40rem) 50vw, 100vw"
+          className="alto-foto-portada"
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/components/marketing/hueco-foto.tsx
+++ b/src/components/marketing/hueco-foto.tsx
@@ -1,0 +1,76 @@
+import Image from "next/image";
+
+import { BUCKET_MEDIOS } from "@/config/constants";
+import type { Medio } from "@/lib/bbdd/landing";
+
+/**
+ * EL HUECO DE UNA FOTO
+ *
+ * La entrega es un diseño conducido por fotografía: la portada parte la
+ * pantalla en dos y la mitad derecha es una imagen. Pero las fotos todavía no
+ * existen, y van a tardar —la sesión de preboda ni siquiera está decidida—.
+ *
+ * De ahí este componente. Lee de `medios` de verdad: el día que se publique una
+ * fila, la foto aparece sola y sin tocar código. Mientras tanto pinta el vacío
+ * que trae la propia entrega —superficie hundida, sin dibujos ni iconos de
+ * «imagen rota»— y la sección se sostiene igual.
+ *
+ * NO PINTA UN MARCADOR DE POSICIÓN CON TEXTO. Un recuadro que pone «foto
+ * vertical de los novios» es una nota para el equipo que se acaba enseñando a
+ * los invitados. Si no hay foto, lo honesto es un plano de color que forma
+ * parte del diseño.
+ */
+
+interface Propiedades {
+  /** La imagen publicada, o `null` si esa sección todavía no tiene ninguna. */
+  medio: Medio | null;
+  /** URL pública de Supabase, para componer la ruta del bucket. */
+  urlBase: string | undefined;
+  /** `sizes` de `next/image`: cuánto ocupa el hueco en cada tamaño. */
+  medidas: string;
+  className?: string;
+  /** La portada se ve nada más entrar: esa no puede cargar en diferido. */
+  prioritaria?: boolean;
+}
+
+export function HuecoFoto({
+  medio,
+  urlBase,
+  medidas,
+  className = "",
+  prioritaria = false,
+}: Propiedades) {
+  const fuente =
+    medio && urlBase
+      ? `${urlBase}/storage/v1/object/public/${BUCKET_MEDIOS}/${medio.ruta}`
+      : null;
+
+  return (
+    <div className={`relative overflow-hidden bg-superficie-hundida ${className}`}>
+      {fuente ? (
+        <Image
+          src={fuente}
+          alt={medio!.textoAlternativo}
+          fill
+          sizes={medidas}
+          priority={prioritaria}
+          className="object-cover"
+          // El marcador borroso lo calcula quien sube la imagen. Sin él, el
+          // hueco se queda en el color de fondo, que ya es un estado digno.
+          placeholder={medio!.marcadorBorroso ? "blur" : "empty"}
+          blurDataURL={medio!.marcadorBorroso ?? undefined}
+        />
+      ) : null}
+
+      {/*
+        El degradado que funde la foto con la página por su borde izquierdo.
+        Va también cuando no hay foto: es lo que evita que el hueco se vea como
+        un rectángulo pegado en lugar de como parte de la composición.
+      */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 left-0 w-bloque bg-gradient-to-r from-fondo to-transparent"
+      />
+    </div>
+  );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -37,6 +37,13 @@ export const LONGITUD_TOKEN_INVITACION = 24;
 /** Peso máximo por imagen subida al gestor de fotos. */
 export const PESO_MAXIMO_IMAGEN_MB = 10;
 
+/**
+ * Bucket de Supabase Storage donde viven las fotos de la landing. La base
+ * guarda sólo la ruta relativa —lo impone `es_ruta_almacenamiento_valida`—,
+ * así que el bucket se nombra una vez, aquí.
+ */
+export const BUCKET_MEDIOS = "medios";
+
 /** Idioma de la aplicación. La boda es en España: solo castellano. */
 export const IDIOMA = "es-ES";
 

--- a/src/lib/bbdd/landing.ts
+++ b/src/lib/bbdd/landing.ts
@@ -263,3 +263,56 @@ export async function obtenerCanciones(limite = 30): Promise<Cancion[]> {
   );
   return filas.map((f) => ({ id: f.id, texto: f.texto }));
 }
+
+export interface Medio {
+  id: string;
+  /** Ruta relativa dentro del bucket, tal y como la valida la base. */
+  ruta: string;
+  textoAlternativo: string;
+  ancho: number | null;
+  alto: number | null;
+  /** Miniatura en base64 para pintar algo mientras carga la de verdad. */
+  marcadorBorroso: string | null;
+}
+
+/**
+ * Las imágenes publicadas de una sección, en su orden.
+ *
+ * Sólo devuelve las que están `publicado`: RLS ya lo impone para `anon`, pero
+ * se escribe igual porque esta consulta también se lee, y quien la lee tiene
+ * que ver la intención sin ir a buscar la política.
+ *
+ * El texto alternativo es `jsonb` por idioma. La boda es sólo en castellano
+ * —decisión cerrada en el plan maestro—, así que se saca `es` y se cae al
+ * primer valor que haya si alguien cargó otro idioma: una imagen sin
+ * alternativa es peor que una con la alternativa en el idioma equivocado.
+ */
+export async function obtenerMedios(seccion: Seccion): Promise<Medio[]> {
+  const filas = await leerComoAnonimo(
+    (tx) => tx<
+      {
+        id: string;
+        ruta_almacenamiento: string;
+        texto_alternativo: Record<string, string>;
+        ancho: number | null;
+        alto: number | null;
+        marcador_borroso: string | null;
+      }[]
+    >`
+      select id, ruta_almacenamiento, texto_alternativo, ancho, alto, marcador_borroso
+      from public.medios
+      where publicado and seccion = ${seccion}::public.seccion_landing
+      order by orden nulls last, creado_en
+    `,
+  );
+
+  return filas.map((f) => ({
+    id: f.id,
+    ruta: f.ruta_almacenamiento,
+    textoAlternativo:
+      f.texto_alternativo?.es ?? Object.values(f.texto_alternativo ?? {})[0] ?? "",
+    ancho: f.ancho,
+    alto: f.alto,
+    marcadorBorroso: f.marcador_borroso,
+  }));
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -79,6 +79,7 @@
   --color-borde: var(--borde);
   --color-borde-fuerte: var(--borde-fuerte);
   --color-borde-tenue: var(--borde-tenue);
+  --color-borde-filete: var(--borde-filete);
   --color-borde-marca: var(--borde-marca);
 
   /* Estado */
@@ -196,6 +197,25 @@
 @utility rejilla-dato {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
+}
+
+/**
+ * La rejilla que se parte sola: dos columnas mientras quepan y una en cuanto
+ * no. La usa la portada —texto a un lado, foto al otro—.
+ *
+ * No lleva `breakpoint` a propósito. Con `auto-fit` el corte ocurre cuando la
+ * columna baja del ancho al que deja de leerse, que es lo que de verdad
+ * importa; un breakpoint fijo acierta en el móvil de quien lo escribió y falla
+ * en la ventana a media pantalla de cualquier otro.
+ */
+@utility rejilla-partida {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--ancho-columna-minima)), 1fr));
+}
+
+/** Alto del hueco de foto de la portada una vez la rejilla se ha apilado. */
+@utility alto-foto-portada {
+  min-height: var(--alto-foto-portada);
 }
 
 /**

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -69,6 +69,11 @@
   --color-nieve-100: #eef2f8;
   --color-nieve-150: #eef1f6;
   --color-bruma-300: #dfe4ec;
+
+  /* El filete que separa las filas de las secciones de contenido. Más suave
+     que un borde normal: la entrega lo usa donde una línea marcada partiría
+     la lectura. */
+  --color-bruma-350: #d6dce7;
   --color-bruma-400: #b7c0d0;
 
   /* ---------------------------------------------------------------------
@@ -204,6 +209,20 @@
 
   /* Ancho mínimo de una cifra grande, para que la cuenta atrás no baile. */
   --size-cifra: 5.5rem;
+
+  /**
+   * Ancho mínimo de columna en las rejillas que se parten solas. Por debajo de
+   * esto, dos columnas dejan de leerse y pasan a apilarse. Sale de la entrega,
+   * y por eso el corte no ocurre en un breakpoint redondo sino cuando estorba.
+   */
+  --size-columna-minima: 22.5rem;
+
+  /**
+   * Alto del hueco de foto de la portada cuando la rejilla ya se ha apilado.
+   * `dvh` y no `vh`: en móvil, con la barra del navegador visible, `vh` mide de
+   * más y la foto empuja el contenido fuera de la pantalla.
+   */
+  --size-foto-portada: min(60dvh, 32.5rem);
 
   /**
    * Alto de la barra de navegación. Sale una vez de aquí y sirve para tres

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -65,6 +65,7 @@
   --borde: var(--color-bruma-300);
   --borde-fuerte: var(--color-bruma-400);
   --borde-tenue: var(--color-nieve-150);
+  --borde-filete: var(--color-bruma-350);
   --borde-marca: var(--color-marino-420);
 
   /* --- Estado -------------------------------------------------------- */
@@ -141,6 +142,8 @@
   --alto-control-compacto: var(--size-control-compacto);
   --alto-campo: var(--size-campo);
   --ancho-cifra: var(--size-cifra);
+  --ancho-columna-minima: var(--size-columna-minima);
+  --alto-foto-portada: var(--size-foto-portada);
   --alto-cabecera: var(--size-cabecera);
   --ancho-lateral: var(--size-lateral);
   --alto-barra-movil: var(--size-barra-movil);
@@ -220,6 +223,7 @@
     --borde: var(--color-marino-775);
     --borde-fuerte: var(--color-marino-600);
     --borde-tenue: var(--color-marino-850);
+    --borde-filete: var(--color-marino-800);
     --borde-marca: var(--color-marino-500);
     --exito: var(--color-exito-oscuro);
     --exito-fondo: var(--color-marino-800);
@@ -262,6 +266,7 @@
   --borde: var(--color-marino-775);
   --borde-fuerte: var(--color-marino-600);
   --borde-tenue: var(--color-marino-850);
+  --borde-filete: var(--color-marino-800);
   --borde-marca: var(--color-marino-500);
   --exito: var(--color-exito-oscuro);
   --exito-fondo: var(--color-marino-800);
@@ -312,6 +317,7 @@
   --borde: var(--color-marino-600);
   --borde-fuerte: var(--color-marino-500);
   --borde-tenue: var(--color-marino-775);
+  --borde-filete: var(--color-marino-600);
   --foco: var(--color-bronce-300);
 }
 

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -84,6 +84,38 @@ test.describe("Landing", () => {
   });
 
   /**
+   * BODA-19 · La portada, según la entrega.
+   */
+  test("la fecha se escribe con puntos medios, como la marca", async ({ page }) => {
+    // `26 · 06 · 2027`. Se comprueba el formato, no la fecha: la fecha la pone
+    // la base y cambia; la forma de escribirla es la marca y no cambia.
+    const fecha = page.locator("#portada time").first();
+    await expect(fecha).toHaveText(/^\d{2} · \d{2} · \d{4}$/);
+  });
+
+  test("la portada se parte en dos cuando hay foto publicada", async ({ page }) => {
+    // El seed publica una foto de portada, así que aquí tiene que haber dos
+    // columnas: el texto y la imagen.
+    const columnas = await page
+      .locator("#portada")
+      .evaluate((seccion) => seccion.children.length);
+
+    expect(columnas).toBe(2);
+  });
+
+  /**
+   * CASO DE ERROR. Una imagen sin publicar no puede asomarse a la landing.
+   *
+   * El seed deja una en `galeria` marcada como borrador justamente para esto:
+   * si apareciera, significaría que la consulta se olvidó del filtro y que
+   * cualquier foto a medio subir acabaría en la web.
+   */
+  test("una imagen sin publicar no aparece en ninguna parte", async ({ page }) => {
+    await expect(page.getByAltText(/Borrador/i)).toHaveCount(0);
+    await expect(page.locator('img[src*="galeria-borrador"]')).toHaveCount(0);
+  });
+
+  /**
    * BODA-17 · El conector va en Italianno, y de verdad.
    *
    * Comprobar la clase no valdría: diría que se ha pedido la fuente, no que


### PR DESCRIPTION
## Qué cambia

La portada pasa a ser la pantalla partida de la entrega: texto a un lado, foto vertical al otro.

Closes #96

Paso 2 de 6 de la reconstrucción de la landing.

## Sin `breakpoint` escrito

El corte lo resuelve `auto-fit` con un ancho mínimo de columna (`--ancho-columna-minima`, 360 px, el de la entrega). Ocurre cuando la columna deja de leerse, no en un número redondo — que acierta en el móvil de quien lo escribió y falla en la ventana a media pantalla de cualquier otro.

## La partición sólo aparece si hay foto

Fotos todavía no hay. Y media pantalla en blanco no se lee como una decisión de diseño: se lee como algo que no ha cargado.

Sin foto publicada, el texto se queda en una columna centrada y la portada se sostiene sola. En cuanto exista una fila en `medios`, `auto-fit` abre la segunda columna sin tocar código. Verificados los dos estados con Playwright: `1440px 0 0 0` con un hijo, `720px 720px 0 0` con dos.

## `medios` estaba muerta

Esa tabla llevaba desde E2 sin que la consultara nadie: **ni una referencia en todo el proyecto**, ningún `next/image` y ningún bucket de Storage. Queda cableada, respetando `publicado` — que es lo que impide que una foto a medio subir acabe en la web.

Subir fotos sigue siendo otro ticket: hace falta el bucket con sus políticas y un gestor en el panel. Aquí sólo se abre el camino de lectura.

## Detalles de la entrega

- Fecha en **`26 · 06 · 2027`**, compuesta por partes y no cortando la cadena formateada: el orden de día y mes depende del idioma, y trocear texto formateado es la forma clásica de acabar publicando el mes como día.
- Bloque de datos en `--tinta-marca`.
- Indicador de «bajad»: versalita y un filete que respira. `aria-hidden`, porque para quien usa lector de pantalla el documento ya continúa y anunciarlo sería ruido. Se apaga con `prefers-reduced-motion`.

## Seguridad de las imágenes

`next/image` sólo acepta imágenes del proyecto de Supabase que ya usa la aplicación, y el host sale de la variable de entorno, no escrito a mano. Sin esa lista, quien pudiera escribir una URL en la base convertiría nuestro optimizador en un servicio gratuito para redimensionar imágenes ajenas. Si la variable falta, no se acepta ninguna imagen remota.

## Cómo probarlo en el preview

1. La portada ocupa la pantalla y el texto se lee a la izquierda.
2. Estrecha la ventana: las dos columnas se apilan solas, sin salto brusco.
3. La fecha se escribe con puntos medios.
4. Abajo a la izquierda, «BAJAD» con su filete.
5. Con `prefers-reduced-motion` activado, el filete deja de moverse.

En el preview no hay fotos en `medios`, así que se verá la versión de una columna — que es justo el estado que tendréis hasta que subáis la primera.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: colores y espaciados son tokens, los textos salen de `content/copy.es.json`, los datos de la boda de la BBDD y los límites de `src/config/constants.ts`
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error
- [x] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion`
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

El caso de error del E2E es el que importa: el seed deja una imagen marcada como borrador, y se comprueba que **no** aparece. Si se colara, significaría que la consulta se olvidó del filtro.

Los valores arbitrarios de Tailwind que pedía esta maquetación (`grid-cols-[…]`, `min-h-[…]`) están prohibidos por ESLint, con razón. Son ahora dos utilidades y dos tokens.

## Base de datos

- [x] No la toca
- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [x] No hace falta
- [ ] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR


---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_