### PR TITLE
feat(BODA-33): las secciones de contenido abren con la cabecera de la entrega

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -66,6 +66,10 @@
     "yaEsHoy": "Hoy es el día",
     "cierre": "Nos hace mucha ilusión celebrarlo con vosotros. Aquí abajo está todo lo que hay que saber."
   },
+  "historia": {
+    "etiqueta": "Cómo llegamos hasta aquí",
+    "titulo": "Nuestra historia"
+  },
   "programa": {
     "etiqueta": "El día, hora a hora",
     "titulo": "El día, hora a hora"
@@ -79,6 +83,10 @@
     "etiqueta": "El lugar",
     "titulo": "Cómo llegar",
     "abrirMapa": "Abrir en el mapa"
+  },
+  "preguntas": {
+    "etiqueta": "Por si os queda alguna duda",
+    "titulo": "Preguntas frecuentes"
   },
   "playlist": {
     "etiqueta": "La pista de baile es cosa de todos",
@@ -112,7 +120,8 @@
     "graciasNoTexto": "Gracias por decírnoslo. Brindaremos por vosotros y os guardaremos un trozo de tarta.",
     "editarRespuesta": "Cambiar la respuesta",
     "tokenInvalido": "Este enlace no es válido. Escribidnos y os mandamos uno nuevo.",
-    "plazoCerrado": "El plazo para confirmar ya se ha cerrado. Escribidnos y lo miramos."
+    "plazoCerrado": "El plazo para confirmar ya se ha cerrado. Escribidnos y lo miramos.",
+    "antesDel": "Antes del {fecha}"
   },
   "saveTheDate": {
     "etiqueta": "Reservad la fecha",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,8 @@ import {
   Cuerpo,
   Display,
   Etiqueta,
-  Titulo2,
+  EtiquetaSeccion,
+  Titulo1,
   Titulo3,
 } from "@/components/ui/tipografia";
 import { ID_CONTENIDO, IDIOMA, ZONA_HORARIA } from "@/config/constants";
@@ -394,7 +395,12 @@ function Historia({
   }[];
 }) {
   return (
-    <Bloque seccion="historia" etiqueta={null} titulo={null}>
+    <Bloque
+      seccion="historia"
+      etiqueta={t("historia.etiqueta")}
+      titulo={t("historia.titulo")}
+      realzada
+    >
       <ol className="grid gap-bloque sm:grid-cols-3">
         {hitos.map((hito) => (
           <li key={hito.id} className="animacion-subir-al-ver">
@@ -552,7 +558,12 @@ function Preguntas({
   preguntas: { id: string; pregunta: string; respuesta: string }[];
 }) {
   return (
-    <Bloque seccion="preguntas_frecuentes" etiqueta={null} titulo={null} hundida>
+    <Bloque
+      seccion="preguntas_frecuentes"
+      etiqueta={t("preguntas.etiqueta")}
+      titulo={t("preguntas.titulo")}
+      hundida
+    >
       <ul className="mx-auto max-w-estrecho border-t border-borde">
         {preguntas.map((pregunta) => (
           <li key={pregunta.id} className="border-b border-borde">
@@ -572,8 +583,14 @@ function Preguntas({
 
 function Playlist({ canciones }: { canciones: { id: string; texto: string }[] }) {
   return (
-    <Bloque seccion="playlist" etiqueta={t("playlist.etiqueta")} titulo={t("playlist.titulo")}>
-      <Cuerpo className="mx-auto max-w-texto text-center">{t("playlist.descripcion")}</Cuerpo>
+    <Bloque
+      seccion="playlist"
+      etiqueta={t("playlist.etiqueta")}
+      titulo={t("playlist.titulo")}
+      entradilla={t("playlist.descripcion")}
+      realzada
+      centrada
+    >
       {canciones.length > 0 ? (
         <ul className="mt-elemento flex flex-wrap justify-center gap-interno-compacto">
           {canciones.map((cancion) => (
@@ -598,33 +615,121 @@ function Rsvp({ configuracion }: { configuracion: ConfiguracionBoda }) {
     <section
       id={anclaDe("rsvp")}
       data-seccion="inversa"
-      className="px-interno py-seccion-compacta text-center"
+      className="px-interno py-seccion-fluida text-center"
       aria-labelledby={idTitulo}
     >
       <div className="mx-auto max-w-estrecho">
-        {configuracion.fechaLimiteRsvp ? (
-          <Etiqueta>{formatoFecha.format(configuracion.fechaLimiteRsvp)}</Etiqueta>
-        ) : null}
-        <Titulo2 id={idTitulo} className="mt-pila">
-          {t("rsvp.titulo")}
-        </Titulo2>
-        <Cita className="mx-auto mt-elemento max-w-texto">{t("meta.descripcion")}</Cita>
+        <CabeceraSeccion
+          idTitulo={idTitulo}
+          etiqueta={
+            configuracion.fechaLimiteRsvp
+              ? t("rsvp.antesDel", {
+                  fecha: formatoFecha.format(configuracion.fechaLimiteRsvp),
+                })
+              : null
+          }
+          titulo={t("rsvp.titulo")}
+          centrada
+        />
+        <Cita className="mx-auto max-w-texto">{t("meta.descripcion")}</Cita>
       </div>
     </section>
   );
 }
 
-/** Envoltura de sección: mantiene el ritmo vertical sin repetirlo por página. */
+/**
+ * LA CABECERA DE UNA SECCIÓN
+ *
+ * El patrón que la entrega repite en todas: versalita arriba, titular grande
+ * debajo y —cuando hace falta— una entradilla corta que lo acompaña.
+ *
+ * Tiene dos composiciones, y la entrega usa las dos. En la **alineada**, que es
+ * la de las secciones con contenido debajo, la entradilla va a la derecha del
+ * titular y pegada a su línea base; el titular abre la sección por la
+ * izquierda, donde empieza a leerse todo lo demás. En la **centrada**, la de
+ * las secciones que son una invitación a hacer algo —la playlist, el RSVP—, la
+ * entradilla cae bajo el titular y todo se alinea al eje: no hay una lista que
+ * seguir, hay una sola cosa que pedir.
+ *
+ * El titular es un `h2` con el tamaño de `Titulo1`, no de `Titulo2`, y por eso
+ * va con la propiedad `como`. Es lo que dice la entrega y se nota: con el
+ * tamaño pequeño las secciones no abren, parecen subapartados de la anterior.
+ * La jerarquía del documento la sigue marcando la etiqueta, que es lo que oye
+ * un lector de pantalla.
+ *
+ * Vive suelta y no dentro de `Bloque` porque la usan dos marcos distintos: las
+ * secciones de contenido y el RSVP, que tiene su propio fondo.
+ */
+function CabeceraSeccion({
+  idTitulo,
+  etiqueta,
+  titulo,
+  entradilla = null,
+  realzada = false,
+  centrada = false,
+}: {
+  idTitulo: string;
+  etiqueta: string | null;
+  titulo: string | null;
+  /** Frase corta que acompaña al titular. Opcional: la mayoría no la lleva. */
+  entradilla?: string | null;
+  /** Bronce y rombo. Sólo las secciones que son un extra; ver `EtiquetaSeccion`. */
+  realzada?: boolean;
+  centrada?: boolean;
+}) {
+  if (!etiqueta && !titulo) return null;
+
+  const rotulo = (
+    <div>
+      {etiqueta ? <EtiquetaSeccion realzada={realzada}>{etiqueta}</EtiquetaSeccion> : null}
+      {titulo ? (
+        <Titulo1 como="h2" id={idTitulo} className="mt-pila">
+          {titulo}
+        </Titulo1>
+      ) : null}
+      {centrada && entradilla ? (
+        <Cuerpo className="mx-auto mt-pila max-w-texto">{entradilla}</Cuerpo>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <header
+      className={`animacion-subir-al-ver mb-bloque-fluido ${
+        centrada ? "text-center" : "flex flex-wrap items-end justify-between gap-elemento"
+      }`}
+    >
+      {rotulo}
+      {!centrada && entradilla ? (
+        <Cuerpo className="ancho-entradilla">{entradilla}</Cuerpo>
+      ) : null}
+    </header>
+  );
+}
+
+/**
+ * EL MARCO DE UNA SECCIÓN DE CONTENIDO
+ *
+ * Mantiene el ritmo vertical sin repetirlo por página. El aire es fluido: 132
+ * px fijos dejan una sección casi vacía en un móvil, y por eso la entrega lo
+ * escribe con `clamp` en todas.
+ */
 function Bloque({
   seccion,
   etiqueta,
   titulo,
+  entradilla = null,
+  realzada = false,
+  centrada = false,
   hundida = false,
   children,
 }: {
   seccion: Seccion;
   etiqueta: string | null;
   titulo: string | null;
+  entradilla?: string | null;
+  realzada?: boolean;
+  centrada?: boolean;
   hundida?: boolean;
   children: ReactNode;
 }) {
@@ -633,20 +738,18 @@ function Bloque({
   return (
     <section
       id={ancla}
-      className={`px-interno py-seccion-compacta ${hundida ? "bg-superficie-hundida" : ""}`}
+      className={`px-interno py-seccion-fluida ${hundida ? "bg-superficie-hundida" : ""}`}
       aria-labelledby={titulo ? idTitulo : undefined}
     >
       <div className="mx-auto max-w-contenido">
-        {etiqueta || titulo ? (
-          <header className="mb-bloque">
-            {etiqueta ? <Etiqueta>{etiqueta}</Etiqueta> : null}
-            {titulo ? (
-              <Titulo2 id={idTitulo} className="mt-pila">
-                {titulo}
-              </Titulo2>
-            ) : null}
-          </header>
-        ) : null}
+        <CabeceraSeccion
+          idTitulo={idTitulo}
+          etiqueta={etiqueta}
+          titulo={titulo}
+          entradilla={entradilla}
+          realzada={realzada}
+          centrada={centrada}
+        />
         {children}
       </div>
     </section>

--- a/src/components/ui/tipografia.tsx
+++ b/src/components/ui/tipografia.tsx
@@ -45,7 +45,10 @@ export function Titulo1({
   className = "",
 }: PropiedadesTitulo) {
   return (
-    <Etiqueta id={id} className={`font-titulo text-titulo-1 leading-titulo ${className}`}>
+    <Etiqueta
+      id={id}
+      className={`font-titulo text-titulo-1 leading-titulo tracking-titulo ${className}`}
+    >
       {children}
     </Etiqueta>
   );
@@ -92,6 +95,50 @@ export function Titulo3({
 export function Conector({ children }: { children: ReactNode }) {
   return (
     <span className="font-conector text-conector leading-conector text-acento">{children}</span>
+  );
+}
+
+/**
+ * LA VERSALITA QUE ABRE UNA SECCIÓN
+ *
+ * Tiene dos formas, y cuál se usa no es una preferencia: es lo que la sección
+ * significa dentro de la página.
+ *
+ * La **sobria** —tinta tenue, sin adorno— abre lo que hay que leer sí o sí: el
+ * programa, el alojamiento, cómo llegar, la confirmación. Ahí la versalita
+ * rotula un dato («Sábado 26 de junio», «Finca La Sierra») y estorbaría que
+ * llamase la atención sobre sí misma.
+ *
+ * La **realzada** —bronce y un rombo delante, un cuadrado de 4 px girado 45°—
+ * abre lo que se ofrece: la playlist, la historia. Son secciones que nadie
+ * necesita para llegar a la boda, y el adorno es la manera de decir «esto es
+ * un extra» sin escribirlo.
+ *
+ * Mezclarlas al azar rompe justamente eso: si el bronce sale en todas, deja de
+ * significar nada. Por eso el realce es una decisión explícita en cada sección
+ * y no el valor por defecto.
+ *
+ * El rombo es `aria-hidden`: para quien escucha la página no significa nada, y
+ * anunciarlo sería un ruido por cada sección.
+ */
+export function EtiquetaSeccion({
+  children,
+  realzada = false,
+}: {
+  children: ReactNode;
+  realzada?: boolean;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-interno-compacto text-etiqueta uppercase tracking-seccion ${
+        realzada ? "text-acento" : "text-tinta-tenue"
+      }`}
+    >
+      {realzada ? (
+        <span aria-hidden className="size-linea rotate-45 bg-current opacity-80" />
+      ) : null}
+      {children}
+    </span>
   );
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -133,6 +133,7 @@
   --tracking-etiqueta: var(--espaciado-etiqueta);
   --tracking-boton: var(--espaciado-boton);
   --tracking-marcado: var(--espaciado-marcado);
+  --tracking-seccion: var(--espaciado-seccion);
 
   /* Espaciado */
   --spacing-linea: var(--espacio-linea);
@@ -143,6 +144,8 @@
   --spacing-bloque: var(--espacio-bloque);
   --spacing-seccion-compacta: var(--espacio-seccion-compacta);
   --spacing-seccion: var(--espacio-seccion);
+  --spacing-seccion-fluida: var(--espacio-seccion-fluida);
+  --spacing-bloque-fluido: var(--espacio-bloque-fluido);
   --spacing-control: var(--alto-control);
   --spacing-control-compacto: var(--alto-control-compacto);
   --spacing-campo: var(--alto-campo);
@@ -212,6 +215,11 @@
 @utility rejilla-partida {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--ancho-columna-minima)), 1fr));
+}
+
+/** La entradilla que acompaña al titular de una sección. */
+@utility ancho-entradilla {
+  max-width: var(--ancho-entradilla);
 }
 
 /** Alto del hueco de foto de la portada una vez la rejilla se ha apilado. */

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -207,6 +207,15 @@
   --letter-spacing-boton: 0.2em;
   --letter-spacing-marcado: 0.44em;
 
+  /**
+   * El espaciado de la versalita que abre una sección. Cuatro centésimas menos
+   * que `marcado` y no es un descuido de la entrega: `marcado` lo llevan las
+   * dos versalitas que van solas y grandes —la de la portada y la del
+   * paisaje—, y ésta, que va pegada a un titular, necesita apretarse un punto
+   * para no competir con él.
+   */
+  --letter-spacing-seccion: 0.4em;
+
   /* ---------------------------------------------------------------------
    * Espaciado — la escala del sistema de marca, no una progresión genérica
    * ------------------------------------------------------------------- */
@@ -220,6 +229,20 @@
   --space-bloque: 3.5rem;
   --space-seccion-compacta: 5rem;
   --space-seccion: 8.25rem;
+
+  /**
+   * El aire vertical de las secciones de contenido, fluido: 76 px en un móvil
+   * y 132 en escritorio. La entrega lo escribe así en todas ellas, y con razón
+   * — 132 px fijos en una pantalla de 640 dejan la sección casi vacía.
+   */
+  --space-seccion-fluida: clamp(4.75rem, 10vw, 8.25rem);
+
+  /**
+   * El hueco entre la cabecera de una sección y su contenido. También fluido,
+   * por lo mismo: es el respiro que separa el titular de lo que anuncia, y en
+   * un móvil un hueco fijo de escritorio parece un olvido de maquetación.
+   */
+  --space-bloque-fluido: clamp(2.5rem, 5vw, 4rem);
 
   /* Altura de los controles: el objetivo táctil cómodo en móvil. */
   --size-control: 3.25rem;
@@ -235,6 +258,14 @@
    * y por eso el corte no ocurre en un breakpoint redondo sino cuando estorba.
    */
   --size-columna-minima: 22.5rem;
+
+  /**
+   * Ancho de la entradilla que acompaña a un titular de sección. Es más
+   * estrecha que la columna mínima a propósito: no es una columna de la
+   * rejilla, es una nota al margen, y se lee como tal justamente porque no
+   * llega a alinearse con nada.
+   */
+  --size-entradilla: 21.25rem;
 
   /**
    * Alto del hueco de foto de la portada cuando la rejilla ya se ha apilado.

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -129,6 +129,7 @@
   --espaciado-etiqueta: var(--letter-spacing-etiqueta);
   --espaciado-boton: var(--letter-spacing-boton);
   --espaciado-marcado: var(--letter-spacing-marcado);
+  --espaciado-seccion: var(--letter-spacing-seccion);
 
   /* --- Espaciado semántico ------------------------------------------- */
   --espacio-linea: var(--space-linea);
@@ -139,11 +140,14 @@
   --espacio-bloque: var(--space-bloque);
   --espacio-seccion-compacta: var(--space-seccion-compacta);
   --espacio-seccion: var(--space-seccion);
+  --espacio-seccion-fluida: var(--space-seccion-fluida);
+  --espacio-bloque-fluido: var(--space-bloque-fluido);
   --alto-control: var(--size-control);
   --alto-control-compacto: var(--size-control-compacto);
   --alto-campo: var(--size-campo);
   --ancho-cifra: var(--size-cifra);
   --ancho-columna-minima: var(--size-columna-minima);
+  --ancho-entradilla: var(--size-entradilla);
   --alto-foto-portada: var(--size-foto-portada);
   --alto-cabecera: var(--size-cabecera);
   --ancho-lateral: var(--size-lateral);

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -162,6 +162,98 @@ test.describe("Landing", () => {
 });
 
 /**
+ * BODA-33 · La cabecera de sección.
+ *
+ * Lo que se comprueba aquí no es que el patrón esté escrito, sino que el
+ * acento sigue siendo escaso. Un componente con una propiedad `realzada` es
+ * muy fácil de encender en todas las secciones «porque queda bien», y el día
+ * que eso pasa el bronce deja de significar nada. El test lo impide.
+ */
+test.describe("Cabecera de sección", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("ninguna sección de contenido se queda sin abrir", async ({ page }) => {
+    // La portada y la cuenta atrás tienen su propia composición; el resto
+    // comparte el patrón y ninguna puede quedarse muda.
+    const mudas = await page.evaluate(() =>
+      [...document.querySelectorAll("main section")]
+        .filter((seccion) => !["portada", "cuenta-atras"].includes(seccion.id))
+        .filter((seccion) => !seccion.querySelector("header h2"))
+        .map((seccion) => seccion.id),
+    );
+
+    expect(mudas).toEqual([]);
+  });
+
+  test("el titular abre la sección, pero sigue siendo un h2", async ({ page }) => {
+    // Tamaño de portada y jerarquía de subapartado son cosas distintas: lo
+    // primero es diseño y lo segundo es lo que oye un lector de pantalla.
+    const cabeceras = await page.evaluate(() =>
+      [...document.querySelectorAll("main section header h2")].map((titulo) => {
+        const seccion = titulo.closest("section")!;
+        const menor = seccion.querySelector("h3");
+        return {
+          id: seccion.id,
+          tam: parseFloat(getComputedStyle(titulo).fontSize),
+          tamMenor: menor ? parseFloat(getComputedStyle(menor).fontSize) : null,
+        };
+      }),
+    );
+
+    expect(cabeceras.length).toBeGreaterThan(0);
+    for (const cabecera of cabeceras) {
+      if (cabecera.tamMenor !== null) {
+        expect(
+          cabecera.tam,
+          `«${cabecera.id}» no abre: su titular no es mayor`,
+        ).toBeGreaterThan(cabecera.tamMenor);
+      }
+    }
+  });
+
+  test("el bronce es una gota: hay secciones sobrias y secciones realzadas", async ({
+    page,
+  }) => {
+    const versalitas = await page.evaluate(() =>
+      [...document.querySelectorAll("main section header > div > span:first-child")].map(
+        (span) => ({
+          id: span.closest("section")!.id,
+          color: getComputedStyle(span).color,
+          rombo: span.querySelectorAll("[aria-hidden]").length,
+        }),
+      ),
+    );
+
+    const realzadas = versalitas.filter((v) => v.rombo === 1);
+    const sobrias = versalitas.filter((v) => v.rombo === 0);
+
+    // Si algún día todas fueran realzadas, el acento habría dejado de serlo.
+    expect(realzadas.length).toBeGreaterThan(0);
+    expect(sobrias.length).toBeGreaterThan(0);
+
+    // Y son de dos colores distintos, no del mismo con un rombo de más.
+    const colores = new Set(versalitas.map((v) => v.color));
+    expect(colores.size).toBeGreaterThan(1);
+  });
+
+  /**
+   * CASO DE ERROR. El rombo es decoración pura. Si se anunciara, quien navega
+   * con lector de pantalla oiría un ruido de más en cada sección realzada.
+   */
+  test("el rombo no se anuncia y no lleva texto", async ({ page }) => {
+    const rombos = page.locator("main section header span[aria-hidden]");
+    expect(await rombos.count()).toBeGreaterThan(0);
+
+    for (const rombo of await rombos.all()) {
+      await expect(rombo).toHaveAttribute("aria-hidden", "true");
+      await expect(rombo).toHaveText("");
+    }
+  });
+});
+
+/**
  * Caso de error: la página no puede quedarse en blanco si la base de datos
  * todavía no tiene configurada la boda. Se comprueba que el texto de respaldo
  * existe en los copys, que es lo que la página pintaría.


### PR DESCRIPTION
## Qué cambia

Las seis secciones que van bajo la cuenta atrás pasan a usar el patrón de cabecera de la entrega —versalita, titular a `--texto-titulo-1` y entradilla opcional—, y las dos que no tenían ninguna la estrenan.

Closes #100

## Cómo probarlo en el preview

1. Bajar por la home hasta pasar la cuenta atrás. Cada sección abre ahora con una versalita y un titular grande, no con el contenido a bocajarro.
2. Fijarse en **Nuestra historia** y **Preguntas frecuentes**: antes empezaban sin titular. Tenían nombre en el menú y ninguno en la página.
3. Comparar la versalita de **Alojamiento** (gris, sin adorno) con la de **Playlist** (bronce, con un rombo delante). Son las dos formas de la entrega y no están repartidas al azar: el bronce va sólo donde la sección es un extra.
4. **Playlist** y **Confirmad asistencia** centran su cabecera; el resto la alinea a la izquierda con la entradilla a la derecha. También es de la entrega: donde no hay una lista que recorrer, hay un eje.
5. Estrechar la ventana hasta un móvil. El titular baja de 68 a 38 px y el aire de la sección de 132 a 76, sin que aparezca scroll horizontal.
6. Cambiar a tema oscuro en `/cocina`. El bronce se aclara y el gris se ajusta solos: se reasignan los semánticos, ningún componente cambia de clase.

## Qué se ha comprobado en el navegador

No sólo que el CI esté verde. Midiendo el DOM con Playwright, contra la tabla de la entrega:

| | Entrega | Medido |
|---|---|---|
| Versalita realzada | `#8A6224` | `rgb(138 98 36)` |
| Versalita sobria | `#78839A` | `rgb(120 131 154)` |
| Versalita sobre marino | `#9DB0CE` | `rgb(157 176 206)` |
| Espaciado de la versalita | `.4em` | `4.4px` sobre 11 px |
| Titular de sección | `clamp(38px, 5.4vw, 68px)` | 68 px a 1440, 38 px a 390 |
| Aire de sección | `clamp(76px, 10vw, 132px)` | 132 px / 76 px |
| Cabecera → contenido | `clamp(40px, 5vw, 64px)` | 64 px / 40 px |

## Decisiones que conviene mirar en la revisión

**La versalita tiene dos formas y el reparto es deliberado.** La entrega usa bronce con rombo en preboda, playlist, regalos y dress code, y tinta tenue en programa, alojamiento, cómo llegar y RSVP. La línea que las separa no es «dato o rótulo» —«Sábado 26 de junio» va en gris y «Viernes 25 de junio» en bronce—: es si la sección hace falta para llegar a la boda o es un extra. Aquí historia y playlist van realzadas; el resto, sobrias. Por eso `realzada` es una decisión explícita en cada sección y no el valor por defecto, y por eso hay un test que falla si algún día todas lo llevan.

**`--letter-spacing-seccion` (0.4em) es un token nuevo y no un duplicado de `marcado` (0.44em).** La entrega usa 0.44 en las dos versalitas que van solas y grandes —portada y paisaje— y 0.4 en las que van pegadas a un titular. Son cuatro centésimas, pero unificarlas sería decidir por la entrega.

**La entradilla centrada usa `max-w-texto` (34rem) y no los 460 px de la entrega.** Es el ancho de prosa que ya usan todos los párrafos centrados de la página; añadir un tercer token de ancho casi idéntico costaba más de lo que arreglaba.

**El programa no lleva entradilla.** La entrega pone ahí «Habrá autobús desde el centro de León a las 12:00…», pero eso es un dato de la boda y no hay columna donde guardarlo. La propiedad existe y queda cableada para cuando la haya; escribirlo en el código sería justo lo que prohíbe la regla 3.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: tres tokens nuevos en la capa de primitivos, los textos nuevos en `content/copy.es.json`
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error (el rombo no puede anunciarse ni llevar texto)
- [ ] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: el titular sigue siendo `h2` aunque tenga tamaño de portada, y el rombo es `aria-hidden`
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

## Base de datos

- [x] No la toca
- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [x] No hace falta
- [ ] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_