### PR TITLE
feat(BODA-34): las constelaciones, el motivo ilustrativo de la marca

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -162,7 +162,13 @@
     "botonSecundario": "Secundario",
     "botonTerciario": "Terciario",
     "botonDesactivado": "Desactivado",
-    "seccionInversa": "Bloque inverso: los mismos componentes, sin cambiar una clase"
+    "seccionInversa": "Bloque inverso: los mismos componentes, sin cambiar una clase",
+    "seccionConstelaciones": "Constelaciones",
+    "constelacionesDescripcion": "El único elemento ilustrativo del sistema: no hay iconos ni ilustraciones. Cada mesa del banquete llevará el nombre y el mapa de una de ellas.",
+    "hemisferioNorte": "Hemisferio norte",
+    "hemisferioNorteNota": "El cielo que habrá sobre la finca esa noche.",
+    "hemisferioSur": "Hemisferio sur",
+    "hemisferioSurNota": "El del viaje de novios, al otro lado del ecuador."
   },
   "acceso": {
     "titulo": "Entrar",

--- a/src/app/cocina/page.tsx
+++ b/src/app/cocina/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { Boton } from "@/components/ui/boton";
 import { CampoTexto } from "@/components/ui/campo";
+import { Constelacion } from "@/components/ui/constelacion";
 import { SelectorTema } from "@/components/ui/selector-tema";
 import { Cita, Etiqueta } from "@/components/ui/tipografia";
 import {
@@ -12,7 +13,22 @@ import {
   TOKENS_SOMBRA,
   TOKENS_TIPOGRAFIA,
 } from "@/config/tokens";
-import { t } from "@/lib/copy";
+import { CONSTELACIONES, type Hemisferio } from "@/config/constelaciones";
+import { t, type ClaveCopy } from "@/lib/copy";
+
+/** Los dos grupos del catálogo, en el orden en que la entrega los presenta. */
+const HEMISFERIOS: readonly {
+  id: Hemisferio;
+  claveTitulo: ClaveCopy;
+  claveNota: ClaveCopy;
+}[] = [
+  {
+    id: "norte",
+    claveTitulo: "cocina.hemisferioNorte",
+    claveNota: "cocina.hemisferioNorteNota",
+  },
+  { id: "sur", claveTitulo: "cocina.hemisferioSur", claveNota: "cocina.hemisferioSurNota" },
+];
 
 export const metadata: Metadata = {
   title: t("cocina.titulo"),
@@ -138,6 +154,44 @@ export default function PaginaCocina() {
             </li>
           ))}
         </ul>
+      </Seccion>
+
+      {/*
+        Las constelaciones son parte del sistema, no de una pantalla: aquí se
+        ven las dieciséis a la vez, que es la única forma de comprobar que
+        comparten trazo. Van `rotulada`: en esta página el dibujo ES la
+        información, así que cada uno se anuncia con su nombre.
+      */}
+      <Seccion titulo={t("cocina.seccionConstelaciones")}>
+        <p className="mb-elemento max-w-texto text-pequeno text-tinta-tenue">
+          {t("cocina.constelacionesDescripcion")}
+        </p>
+        <div className="grid gap-bloque sm:grid-cols-2">
+          {HEMISFERIOS.map((hemisferio) => (
+            <div key={hemisferio.id}>
+              <h3 className="text-pequeno uppercase tracking-amplio text-tinta-tenue">
+                {t(hemisferio.claveTitulo)}
+              </h3>
+              <p className="mt-linea text-pequeno text-tinta-suave">
+                {t(hemisferio.claveNota)}
+              </p>
+              <ul className="mt-pila grid grid-cols-2 gap-pila sm:grid-cols-4">
+                {CONSTELACIONES.filter((c) => c.hemisferio === hemisferio.id).map(
+                  (constelacion) => (
+                    <li key={constelacion.clave}>
+                      <div className="aspect-square rounded-imagen border border-borde bg-superficie p-interno">
+                        <Constelacion clave={constelacion.clave} rotulada />
+                      </div>
+                      <span className="mt-linea block text-diminuto text-tinta-tenue">
+                        {constelacion.nombre}
+                      </span>
+                    </li>
+                  ),
+                )}
+              </ul>
+            </div>
+          ))}
+        </div>
       </Seccion>
 
       <Seccion titulo={t("cocina.seccionComponentes")}>

--- a/src/app/reserva-la-fecha/page.tsx
+++ b/src/app/reserva-la-fecha/page.tsx
@@ -3,7 +3,9 @@ import { notFound } from "next/navigation";
 
 import { EnPreparacion } from "@/components/marketing/en-preparacion";
 import { BotonEnlace } from "@/components/ui/boton";
+import { Constelacion } from "@/components/ui/constelacion";
 import { Conector, Etiqueta, Titulo3 } from "@/components/ui/tipografia";
+import { CONSTELACION_NOVIOS } from "@/config/constelaciones";
 import { IDIOMA, RUTA_CALENDARIO, ZONA_HORARIA } from "@/config/constants";
 import { obtenerConfiguracion, obtenerSecciones } from "@/lib/bbdd/landing";
 import { t } from "@/lib/copy";
@@ -90,6 +92,19 @@ export default async function PaginaReservaLaFecha() {
       className="grid min-h-dvh place-items-center px-interno py-pila text-center"
     >
       <div className="mx-auto w-full max-w-estrecho">
+        {/*
+          Lira, la constelación de los novios, abre la pieza igual que en la
+          entrega. Va sin rotular: aquí es adorno sobre unos nombres, y
+          anunciarle «Lira» a quien escucha la página no le diría nada.
+
+          Y sólo aparece si hay alto de sobra. Esta página promete caber de una
+          vez —se abre en WhatsApp y se mira dos segundos—, así que cuando el
+          adorno y la información no caben juntos, el que se va es el adorno.
+        */}
+        <div className="mx-auto mb-elemento hidden size-constelacion pantalla-alta:block">
+          <Constelacion clave={CONSTELACION_NOVIOS} />
+        </div>
+
         <Etiqueta>{t("saveTheDate.etiqueta")}</Etiqueta>
 
         {/* Un solo h1 con los dos nombres: es el título de la página, y para un

--- a/src/components/ui/constelacion.tsx
+++ b/src/components/ui/constelacion.tsx
@@ -1,0 +1,89 @@
+import { constelacionPorClave, GROSOR_TRAZO, type Constelacion } from "@/config/constelaciones";
+
+/**
+ * UNA CONSTELACIÓN
+ *
+ * Dibuja el mapa que hay en `config/constelaciones.ts`: primero las líneas,
+ * luego las estrellas encima. El orden importa —si se pintaran al revés, cada
+ * línea cruzaría por delante de la estrella y el punto perdería el brillo.
+ *
+ * NO LLEVA NI UN COLOR. Las estrellas van a `fill-constelacion-estrella` y el
+ * trazo a `stroke-constelacion-trazo`, dos semánticos que se reasignan solos en
+ * los cuatro fondos del sistema: claro, oscuro, bloque inverso y pie. Meterla
+ * en una sección marino la aclara sin tocar una clase, que es justamente lo que
+ * el sistema promete.
+ *
+ * EL VIEWBOX ES 100 × 100 Y EL SVG NO TIENE TAMAÑO PROPIO: ocupa el hueco que
+ * le dé quien la usa. Así el mismo mapa vale para un marcasitios de 40 px y
+ * para un cartel, sin duplicar coordenadas.
+ *
+ * ACCESIBILIDAD. Por defecto es decoración y va `aria-hidden`: en una página
+ * donde acompaña a un nombre, anunciar «Lira» sería ruido. Cuando la
+ * constelación **es** la información —el catálogo del sistema de marca, o el
+ * día que una mesa se identifique por su dibujo— se le pasa `rotulada` y
+ * entonces se anuncia con su nombre.
+ */
+
+/** Lado del lienzo. Las coordenadas del mapa son porcentajes de este número. */
+const LIENZO = 100;
+
+export function Constelacion({
+  clave,
+  rotulada = false,
+  className = "",
+}: {
+  clave: string;
+  /** Si es información y no adorno: se anuncia con su nombre. */
+  rotulada?: boolean;
+  className?: string;
+}) {
+  const constelacion: Constelacion | undefined = constelacionPorClave(clave);
+
+  // Una clave que no existe no puede tumbar la página que la pinta: se calla.
+  // Que la clave exista lo garantiza el test unitario, no un error en runtime.
+  if (!constelacion) return null;
+
+  const { estrellas, lineas, nombre } = constelacion;
+  const idTitulo = `constelacion-${constelacion.clave}`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${LIENZO} ${LIENZO}`}
+      className={`block h-full w-full ${className}`}
+      fill="none"
+      preserveAspectRatio="xMidYMid meet"
+      role={rotulada ? "img" : undefined}
+      aria-hidden={rotulada ? undefined : true}
+      aria-labelledby={rotulada ? idTitulo : undefined}
+    >
+      {rotulada ? <title id={idTitulo}>{nombre}</title> : null}
+
+      {lineas.map(([desde, hasta]) => {
+        const [x1, y1] = estrellas[desde];
+        const [x2, y2] = estrellas[hasta];
+        return (
+          <line
+            key={`${desde}-${hasta}`}
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            className="stroke-constelacion-trazo"
+            strokeWidth={GROSOR_TRAZO}
+            strokeLinecap="round"
+          />
+        );
+      })}
+
+      {estrellas.map(([x, y, radio]) => (
+        <circle
+          key={`${x}-${y}`}
+          cx={x}
+          cy={y}
+          r={radio}
+          className="fill-constelacion-estrella"
+        />
+      ))}
+    </svg>
+  );
+}

--- a/src/config/constelaciones.ts
+++ b/src/config/constelaciones.ts
@@ -1,0 +1,385 @@
+/**
+ * LAS CONSTELACIONES
+ *
+ * El único elemento ilustrativo de todo el sistema de marca. No hay iconos, ni
+ * ilustraciones, ni fotos decorativas: hay dieciséis mapas de estrellas, y de
+ * ahí salen los nombres de las mesas.
+ *
+ * Ocho del hemisferio norte —el cielo que habrá sobre la finca esa noche— y
+ * ocho del sur. La entrega lo dice así y no es un adorno: la mesa de los
+ * novios es Lira porque Vega es la estrella más brillante del verano boreal.
+ *
+ * POR QUÉ VIVE EN `config` Y NO EN UN COMPONENTE
+ *
+ * Son coordenadas de marca, del mismo orden que un logotipo: pueden cambiar
+ * —añadir una constelación, mover una estrella— sin que cambie una línea de la
+ * lógica que las dibuja. La regla 1 del proyecto dice dónde va eso.
+ *
+ * Y no van en la base de datos: no son datos de la boda, que los edita quien
+ * organiza, sino la identidad, que se edita con una PR. Cuando se asignen a
+ * mesas de verdad (BODA-83), la mesa guardará **la clave**, no el dibujo.
+ *
+ * EL SISTEMA DE COORDENADAS es un lienzo de 100 × 100 sin unidades, que el SVG
+ * escala con `viewBox`. Así el mismo mapa sirve para un marcasitios de 40 px y
+ * para un cartel A0 sin tocar un número.
+ */
+
+/** Dónde se ve. Decide en qué grupo entra en el catálogo, no cómo se dibuja. */
+export type Hemisferio = "norte" | "sur";
+
+export interface Constelacion {
+  /** Identificador estable. Es lo que guardará una mesa cuando las haya. */
+  clave: string;
+  nombre: string;
+  hemisferio: Hemisferio;
+  /** `[x, y, radio]` en el lienzo de 100 × 100. El radio es el brillo. */
+  estrellas: readonly (readonly [number, number, number])[];
+  /** Pares de índices sobre `estrellas`. El test comprueba que existen. */
+  lineas: readonly (readonly [number, number])[];
+}
+
+export const CONSTELACIONES: readonly Constelacion[] = [
+  {
+    clave: "lira",
+    nombre: "Lira",
+    hemisferio: "norte",
+    estrellas: [
+      [50, 9, 1.8],
+      [35, 36, 1],
+      [65, 40, 1],
+      [39, 72, 1],
+      [69, 76, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [0, 2],
+      [1, 3],
+      [3, 4],
+      [4, 2],
+      [1, 2],
+    ],
+  },
+  {
+    clave: "casiopea",
+    nombre: "Casiopea",
+    hemisferio: "norte",
+    estrellas: [
+      [10, 32, 1],
+      [31, 62, 1.3],
+      [50, 26, 1.6],
+      [72, 60, 1.2],
+      [92, 34, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+    ],
+  },
+  {
+    clave: "osamayor",
+    nombre: "Osa Mayor",
+    hemisferio: "norte",
+    estrellas: [
+      [9, 56, 1.2],
+      [24, 70, 1],
+      [41, 63, 1],
+      [51, 45, 1.4],
+      [67, 37, 1.1],
+      [81, 43, 1],
+      [94, 27, 1.3],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 0],
+      [3, 4],
+      [4, 5],
+      [5, 6],
+    ],
+  },
+  {
+    clave: "cisne",
+    nombre: "Cisne",
+    hemisferio: "norte",
+    estrellas: [
+      [50, 7, 1.6],
+      [50, 47, 1.2],
+      [50, 92, 1.3],
+      [13, 39, 1],
+      [87, 44, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [3, 1],
+      [1, 4],
+    ],
+  },
+  {
+    clave: "perseo",
+    nombre: "Perseo",
+    hemisferio: "norte",
+    estrellas: [
+      [13, 18, 1.1],
+      [29, 41, 1.4],
+      [46, 33, 1],
+      [59, 57, 1.2],
+      [74, 49, 1],
+      [86, 76, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+      [3, 5],
+    ],
+  },
+  {
+    clave: "coronaboreal",
+    nombre: "Corona Boreal",
+    hemisferio: "norte",
+    estrellas: [
+      [9, 62, 1],
+      [20, 40, 1],
+      [35, 28, 1.1],
+      [51, 24, 1.5],
+      [67, 30, 1.1],
+      [81, 43, 1],
+      [92, 64, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+      [4, 5],
+      [5, 6],
+    ],
+  },
+  {
+    clave: "aguila",
+    nombre: "Águila",
+    hemisferio: "norte",
+    estrellas: [
+      [50, 44, 1.7],
+      [37, 26, 1],
+      [64, 24, 1],
+      [28, 65, 1],
+      [72, 67, 1],
+      [50, 88, 1.1],
+    ],
+    lineas: [
+      [1, 0],
+      [0, 2],
+      [3, 0],
+      [0, 4],
+      [0, 5],
+    ],
+  },
+  {
+    clave: "orion",
+    nombre: "Orión",
+    hemisferio: "norte",
+    estrellas: [
+      [22, 16, 1.7],
+      [73, 13, 1.2],
+      [38, 48, 1.1],
+      [50, 53, 1.1],
+      [62, 58, 1.1],
+      [74, 88, 1.2],
+      [25, 86, 1.6],
+    ],
+    lineas: [
+      [0, 2],
+      [1, 4],
+      [2, 3],
+      [3, 4],
+      [2, 6],
+      [4, 5],
+      [0, 1],
+    ],
+  },
+  {
+    clave: "cruzdelsur",
+    nombre: "Cruz del Sur",
+    hemisferio: "sur",
+    estrellas: [
+      [50, 8, 1.6],
+      [50, 88, 1.3],
+      [15, 50, 1.1],
+      [85, 44, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [2, 3],
+    ],
+  },
+  {
+    clave: "centauro",
+    nombre: "Centauro",
+    hemisferio: "sur",
+    estrellas: [
+      [13, 74, 1.6],
+      [30, 55, 1.4],
+      [48, 46, 1.1],
+      [67, 58, 1],
+      [83, 40, 1.1],
+      [58, 22, 1],
+      [37, 19, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+      [2, 5],
+      [5, 6],
+    ],
+  },
+  {
+    clave: "escorpio",
+    nombre: "Escorpio",
+    hemisferio: "sur",
+    estrellas: [
+      [10, 16, 1],
+      [22, 27, 1.1],
+      [34, 15, 1],
+      [41, 41, 1.7],
+      [51, 57, 1.1],
+      [63, 70, 1],
+      [75, 80, 1.1],
+      [87, 73, 1],
+      [91, 57, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [1, 3],
+      [3, 4],
+      [4, 5],
+      [5, 6],
+      [6, 7],
+      [7, 8],
+    ],
+  },
+  {
+    clave: "tucan",
+    nombre: "Tucán",
+    hemisferio: "sur",
+    estrellas: [
+      [17, 71, 1.1],
+      [36, 53, 1],
+      [56, 44, 1.4],
+      [76, 28, 1],
+      [88, 53, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+    ],
+  },
+  {
+    clave: "fenix",
+    nombre: "Fénix",
+    hemisferio: "sur",
+    estrellas: [
+      [14, 26, 1],
+      [34, 41, 1.5],
+      [53, 30, 1],
+      [70, 48, 1.1],
+      [87, 30, 1],
+      [50, 69, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+      [1, 5],
+    ],
+  },
+  {
+    clave: "carina",
+    nombre: "Carina",
+    hemisferio: "sur",
+    estrellas: [
+      [11, 58, 1.8],
+      [30, 42, 1.1],
+      [50, 51, 1],
+      [70, 34, 1.2],
+      [88, 52, 1],
+      [58, 74, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+      [2, 5],
+    ],
+  },
+  {
+    clave: "grulla",
+    nombre: "Grulla",
+    hemisferio: "sur",
+    estrellas: [
+      [20, 19, 1],
+      [36, 38, 1.4],
+      [53, 34, 1.1],
+      [65, 55, 1],
+      [81, 73, 1],
+      [46, 61, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 4],
+      [2, 5],
+    ],
+  },
+  {
+    clave: "vela",
+    nombre: "Vela",
+    hemisferio: "sur",
+    estrellas: [
+      [15, 40, 1.2],
+      [38, 27, 1],
+      [60, 41, 1.1],
+      [83, 30, 1],
+      [50, 67, 1],
+    ],
+    lineas: [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [1, 4],
+      [2, 4],
+    ],
+  },
+] as const;
+
+/** Búsqueda por clave. La usan el componente y, más adelante, el plano de mesas. */
+export function constelacionPorClave(clave: string): Constelacion | undefined {
+  return CONSTELACIONES.find((constelacion) => constelacion.clave === clave);
+}
+
+/**
+ * La constelación de los novios. Es la que abre el sistema de marca y la que
+ * lleva el Save the Date, y por eso tiene nombre propio en lugar de aparecer
+ * como una cadena suelta en dos sitios distintos.
+ */
+export const CONSTELACION_NOVIOS = "lira";
+
+/**
+ * Grosor de la línea, en unidades del lienzo de 100. Va aquí y no como número
+ * suelto en el componente porque es geometría del dibujo, igual que las
+ * coordenadas: una línea más gruesa deja de parecer un mapa del cielo.
+ */
+export const GROSOR_TRAZO = 0.7;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -75,6 +75,10 @@
   --color-acento: var(--acento);
   --color-acento-hover: var(--acento-hover);
 
+  /* Constelaciones: dan `fill-*` y `stroke-*` sin valores arbitrarios */
+  --color-constelacion-estrella: var(--constelacion-estrella);
+  --color-constelacion-trazo: var(--constelacion-trazo);
+
   /* Bordes */
   --color-borde: var(--borde);
   --color-borde-fuerte: var(--borde-fuerte);
@@ -151,6 +155,9 @@
   --spacing-campo: var(--alto-campo);
   --spacing-cifra: var(--ancho-cifra);
 
+  /* Un solo token da `size-constelacion`: el hueco es cuadrado por definición. */
+  --spacing-constelacion: var(--lado-constelacion);
+
   /* Un solo token da `h-cabecera`, `pt-cabecera` y `scroll-mt-cabecera`. */
   --spacing-cabecera: var(--alto-cabecera);
 
@@ -192,6 +199,25 @@
   --breakpoint-lg: 64rem;
   --breakpoint-xl: 80rem;
 }
+
+/**
+ * PANTALLA ALTA — el único punto de ruptura que mide el alto
+ *
+ * Todo el diseño responde al ancho menos una cosa: el Save the Date, que
+ * promete caber de una vez sin que nadie haga scroll. Ahí el ancho da igual y
+ * lo que manda es cuánto alto hay.
+ *
+ * Sirve para que un adorno ceda el sitio a la información. La página necesita
+ * unos 690 px de contenido y la constelación cuesta 108 más; por debajo de
+ * este umbral no caben las dos, y lo que se va es el adorno. Los móviles de
+ * hoy pasan de 840 px de alto, así que la constelación se ve donde de verdad
+ * se abre esta página — en el móvil, desde WhatsApp— y desaparece en una
+ * ventana de escritorio baja, que es donde menos falta hace.
+ *
+ * Va como valor directo por lo mismo que los breakpoints de arriba: una media
+ * query no acepta `var()`.
+ */
+@custom-variant pantalla-alta (@media (min-height: 52rem));
 
 /**
  * Patrón «dato + contenido»: una columna estrecha con la hora o la duración,

--- a/src/styles/tokens/primitives.css
+++ b/src/styles/tokens/primitives.css
@@ -140,6 +140,15 @@
   --color-estrella-3: rgb(238 242 248 / 42%);
   --color-estrella-4: rgb(238 242 248 / 28%);
 
+  /**
+   * El trazo que une las estrellas de una constelación. La entrega es literal
+   * —«estrellas llenas, líneas al 42 %»— y ese 42 es lo que hace que el dibujo
+   * se lea como un mapa del cielo y no como un diagrama: las estrellas mandan y
+   * la línea sólo sugiere por dónde va la figura.
+   */
+  --color-trazo-marino: rgb(63 79 112 / 42%);
+  --color-trazo-nieve: rgb(238 242 248 / 42%);
+
   /* ---------------------------------------------------------------------
    * Tipografía — las tres familias de la entrega
    *
@@ -251,6 +260,12 @@
 
   /* Ancho mínimo de una cifra grande, para que la cuenta atrás no baile. */
   --size-cifra: 5.5rem;
+
+  /**
+   * El hueco de una constelación cuando acompaña a un texto. Es cuadrado: el
+   * lienzo del mapa lo es, y darle otra proporción deformaría el cielo.
+   */
+  --size-constelacion: 4.625rem;
 
   /**
    * Ancho mínimo de columna en las rejillas que se parten solas. Por debajo de

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -61,6 +61,10 @@
   --acento: var(--color-bronce-600);
   --acento-hover: var(--color-bronce-500);
 
+  /* --- Constelaciones (el único motivo ilustrativo del sistema) -------- */
+  --constelacion-estrella: var(--color-marino-700);
+  --constelacion-trazo: var(--color-trazo-marino);
+
   /* --- Bordes -------------------------------------------------------- */
   --borde: var(--color-bruma-300);
   --borde-fuerte: var(--color-bruma-400);
@@ -146,6 +150,7 @@
   --alto-control-compacto: var(--size-control-compacto);
   --alto-campo: var(--size-campo);
   --ancho-cifra: var(--size-cifra);
+  --lado-constelacion: var(--size-constelacion);
   --ancho-columna-minima: var(--size-columna-minima);
   --ancho-entradilla: var(--size-entradilla);
   --alto-foto-portada: var(--size-foto-portada);
@@ -225,6 +230,8 @@
     --accion-hover: var(--color-blanco);
     --acento: var(--color-bronce-300);
     --acento-hover: var(--color-bronce-200);
+    --constelacion-estrella: var(--color-nieve-100);
+    --constelacion-trazo: var(--color-trazo-nieve);
     --borde: var(--color-marino-775);
     --borde-fuerte: var(--color-marino-600);
     --borde-tenue: var(--color-marino-850);
@@ -268,6 +275,8 @@
   --accion-hover: var(--color-blanco);
   --acento: var(--color-bronce-300);
   --acento-hover: var(--color-bronce-200);
+  --constelacion-estrella: var(--color-nieve-100);
+  --constelacion-trazo: var(--color-trazo-nieve);
   --borde: var(--color-marino-775);
   --borde-fuerte: var(--color-marino-600);
   --borde-tenue: var(--color-marino-850);
@@ -318,6 +327,8 @@
   --tinta-sobre-accion: var(--color-pizarra-900);
   --acento: var(--color-bronce-300);
   --acento-hover: var(--color-bronce-200);
+  --constelacion-estrella: var(--color-nieve-100);
+  --constelacion-trazo: var(--color-trazo-nieve);
   --tinta-sobre-acento: var(--color-pizarra-900);
   --borde: var(--color-marino-600);
   --borde-fuerte: var(--color-marino-500);
@@ -339,6 +350,8 @@
   --tinta-sobre-accion: var(--color-pizarra-900);
   --acento: var(--color-bronce-300);
   --acento-hover: var(--color-bronce-200);
+  --constelacion-estrella: var(--color-nieve-100);
+  --constelacion-trazo: var(--color-trazo-nieve);
   --tinta-sobre-acento: var(--color-pizarra-900);
   --borde: var(--color-marino-800);
   --foco: var(--color-bronce-300);

--- a/tests/e2e/constelaciones.spec.ts
+++ b/tests/e2e/constelaciones.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "@playwright/test";
+
+import copy from "../../content/copy.es.json";
+
+/**
+ * BODA-34 · Las constelaciones
+ *
+ * El único elemento ilustrativo del sistema de marca. Lo que se comprueba aquí
+ * es lo que de verdad puede romperse: que se dibujan, que cambian de color
+ * solas al cambiar el fondo —sin tocar una clase— y que no le cuentan nada a
+ * quien escucha la página cuando son adorno.
+ */
+
+test.describe("El catálogo del sistema de marca", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/cocina");
+  });
+
+  test("se dibujan las dieciséis, repartidas por hemisferio", async ({ page }) => {
+    const catalogo = page.locator("section", {
+      has: page.getByRole("heading", { name: copy.cocina.seccionConstelaciones }),
+    });
+
+    await expect(catalogo.locator("svg[role='img']")).toHaveCount(16);
+    await expect(catalogo.getByText(copy.cocina.hemisferioNorte)).toBeVisible();
+    await expect(catalogo.getByText(copy.cocina.hemisferioSur)).toBeVisible();
+  });
+
+  test("cada mapa tiene sus estrellas y sus líneas, no un hueco", async ({ page }) => {
+    // Un SVG vacío ocupa el mismo sitio que uno dibujado: sin contar los
+    // elementos de dentro, este test pasaría con dieciséis cuadros en blanco.
+    const dibujos = await page.evaluate(() =>
+      [...document.querySelectorAll("svg[role='img']")].map((svg) => ({
+        nombre: svg.querySelector("title")?.textContent ?? "",
+        estrellas: svg.querySelectorAll("circle").length,
+        lineas: svg.querySelectorAll("line").length,
+      })),
+    );
+
+    expect(dibujos).toHaveLength(16);
+    for (const dibujo of dibujos) {
+      expect(dibujo.nombre.length, "una constelación sin nombre").toBeGreaterThan(0);
+      expect(dibujo.estrellas, `${dibujo.nombre} sin estrellas`).toBeGreaterThanOrEqual(4);
+      expect(dibujo.lineas, `${dibujo.nombre} sin líneas`).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  /**
+   * La promesa del sistema, comprobada donde se puede comprobar: la misma
+   * constelación, sin una sola clase distinta, cambia de color al meterla en un
+   * bloque inverso. Si esto falla, el color se ha colado en el componente.
+   */
+  test("el mismo dibujo se aclara solo dentro de un bloque inverso", async ({ page }) => {
+    const colores = await page.evaluate(() => {
+      const original = document.querySelector("svg[role='img']")!;
+      const claro = {
+        estrella: getComputedStyle(original.querySelector("circle")!).fill,
+        trazo: getComputedStyle(original.querySelector("line")!).stroke,
+      };
+
+      // El mismo nodo, clonado dentro de un bloque inverso. Ni una clase cambia.
+      const bloque = document.createElement("div");
+      bloque.setAttribute("data-seccion", "inversa");
+      const copia = original.cloneNode(true) as SVGElement;
+      bloque.append(copia);
+      document.body.append(bloque);
+
+      const inverso = {
+        estrella: getComputedStyle(copia.querySelector("circle")!).fill,
+        trazo: getComputedStyle(copia.querySelector("line")!).stroke,
+      };
+      bloque.remove();
+
+      return { claro, inverso, clases: original.getAttribute("class") };
+    });
+
+    expect(colores.claro.estrella).not.toBe(colores.inverso.estrella);
+    expect(colores.claro.trazo).not.toBe(colores.inverso.trazo);
+
+    // Y ninguno de los dos es transparente: un token que no resuelve pinta
+    // `rgba(0, 0, 0, 0)` y el dibujo desaparecería sin dar ningún error.
+    for (const color of Object.values({ ...colores.claro, ...colores.inverso })) {
+      expect(color).not.toContain("rgba(0, 0, 0, 0)");
+    }
+  });
+});
+
+/**
+ * El Save the Date se abre en un móvil, desde WhatsApp. Por eso estas pruebas
+ * fijan el alto en vez de heredar el del proyecto: lo que se comprueba aquí
+ * depende de cuánta pantalla hay, no de cuál es el navegador.
+ */
+test.describe("La constelación del Save the Date", () => {
+  const MOVIL = { width: 390, height: 844 };
+  const VENTANA_BAJA = { width: 1280, height: 720 };
+
+  test("Lira abre la página en un móvil de hoy", async ({ page }) => {
+    await page.setViewportSize(MOVIL);
+    await page.goto("/reserva-la-fecha");
+
+    const dibujo = page.locator("main svg").first();
+    await expect(dibujo).toBeVisible();
+    expect(await dibujo.locator("circle").count()).toBeGreaterThanOrEqual(4);
+  });
+
+  /**
+   * CASO DE ERROR / ACCESIBILIDAD. Aquí la constelación es adorno sobre unos
+   * nombres. Si se anunciara, quien navega con lector de pantalla oiría «Lira»
+   * antes que a los novios, que es lo único que la página tiene que decir.
+   */
+  test("como adorno, no le dice nada a un lector de pantalla", async ({ page }) => {
+    await page.setViewportSize(MOVIL);
+    await page.goto("/reserva-la-fecha");
+
+    const dibujo = page.locator("main svg").first();
+    await expect(dibujo).toHaveAttribute("aria-hidden", "true");
+    await expect(dibujo.locator("title")).toHaveCount(0);
+  });
+
+  /**
+   * CASO DE ERROR. La página promete caber de una vez, y un adorno no puede
+   * romper esa promesa. En una ventana baja la constelación se retira sola.
+   */
+  test("en una pantalla baja el adorno se retira y la página sigue cabiendo", async ({
+    page,
+  }) => {
+    await page.setViewportSize(VENTANA_BAJA);
+    await page.goto("/reserva-la-fecha");
+
+    await expect(page.locator("main svg").first()).toBeHidden();
+
+    const medidas = await page.evaluate(() => ({
+      alto: document.documentElement.scrollHeight,
+      ventana: window.innerHeight,
+    }));
+    expect(medidas.alto).toBeLessThanOrEqual(medidas.ventana + 1);
+  });
+
+  test("y donde sí cabe, sigue cabiendo con la constelación puesta", async ({ page }) => {
+    await page.setViewportSize(MOVIL);
+    await page.goto("/reserva-la-fecha");
+
+    const medidas = await page.evaluate(() => ({
+      alto: document.documentElement.scrollHeight,
+      ventana: window.innerHeight,
+      adorno: document.querySelector("main svg")!.getBoundingClientRect().height,
+    }));
+
+    expect(medidas.adorno).toBeGreaterThan(0);
+    expect(medidas.alto).toBeLessThanOrEqual(medidas.ventana + 1);
+  });
+});

--- a/tests/unidad/constelaciones.test.ts
+++ b/tests/unidad/constelaciones.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CONSTELACIONES,
+  CONSTELACION_NOVIOS,
+  constelacionPorClave,
+  GROSOR_TRAZO,
+} from "@/config/constelaciones";
+
+/**
+ * LAS CONSTELACIONES
+ *
+ * Son ciento y pico números transcritos de la entrega, y ese es exactamente el
+ * tipo de dato donde un dedazo no se nota: una estrella movida tres unidades
+ * sigue pareciendo una constelación. Por eso lo que se comprueba aquí no es
+ * «que estén», sino las invariantes que romperían el dibujo de verdad.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+
+describe("El catálogo de constelaciones", () => {
+  it("tiene las dieciséis de la entrega, ocho por hemisferio", () => {
+    expect(CONSTELACIONES).toHaveLength(16);
+    expect(CONSTELACIONES.filter((c) => c.hemisferio === "norte")).toHaveLength(8);
+    expect(CONSTELACIONES.filter((c) => c.hemisferio === "sur")).toHaveLength(8);
+  });
+
+  it("no repite ninguna clave", () => {
+    const claves = CONSTELACIONES.map((c) => c.clave);
+    expect(new Set(claves).size).toBe(claves.length);
+  });
+
+  /**
+   * CASO DE ERROR. El fallo silencioso de este dato: una línea que apunta a una
+   * estrella que no existe. React pintaría `x1={undefined}` y la línea
+   * sencillamente no saldría, sin un solo error en consola.
+   */
+  it("cada línea une dos estrellas que existen", () => {
+    for (const { clave, estrellas, lineas } of CONSTELACIONES) {
+      for (const [desde, hasta] of lineas) {
+        expect(
+          estrellas[desde],
+          `${clave}: la línea sale de la estrella ${desde}`,
+        ).toBeDefined();
+        expect(
+          estrellas[hasta],
+          `${clave}: la línea llega a la estrella ${hasta}`,
+        ).toBeDefined();
+        // Una línea de una estrella a sí misma es un punto: no dibuja nada.
+        expect(desde, `${clave}: línea de una estrella a sí misma`).not.toBe(hasta);
+      }
+    }
+  });
+
+  it("ninguna estrella se sale del lienzo", () => {
+    for (const { clave, estrellas } of CONSTELACIONES) {
+      for (const [x, y, radio] of estrellas) {
+        // El radio cuenta: una estrella en x=100 con r=1.8 saldría cortada.
+        expect(x - radio, `${clave}: estrella cortada por la izquierda`).toBeGreaterThanOrEqual(
+          0,
+        );
+        expect(x + radio, `${clave}: estrella cortada por la derecha`).toBeLessThanOrEqual(100);
+        expect(y - radio, `${clave}: estrella cortada por arriba`).toBeGreaterThanOrEqual(0);
+        expect(y + radio, `${clave}: estrella cortada por abajo`).toBeLessThanOrEqual(100);
+        expect(radio, `${clave}: estrella sin brillo`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("ninguna constelación se queda con estrellas sueltas", () => {
+    // Una estrella que no toca ninguna línea es un punto perdido en el mapa:
+    // o falta una línea, o sobra la estrella.
+    for (const { clave, estrellas, lineas } of CONSTELACIONES) {
+      const unidas = new Set(lineas.flat());
+      for (let i = 0; i < estrellas.length; i++) {
+        expect(unidas.has(i), `${clave}: la estrella ${i} no une con ninguna otra`).toBe(true);
+      }
+    }
+  });
+
+  it("la constelación de los novios existe y es del norte", () => {
+    const novios = constelacionPorClave(CONSTELACION_NOVIOS);
+    expect(novios).toBeDefined();
+    // Vega, la más brillante del verano boreal: es el cielo de esa noche.
+    expect(novios?.hemisferio).toBe("norte");
+  });
+
+  it("una clave que no existe devuelve nada, no revienta", () => {
+    expect(constelacionPorClave("perro")).toBeUndefined();
+  });
+});
+
+/**
+ * REGLA 1 · Ni el dibujo ni sus colores pueden estar escritos en el componente.
+ */
+describe("Las constelaciones respetan el sistema de tokens", () => {
+  const componente = readFileSync(
+    join(RAIZ, "src", "components", "ui", "constelacion.tsx"),
+    "utf8",
+  );
+
+  it("el componente no escribe ni un color", () => {
+    // Ni hex, ni rgb(), ni nombres de color sueltos en atributos de SVG.
+    expect(componente).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(componente).not.toMatch(/\brgba?\(/);
+    expect(componente).toContain("fill-constelacion-estrella");
+    expect(componente).toContain("stroke-constelacion-trazo");
+  });
+
+  it("el grosor del trazo sale de la configuración, no del componente", () => {
+    expect(componente).toContain("GROSOR_TRAZO");
+    expect(GROSOR_TRAZO).toBeGreaterThan(0);
+  });
+
+  it("los dos semánticos existen en los cuatro fondos del sistema", () => {
+    const semanticos = readFileSync(
+      join(RAIZ, "src", "styles", "tokens", "semantic.css"),
+      "utf8",
+    );
+
+    // Claro, oscuro por preferencia, oscuro forzado, bloque inverso y pie.
+    const apariciones = semanticos.match(/--constelacion-estrella:/g) ?? [];
+    expect(apariciones.length).toBe(5);
+    expect(semanticos.match(/--constelacion-trazo:/g)?.length).toBe(5);
+
+    // Y sólo referencian primitivos: la capa 2 no inventa valores.
+    for (const linea of semanticos.split("\n")) {
+      if (linea.includes("--constelacion-")) {
+        expect(linea, `capa 2 con literal: ${linea.trim()}`).toMatch(/var\(--color-/);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Qué cambia

Los dieciséis mapas de estrellas de la entrega entran en el proyecto y se ven donde ella los pone: el catálogo del sistema de marca y el Save the Date.

Closes #102

## Cómo probarlo en el preview

1. Ir a `/cocina` y bajar hasta **Constelaciones**. Están las dieciséis, ocho por hemisferio, con el mismo trazo.
2. Cambiar a tema oscuro con el selector de arriba. Las estrellas y las líneas se aclaran solas; ningún componente cambia de clase.
3. Abrir `/reserva-la-fecha` **en un móvil** (o estrechando la ventana a ~390 × 844). Lira abre la página sobre los nombres.
4. Ahora la misma página en una ventana de escritorio baja (1280 × 720): la constelación no está, y la página sigue cabiendo sin scroll. Es deliberado — ver abajo.

## Lo que se ha medido en el navegador

| | Entrega | Medido |
|---|---|---|
| Estrella, fondo claro | `#1F2B44` | `rgb(31, 43, 68)` |
| Trazo, fondo claro | `rgba(63,79,112,0.42)` | `rgba(63, 79, 112, 0.42)` |
| Estrella, fondo marino | `#EEF2F8` | `rgb(238, 242, 248)` |
| Grosor del trazo | `0.7` | `0.7` |
| Constelaciones dibujadas | 16 | 16 |

## Decisiones que conviene mirar

**Los mapas van a `src/config/`, no a la base de datos.** No son datos de la boda —que los edita quien organiza desde el panel— sino identidad, que se edita con una PR. Cuando existan las mesas (BODA-83), la mesa guardará la clave (`lira`, `osamayor`) y no el dibujo.

**El componente no escribe ni un color, y hay un test que lo prueba de verdad.** No comprobando que la clase esté puesta —eso diría que se ha pedido el token, no que funcione— sino clonando un dibujo dentro de un `[data-seccion="inversa"]` y comparando el `fill` computado de los dos. Si algún día alguien mete un hex en el SVG, ese test se cae.

**Un test existente pilló una regresión y se ha arreglado la causa, no el test.** El Save the Date promete caber de una vez, y la constelación lo desbordaba 75 px en una ventana de 720. En lugar de relajar el umbral, el adorno cede: `pantalla-alta` es el único punto de ruptura del proyecto que mide el **alto**, y por debajo de 832 px retira la constelación. Los móviles de hoy pasan de 840, así que se ve donde esta página se abre de verdad —WhatsApp, en el móvil— y desaparece en una ventana baja de escritorio, que es donde menos falta hace. Hay dos tests nuevos para las dos mitades de esa regla.

**Los dieciséis mapas no se han transcrito a mano.** Se han extraído del componente de la entrega con un script y validado: ninguna línea apunta a una estrella inexistente, ninguna estrella se sale del lienzo contando su radio, y ninguna se queda sin unir a otra. Son las tres formas en que este dato falla en silencio.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: dos primitivos y un semántico nuevos; ni un color ni el grosor en el componente
- [x] Test E2E incluido: camino feliz **y** dos casos de error (el adorno que desborda, el que se anuncia)
- [ ] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: decoración `aria-hidden` por defecto, rotulada sólo donde el dibujo es la información
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview

## Base de datos

- [x] No la toca
- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [x] No hace falta
- [ ] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_