### PR TITLE
feat(BODA-20): la cuenta atrás recupera su cielo

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -63,7 +63,8 @@
     "horas": "horas",
     "minutos": "minutos",
     "segundos": "segundos",
-    "yaEsHoy": "Hoy es el día"
+    "yaEsHoy": "Hoy es el día",
+    "cierre": "Nos hace mucha ilusión celebrarlo con vosotros. Aquí abajo está todo lo que hay que saber."
   },
   "programa": {
     "etiqueta": "El día, hora a hora",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -345,23 +345,39 @@ function Portada({
   );
 }
 
+/**
+ * LA CUENTA ATRÁS, BAJO UN CIELO
+ *
+ * En la entrega no es una franja de color: es una noche. El fondo lleva cuatro
+ * capas de estrellas que derivan durante 44 s y titilan cada 7, tan despacio
+ * que no se leen como animación — sólo se nota que el bloque está vivo.
+ *
+ * El cielo es decoración pura, así que va `aria-hidden` y por debajo del
+ * contenido. Y se apaga entero con `prefers-reduced-motion`: un fondo en
+ * movimiento perpetuo es justo lo que marea a quien activa esa preferencia.
+ */
 function CuentaAtrasSeccion({ configuracion }: { configuracion: ConfiguracionBoda }) {
   const idTitulo = `titulo-${anclaDe("cuenta_atras")}`;
   return (
     <section
       id={anclaDe("cuenta_atras")}
       data-seccion="inversa"
-      className="px-interno py-seccion-compacta text-center"
+      className="relative overflow-hidden px-interno py-seccion-compacta text-center"
       aria-labelledby={idTitulo}
     >
-      <div className="mx-auto max-w-estrecho">
+      <div
+        aria-hidden
+        className="animacion-cielo cielo-estrellado pointer-events-none absolute -inset-bloque"
+      />
+
+      <div className="animacion-cortina-al-ver relative mx-auto max-w-estrecho">
         <Etiqueta id={idTitulo}>{t("cuentaAtras.titulo")}</Etiqueta>
         <div className="mt-elemento">
           <CuentaAtras fechaIso={configuracion.fechaCeremonia.toISOString()} />
         </div>
-        <p className="mt-bloque text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">
-          {formatoFecha.format(configuracion.fechaCeremonia)}
-        </p>
+        <Cita className="mx-auto mt-bloque max-w-texto text-tinta-suave">
+          {t("cuentaAtras.cierre")}
+        </Cita>
       </div>
     </section>
   );

--- a/src/components/marketing/cuenta-atras.tsx
+++ b/src/components/marketing/cuenta-atras.tsx
@@ -73,8 +73,12 @@ export function CuentaAtras({ fechaIso }: { fechaIso: string }) {
       aria-label={`${restante.dias} ${t("cuentaAtras.dias")}`}
     >
       {bloques.map((bloque) => (
-        <div key={bloque.etiqueta} className="min-w-cifra text-center">
-          <div className="font-titulo text-display leading-display tabular-nums">
+        <div key={bloque.etiqueta} className="animacion-escala-al-ver min-w-cifra text-center">
+          {/*
+            Las cifras tienen su propio tamaño, más contenido que el titular:
+            son cuatro seguidas y a tamaño de portada no cabrían en un móvil.
+          */}
+          <div className="font-titulo text-cifra font-light leading-none tabular-nums">
             {bloque.valor}
           </div>
           <div className="mt-linea text-etiqueta uppercase tracking-etiqueta text-tinta-tenue">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -109,6 +109,7 @@
   --text-titulo-2: var(--texto-titulo-2);
   --text-titulo-3: var(--texto-titulo-3);
   --text-conector: var(--texto-conector);
+  --text-cifra: var(--texto-cifra);
   --text-cita: var(--texto-cita);
   --text-cuerpo-grande: var(--texto-cuerpo-grande);
   --text-cuerpo: var(--texto-cuerpo);
@@ -216,6 +217,29 @@
 /** Alto del hueco de foto de la portada una vez la rejilla se ha apilado. */
 @utility alto-foto-portada {
   min-height: var(--alto-foto-portada);
+}
+
+/**
+ * EL CIELO ESTRELLADO de la cuenta atrás.
+ *
+ * Cuatro capas de puntos, cada una con su alfa, su tamaño y su rejilla. Que no
+ * coincidan es lo que lo hace parecer un cielo: cuatro rejillas iguales se
+ * leerían como una trama de imprenta.
+ *
+ * Va en CSS y no como imagen: pesa cero, se adapta a cualquier tamaño de
+ * pantalla y cambia de color solo si algún día cambia la paleta.
+ */
+@utility cielo-estrellado {
+  background-image:
+    radial-gradient(circle at 18% 24%, var(--color-estrella-1) 1.3px, transparent 0),
+    radial-gradient(circle at 64% 12%, var(--color-estrella-2) 1px, transparent 0),
+    radial-gradient(circle at 86% 58%, var(--color-estrella-3) 1.5px, transparent 0),
+    radial-gradient(circle at 34% 76%, var(--color-estrella-4) 1.1px, transparent 0);
+  background-size:
+    250px 220px,
+    180px 200px,
+    300px 270px,
+    220px 250px;
 }
 
 /**

--- a/src/styles/tokens/motion.css
+++ b/src/styles/tokens/motion.css
@@ -62,6 +62,47 @@
   }
 }
 
+/**
+ * EL CIELO DE LA CUENTA ATRÁS
+ *
+ * Dos movimientos a la vez y muy lentos: las estrellas derivan en diagonal
+ * durante 44 s y, por encima, titilan en 7 s. Ninguno de los dos se percibe
+ * como animación —a esa velocidad el ojo no sigue el movimiento—, y eso es lo
+ * que buscaba la entrega: que el fondo esté vivo sin pedir atención.
+ */
+@keyframes escala {
+  from {
+    opacity: 0%;
+    transform: scale(0.94);
+  }
+
+  to {
+    opacity: 100%;
+    transform: scale(1);
+  }
+}
+
+@keyframes deriva {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    transform: translate3d(-40px, -26px, 0);
+  }
+}
+
+@keyframes titilar {
+  0%,
+  100% {
+    opacity: 90%;
+  }
+
+  50% {
+    opacity: 40%;
+  }
+}
+
 /* Una línea que se traza. Se usa como separador que "dibuja" la sección. */
 @keyframes trazar-horizontal {
   from {
@@ -159,6 +200,12 @@
   animation: flotar calc(var(--duration-cinematic) * 2.6) ease-in-out infinite;
 }
 
+.animacion-cielo {
+  animation:
+    deriva calc(var(--duration-cinematic) * 31) linear infinite alternate,
+    titilar calc(var(--duration-cinematic) * 5) ease-in-out infinite;
+}
+
 .animacion-trazar {
   animation: trazar-horizontal var(--transicion-cinematica) both;
   transform-origin: left;
@@ -172,7 +219,8 @@
 @supports (animation-timeline: view()) {
   .animacion-subir-al-ver,
   .animacion-aparecer-al-ver,
-  .animacion-cortina-al-ver {
+  .animacion-cortina-al-ver,
+  .animacion-escala-al-ver {
     animation-fill-mode: both;
     animation-range: entry 4% cover 24%;
     animation-timeline: view();
@@ -192,6 +240,11 @@
   .animacion-cortina-al-ver {
     animation-duration: var(--duration-slower);
     animation-name: cortina;
+  }
+
+  .animacion-escala-al-ver {
+    animation-duration: var(--duration-slow);
+    animation-name: escala;
   }
 }
 
@@ -216,12 +269,14 @@
   .animacion-trazar-vertical,
   .animacion-subir-al-ver,
   .animacion-aparecer-al-ver,
-  .animacion-cortina-al-ver {
+  .animacion-cortina-al-ver,
+  .animacion-escala-al-ver {
     animation: aparecer var(--duration-instant) var(--ease-salida) both;
     animation-timeline: auto;
   }
 
-  .animacion-flotar {
+  .animacion-flotar,
+  .animacion-cielo {
     animation: none;
   }
 

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -128,6 +128,18 @@
   --color-velado-nieve: rgb(248 249 252 / 86%);
   --color-velado-marino: rgb(16 22 35 / 86%);
 
+  /**
+   * Las estrellas del cielo de la cuenta atrás. Cuatro alfas distintas y no uno
+   * solo: un campo de puntos todos iguales se lee como una trama de imprenta,
+   * no como un cielo. La irregularidad es lo que lo hace funcionar.
+   *
+   * El blanco es el mismo de la tinta sobre oscuro, con transparencia.
+   */
+  --color-estrella-1: rgb(238 242 248 / 50%);
+  --color-estrella-2: rgb(238 242 248 / 30%);
+  --color-estrella-3: rgb(238 242 248 / 42%);
+  --color-estrella-4: rgb(238 242 248 / 28%);
+
   /* ---------------------------------------------------------------------
    * Tipografía — las tres familias de la entrega
    *
@@ -160,6 +172,13 @@
   --font-size-titulo-2: clamp(2rem, 3.4vw, 2.375rem);
   --font-size-titulo-3: 1.6875rem;
   --font-size-conector: clamp(2.75rem, 8vw, 6.5rem);
+
+  /**
+   * Las cifras de la cuenta atrás: 46–86 px. Ni display ni título — la entrega
+   * les da su propio tamaño, más contenido que el titular porque son cuatro
+   * seguidas y a tamaño de portada no cabrían en un móvil.
+   */
+  --font-size-cifra: clamp(2.875rem, 8vw, 5.375rem);
   --font-size-cita: 1.5rem;
   --font-size-cuerpo-grande: 1.1875rem;
   --font-size-cuerpo: 1rem;

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -105,6 +105,7 @@
   --texto-titulo-2: var(--font-size-titulo-2);
   --texto-titulo-3: var(--font-size-titulo-3);
   --texto-conector: var(--font-size-conector);
+  --texto-cifra: var(--font-size-cifra);
   --texto-cita: var(--font-size-cita);
   --texto-cuerpo-grande: var(--font-size-cuerpo-grande);
   --texto-cuerpo: var(--font-size-cuerpo);

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -116,6 +116,22 @@ test.describe("Landing", () => {
   });
 
   /**
+   * BODA-20 · El cielo de la cuenta atrás.
+   */
+  test("la cuenta atrás lleva su cielo, y es decoración para quien no ve", async ({ page }) => {
+    const cielo = page.locator("#cuenta-atras .cielo-estrellado");
+    await expect(cielo).toHaveCount(1);
+
+    // Decoración pura: anunciarlo sería ruido en un lector de pantalla.
+    await expect(cielo).toHaveAttribute("aria-hidden", "true");
+
+    const capas = await cielo.evaluate(
+      (nodo) => getComputedStyle(nodo).backgroundImage.split("radial-gradient").length - 1,
+    );
+    expect(capas).toBe(4);
+  });
+
+  /**
    * BODA-17 · El conector va en Italianno, y de verdad.
    *
    * Comprobar la clase no valdría: diría que se ha pedido la fuente, no que
@@ -153,5 +169,36 @@ test.describe("Landing", () => {
 test.describe("Landing sin configurar", () => {
   test("existe un mensaje para cuando no hay datos", () => {
     expect(copy.errores.generico.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * CASO DE ERROR / ACCESIBILIDAD
+ *
+ * Un fondo en movimiento perpetuo es justo lo que marea a quien activa
+ * «movimiento reducido». El cielo de la cuenta atrás tiene que pararse del
+ * todo, no ralentizarse.
+ */
+test.describe("Cielo con movimiento reducido", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+  });
+
+  test("el cielo deja de moverse", async ({ page }) => {
+    await page.goto("/");
+
+    const emulacionActiva = await page.evaluate(
+      () => window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+    );
+    test.skip(
+      !emulacionActiva,
+      "Este navegador no aplica la emulación de prefers-reduced-motion",
+    );
+
+    const nombre = await page
+      .locator("#cuenta-atras .cielo-estrellado")
+      .evaluate((nodo) => getComputedStyle(nodo).animationName);
+
+    expect(nombre).toBe("none");
   });
 });


### PR DESCRIPTION
## Qué cambia

La cuenta atrás pasa de franja de color a la noche de la entrega.

Closes #98

Paso 3 de la reconstrucción de la landing.

## El cielo

Cuatro capas de estrellas que derivan durante 44 s y titilan cada 7. Tan despacio que no se leen como animación — sólo se nota que el bloque está vivo.

Va en **CSS, no como imagen**: pesa cero, se adapta a cualquier pantalla y sigue a la paleta. Las cuatro capas llevan alfas, tamaños y rejillas distintos a propósito: cuatro rejillas iguales se leen como una trama de imprenta, no como un cielo.

## Lo demás

- **Cifras con tamaño propio** (46–86 px). Iban a tamaño de portada, y cuatro seguidas a ese cuerpo no caben en un móvil.
- **Frase en cursiva** debajo, en lugar de repetir la fecha — que ya está en la portada.
- Entrada en cortina al hacer scroll.

## Accesibilidad

El cielo es `aria-hidden`: es decoración y anunciarlo sería ruido.

Con `prefers-reduced-motion` **se para del todo**, no se ralentiza. Un fondo en movimiento perpetuo es exactamente lo que marea a quien activa esa preferencia, y a media velocidad sigue mareando. Ese es el caso de error del E2E: comprueba que `animationName` es `none`.

## Cómo probarlo en el preview

1. Baja a la cuenta atrás: el fondo tiene estrellas.
2. Quédate 20 s mirando: derivan en diagonal y titilan.
3. Activa «reducir movimiento» en el sistema y recarga: se quedan quietas.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: colores y espaciados son tokens, los textos salen de `content/copy.es.json`, los datos de la boda de la BBDD y los límites de `src/config/constants.ts`
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error
- [x] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: teclado, foco visible, contraste AA, `prefers-reduced-motion`
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

146 unitarios y 15 E2E de la landing en verde, contra Postgres con migraciones y seed.

## Base de datos

- [x] No la toca
- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [x] No hace falta
- [ ] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR


---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_