### PR TITLE
feat(rsvp): a quién escribir cuando el enlace no vale o el plazo se cerró

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -143,6 +143,7 @@
     "editarRespuesta": "Cambiar la respuesta",
     "tokenInvalido": "Este enlace no es válido. Escribidnos y os mandamos uno nuevo.",
     "plazoCerrado": "El plazo para confirmar ya se ha cerrado. Escribidnos y lo miramos.",
+    "plazoCerradoContacto": "Si tenéis que cambiar algo, escribidnos y lo miramos.",
     "antesDel": "Antes del {fecha}",
     "etiquetaPaso": "Paso {actual} de {total}",
     "saludo": "Hola, {grupo}",

--- a/src/app/rsvp/[token]/page.tsx
+++ b/src/app/rsvp/[token]/page.tsx
@@ -90,7 +90,7 @@ export default async function PaginaRsvp({ params, searchParams }: Parametros) {
 
   // Cero filas es el contrato de la base para «este enlace no vale». No se
   // dice nada más: ni si el token existió, ni de quién era.
-  if (!invitacion) return <EnlaceNoValido />;
+  if (!invitacion) return <EnlaceNoValido correo={configuracion?.correoContacto ?? null} />;
 
   const plazoCerrado = Boolean(
     configuracion?.fechaLimiteRsvp && configuracion.fechaLimiteRsvp < new Date(),
@@ -103,7 +103,12 @@ export default async function PaginaRsvp({ params, searchParams }: Parametros) {
   if (consulta.enviado === "1" || (yaRespondido && !consulta.paso)) {
     return (
       <Marco>
-        <RespuestaEnviada personas={invitacion.personas} token={token} cerrado={plazoCerrado} />
+        <RespuestaEnviada
+          personas={invitacion.personas}
+          token={token}
+          cerrado={plazoCerrado}
+          correo={configuracion?.correoContacto ?? null}
+        />
       </Marco>
     );
   }
@@ -115,6 +120,10 @@ export default async function PaginaRsvp({ params, searchParams }: Parametros) {
       <Marco>
         <Titulo1 className="text-center">{t("rsvp.titulo")}</Titulo1>
         <Cuerpo className="mt-elemento text-center">{t("rsvp.plazoCerrado")}</Cuerpo>
+        <LineaContacto
+          correo={configuracion?.correoContacto ?? null}
+          texto={t("rsvp.plazoCerradoContacto")}
+        />
       </Marco>
     );
   }
@@ -219,19 +228,55 @@ function Marco({ children }: { children: React.ReactNode }) {
  * quién era, ni cuántas personas tenía. Sólo dice que no vale y a quién
  * escribir.
  */
-function EnlaceNoValido() {
+function EnlaceNoValido({ correo }: { correo: string | null }) {
   return (
     <Marco>
       <Titulo1 className="text-center">{t("rsvp.titulo")}</Titulo1>
       <Cuerpo className="mx-auto mt-elemento max-w-texto text-center">
         {t("rsvp.tokenInvalido")}
       </Cuerpo>
+
+      {/*
+        A QUIÉN ESCRIBIR, que es lo único útil que se le puede dar a quien
+        llega aquí. «Escribidnos» sin una dirección deja a alguien mirando una
+        pantalla que no le resuelve nada.
+
+        El correo sale de la configuración y es el mismo que ya está en el pie
+        de la web pública, así que enseñarlo no cuenta nada que no se supiera.
+        Lo que NO cambia es el resto: el mensaje es idéntico exista el token o
+        no, y esta línea también, porque no depende del token.
+      */}
+      <LineaContacto correo={correo} texto={t("rsvp.enlacePerdido")} />
+
       <div className="mt-elemento flex justify-center">
         <BotonEnlace href="/" jerarquia="secundario">
           {t("saveTheDate.verLaWeb")}
         </BotonEnlace>
       </div>
     </Marco>
+  );
+}
+
+/**
+ * LA DIRECCIÓN A LA QUE ESCRIBIR.
+ *
+ * Sin correo configurado no se pinta nada: mejor una frase de menos que un
+ * «escribidnos a» seguido de un hueco. Es el mismo patrón que usa el pie de la
+ * landing, y el mismo correo.
+ */
+function LineaContacto({ correo, texto }: { correo: string | null; texto: string }) {
+  if (!correo) return null;
+
+  return (
+    <p className="mx-auto mt-elemento max-w-texto text-center text-pequeno text-tinta-suave">
+      {texto}{" "}
+      <a
+        href={`mailto:${correo}`}
+        className="border-b border-borde-fuerte transicion-color hover:text-acento"
+      >
+        {correo}
+      </a>
+    </p>
   );
 }
 
@@ -435,10 +480,12 @@ function RespuestaEnviada({
   personas,
   token,
   cerrado,
+  correo,
 }: {
   personas: PersonaInvitada[];
   token: string;
   cerrado: boolean;
+  correo: string | null;
 }) {
   const vienen = personas.filter((p) => p.estado === "confirmado");
   const noVienen = personas.filter((p) => p.estado === "rechazado");
@@ -480,6 +527,21 @@ function RespuestaEnviada({
         <p className="mt-elemento text-pequeno text-tinta-tenue">
           {t("rsvp.respuestaGuardada", { fecha: formatoFechaHora.format(respondido) })}
         </p>
+      ) : null}
+
+      {/*
+        Y si el plazo ya se ha cerrado, se dice por qué no está el botón de
+        cambiar la respuesta. Un botón que desaparece sin explicación se lee
+        como una avería, y el siguiente paso de quien lo ve es un WhatsApp
+        preguntando qué ha pasado — que es justo lo que este ticket evita.
+      */}
+      {cerrado ? (
+        <>
+          <Cuerpo className="mx-auto mt-elemento max-w-texto text-pequeno">
+            {t("rsvp.plazoCerrado")}
+          </Cuerpo>
+          <LineaContacto correo={correo} texto={t("rsvp.plazoCerradoContacto")} />
+        </>
       ) : null}
 
       <div className="mt-elemento flex flex-wrap justify-center gap-interno">

--- a/tests/e2e/rsvp.spec.ts
+++ b/tests/e2e/rsvp.spec.ts
@@ -3,6 +3,7 @@ import postgres from "postgres";
 
 import copy from "../../content/copy.es.json";
 import { RUTA_RSVP } from "../../src/config/constants";
+import { conPlazoCerrado } from "./utiles/plazo";
 
 /**
  * BODA-55 · Confirmación de asistencia
@@ -32,6 +33,17 @@ async function conBase<T>(trabajo: (sql: postgres.Sql) => Promise<T>): Promise<T
   } finally {
     await sql.end();
   }
+}
+
+/** El correo de contacto que hay en la base, que es el que tiene que salir. */
+async function correoDeContacto(): Promise<string> {
+  const [fila] = await conBase(
+    (sql) => sql<{ correo_contacto: string | null }[]>`
+      select correo_contacto from public.configuracion_boda
+    `,
+  );
+  if (!fila?.correo_contacto) throw new Error("El seed tiene que traer correo de contacto.");
+  return fila.correo_contacto;
 }
 
 /** Crea un grupo sin contestar y devuelve su token. */
@@ -357,10 +369,223 @@ test.describe("Un enlace que no vale", () => {
     await expect(page.locator('input[type="radio"]')).toHaveCount(0);
   });
 
+  /**
+   * BODA-58 · UN TOKEN FALSO Y UNO REVOCADO TIENEN QUE SER INDISTINGUIBLES.
+   *
+   * Si la respuesta cambiara entre «este token no ha existido nunca» y
+   * «existió y se revocó», quien fuera probando cadenas sabría cuándo ha dado
+   * con la forma de un token de verdad. Y ése es justo el trabajo previo de
+   * adivinar uno.
+   *
+   * HOY ESTO SE CUMPLE POR CONSTRUCCIÓN, y el test existe para que siga
+   * cumpliéndose. La base no guarda el token sino su huella, y revocar es
+   * dejar de tener una fila con esa huella: no queda ni rastro de que existiera,
+   * así que no hay nada que pudiera contarlo. El día que alguien añada una
+   * tabla de tokens retirados para dar un mensaje más amable —«este enlace se
+   * sustituyó por otro», que es una idea razonable— este test se pondrá rojo y
+   * dirá por qué no se puede.
+   *
+   * Se comparan los dos HTML enteros y no sólo el rótulo: una diferencia en
+   * una etiqueta oculta, en el título del documento o en una meta cuenta lo
+   * mismo que una diferencia a la vista.
+   *
+   * La revocación se hace borrando el grupo y volviéndolo a emitir, que es lo
+   * que queda al alcance de un test sin sesión: el trigger `RSV06` sólo deja
+   * cambiar la huella a un editor. La rotación por el panel, con sesión, la
+   * cubre `panel-invitados.spec.ts`.
+   */
+  test("un token falso y uno revocado dan exactamente la misma respuesta", async ({
+    request,
+  }) => {
+    const revocado = await crearGrupo(`revocado-${Date.now()}`, ["(DES) Revocada"]);
+
+    // Mientras vale, vale: si esto no pasara, el resto del test compararía dos
+    // páginas de error sin haber demostrado nada.
+    const valido = await request.get(`${RUTA_RSVP}/${revocado}`);
+    expect(await valido.text()).toContain("(DES) Revocada");
+
+    await conBase(
+      (sql) => sql`
+        delete from public.grupos_invitacion
+         where huella_token = public.huella_token(${revocado})
+      `,
+    );
+
+    // Y uno que no ha existido nunca, con la misma pinta y la misma longitud:
+    // comparar contra una cadena más corta mediría el largo, no el contrato.
+    const inventado = revocado.replace(/.$/, "9");
+    expect(inventado).not.toBe(revocado);
+    expect(inventado).toHaveLength(revocado.length);
+
+    const [comoRevocado, comoInventado] = await Promise.all([
+      request.get(`${RUTA_RSVP}/${revocado}`),
+      request.get(`${RUTA_RSVP}/${inventado}`),
+    ]);
+
+    expect(comoRevocado.status()).toBe(comoInventado.status());
+
+    const htmlRevocado = await comoRevocado.text();
+    const htmlInventado = await comoInventado.text();
+
+    // El token va en la URL, así que aparece en el HTML de su propia página:
+    // se neutraliza en los dos antes de comparar, que es lo único que puede
+    // diferir legítimamente.
+    const sinToken = (html: string, token: string) => html.replaceAll(token, "TOKEN");
+
+    expect(
+      sinToken(htmlInventado, inventado),
+      "el HTML delata si el token existió: se podría adivinar uno probando",
+    ).toBe(sinToken(htmlRevocado, revocado));
+
+    // Y lo que dicen los dos es que no vale, sin contar de quién era.
+    expect(htmlRevocado).toContain(copy.rsvp.tokenInvalido);
+    expect(htmlRevocado).not.toContain("(DES) Revocada");
+  });
+
   test("la página del RSVP no se indexa", async ({ page }) => {
     // El token va en la URL. Una línea en un buscador, o una vista previa de
     // WhatsApp con el nombre del grupo, es una fuga.
     const respuesta = await page.goto(`${RUTA_RSVP}/token-que-no-existe-000000`);
     expect(respuesta?.headers()["x-robots-tag"] ?? "").toMatch(/noindex/);
+  });
+});
+
+/**
+ * BODA-56 · EDITAR LA RESPUESTA HASTA LA FECHA LÍMITE
+ *
+ * La gente cambia de planes. Si no puede cambiarlo sola acaba mandando un
+ * WhatsApp que hay que transcribir a mano, y transcribir a mano es donde se
+ * pierden los números que ya se le habían dado al catering.
+ *
+ * Lo que se prueba no es que el botón esté: es que la respuesta **cambia en la
+ * base** y que la anterior no desaparece. Un histórico que se pisa a sí mismo
+ * no sirve para contestar la única pregunta que importa cuando cambia un
+ * número —«¿desde cuándo?»—.
+ */
+test.describe("Cambiar una respuesta ya dada", () => {
+  test("se puede editar mientras haya plazo, y la anterior queda en el historial", async ({
+    browser,
+  }) => {
+    const token = await crearGrupo(`editar-${Date.now()}`, ["(DES) Editable"]);
+
+    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const pagina = await contexto.newPage();
+
+    // Primero, que sí.
+    await pagina.goto(`${RUTA_RSVP}/${token}`);
+    await pagina.locator('input[value="confirmado"]').first().check();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.enviar }).click();
+    await expect(pagina.getByRole("heading", { level: 1 })).toHaveText(copy.rsvp.graciasSi);
+
+    // Y ahora, que no: el mismo enlace reabre la respuesta.
+    await pagina.getByRole("button", { name: copy.rsvp.editarRespuesta }).click();
+    await pagina.locator('input[value="rechazado"]').first().check();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.enviar }).click();
+    await expect(pagina.getByRole("heading", { level: 1 })).toHaveText(copy.rsvp.graciasNo);
+
+    await contexto.close();
+
+    // La base es la que manda: la vigente es la nueva y la vieja sigue ahí.
+    const filas = await conBase(
+      (sql) => sql<{ estado: string; es_vigente: boolean }[]>`
+        select c.estado, c.es_vigente
+          from public.confirmaciones as c
+          join public.invitados as i on i.id = c.invitado_id
+          join public.grupos_invitacion as g on g.id = i.grupo_id
+         where g.huella_token = public.huella_token(${token})
+         order by c.creado_en
+      `,
+    );
+
+    const vigentes = filas.filter((fila) => fila.es_vigente);
+    expect(vigentes, "tiene que haber exactamente una respuesta vigente").toHaveLength(1);
+    expect(vigentes[0].estado).toBe("rechazado");
+
+    // Y la anterior no se ha borrado: sin esto no se puede saber desde cuándo
+    // cambió un número que ya se había dado al catering.
+    expect(
+      filas.some((fila) => !fila.es_vigente && fila.estado === "confirmado"),
+      "la respuesta anterior tiene que quedar en el historial",
+    ).toBe(true);
+  });
+
+  /**
+   * CASO DE ERROR · Con el plazo cerrado se puede ver, pero no cambiar.
+   *
+   * Y no basta con esconder el botón: lo que de verdad cierra la puerta es el
+   * trigger de la base, que es lo que este test comprueba llamando a la función
+   * pública **como `anon`**, saltándose la pantalla entera. Si sólo se probara
+   * el botón, cualquiera con la URL podría seguir escribiendo.
+   */
+  test("con el plazo cerrado no se puede cambiar, y se dice a quién escribir", async ({
+    browser,
+  }) => {
+    const token = await crearGrupo(`plazo-${Date.now()}`, ["(DES) Tarde"]);
+
+    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const pagina = await contexto.newPage();
+
+    await pagina.goto(`${RUTA_RSVP}/${token}`);
+    await pagina.locator('input[value="confirmado"]').first().check();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.enviar }).click();
+    await expect(pagina.getByRole("heading", { level: 1 })).toHaveText(copy.rsvp.graciasSi);
+
+    await conPlazoCerrado(async () => {
+      await pagina.goto(`${RUTA_RSVP}/${token}`);
+
+      // Se sigue viendo lo que se contestó: cerrar el plazo no es esconder la
+      // respuesta, es no dejar cambiarla.
+      await expect(pagina.getByText("(DES) Tarde")).toBeVisible();
+
+      // El botón de cambiar no está, y en su lugar hay una explicación.
+      await expect(pagina.getByRole("button", { name: copy.rsvp.editarRespuesta })).toHaveCount(
+        0,
+      );
+      await expect(pagina.getByText(copy.rsvp.plazoCerradoContacto)).toBeVisible();
+
+      // Y a quién escribir, que es el criterio del ticket: «escribidnos» sin
+      // una dirección no le resuelve nada a nadie.
+      const correo = await correoDeContacto();
+      await expect(pagina.getByRole("link", { name: correo })).toHaveAttribute(
+        "href",
+        `mailto:${correo}`,
+      );
+
+      // Lo que de verdad cierra la puerta: forzar el envío por debajo de la
+      // pantalla, como `anon`, tampoco escribe nada.
+      const intento = conBase(
+        (sql) =>
+          sql.begin(async (tx) => {
+            await tx`set local role anon`;
+            return tx`
+              select public.registrar_confirmacion(
+                ${token},
+                ${tx.json([{ invitado_id: "00000000-0000-4000-8000-000000000000", estado: "rechazado" }])}
+              )
+            `;
+          }) as Promise<unknown>,
+      );
+
+      await expect(intento, "con el plazo cerrado la base tiene que negarse").rejects.toThrow();
+    });
+
+    await contexto.close();
+
+    // Y sigue siendo la que era.
+    const [vigente] = await conBase(
+      (sql) => sql<{ estado: string }[]>`
+        select c.estado
+          from public.confirmaciones as c
+          join public.invitados as i on i.id = c.invitado_id
+          join public.grupos_invitacion as g on g.id = i.grupo_id
+         where g.huella_token = public.huella_token(${token}) and c.es_vigente
+      `,
+    );
+    expect(vigente.estado).toBe("confirmado");
   });
 });

--- a/tests/e2e/utiles/plazo.ts
+++ b/tests/e2e/utiles/plazo.ts
@@ -1,0 +1,67 @@
+import postgres from "postgres";
+
+/**
+ * ABRIR Y CERRAR EL PLAZO DE CONFIRMACIÓN DESDE UN TEST
+ *
+ * El plazo vive en `configuracion_boda.fecha_limite_rsvp` y lo aplica un
+ * trigger contra `now()`, nunca contra una fecha que mande el cliente. Para
+ * probar qué pasa cuando se cierra hay que moverlo de verdad: no hay forma de
+ * simularlo desde el navegador, y simularlo sería probar otra cosa.
+ *
+ * ES ESTADO GLOBAL, así que quien lo toca lo devuelve. `conPlazoCerrado` existe
+ * justamente para que devolverlo no dependa de acordarse: si el test falla a
+ * media, el `finally` deja la boda con su plazo original y el resto de la suite
+ * no se entera.
+ */
+async function conBase<T>(trabajo: (sql: postgres.Sql) => Promise<T>): Promise<T> {
+  const cadena = process.env.DATABASE_URL;
+  if (!cadena) throw new Error("Sin DATABASE_URL no se puede mover el plazo.");
+
+  const sql = postgres(cadena, { max: 1, prepare: false, onnotice: () => {} });
+  try {
+    return await trabajo(sql);
+  } finally {
+    await sql.end();
+  }
+}
+
+/** La fecha límite que hay ahora mismo, para poder devolverla tal cual. */
+export async function plazoActual(): Promise<Date | null> {
+  const filas = await conBase(
+    (sql) => sql<{ fecha_limite_rsvp: Date | null }[]>`
+      select fecha_limite_rsvp from public.configuracion_boda
+    `,
+  );
+  return filas[0]?.fecha_limite_rsvp ?? null;
+}
+
+export async function fijarPlazo(fecha: Date | null): Promise<void> {
+  await conBase(
+    (sql) => sql`
+      update public.configuracion_boda set fecha_limite_rsvp = ${fecha}
+    `,
+  );
+}
+
+/**
+ * Cierra el plazo, ejecuta el trabajo y lo deja como estaba.
+ *
+ * El ayer se calcula sobre el reloj de la base y no sobre el del test: si el
+ * contenedor va desfasado respecto al servidor, una fecha «de ayer» calculada
+ * aquí podría caer en el futuro de allí y el plazo no llegaría a cerrarse — un
+ * test que pasa sin haber probado nada.
+ */
+export async function conPlazoCerrado(trabajo: () => Promise<void>): Promise<void> {
+  const original = await plazoActual();
+
+  const [{ ayer }] = await conBase(
+    (sql) => sql<{ ayer: Date }[]>`select now() - interval '1 day' as ayer`,
+  );
+
+  await fijarPlazo(ayer);
+  try {
+    await trabajo();
+  } finally {
+    await fijarPlazo(original);
+  }
+}


### PR DESCRIPTION
## Qué cambia

Los dos mensajes que mandaban a «escribidnos» ahora dicen **a qué dirección**, y con el plazo cerrado se explica por qué ya no está el botón de cambiar la respuesta.

Closes #45
Closes #43

Los dos tickets pedían lo mismo con otras palabras —«mensaje claro **y a quién escribir**», «al cerrarse el plazo se explica a quién escribir»— y ninguna de las dos pantallas daba una dirección. El correo sale de `configuracion_boda`, que es el mismo del pie de la web pública, así que enseñarlo no cuenta nada que no se supiera; si no hay correo configurado no se pinta la línea, que es mejor que un «escribidnos a» seguido de un hueco.

También se explica por qué desaparece el botón de editar cuando pasa la fecha. Un botón que se esfuma sin decir nada se lee como una avería, y el siguiente paso de quien lo ve es justo el WhatsApp que BODA-56 quería evitar.

## Cómo probarlo en el preview

1. Abrir `/rsvp/loquesea` (un token inventado): dice que el enlace no vale y debajo ofrece el correo como enlace `mailto:`. No aparece ningún dato de ningún invitado.
2. Con una invitación real, contestar y llegar a la pantalla de gracias: sale el botón de cambiar la respuesta.
3. Poner `fecha_limite_rsvp` en el pasado y recargar el mismo enlace: se sigue viendo lo contestado, el botón ya no está, y en su lugar hay la explicación y el correo.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: el correo sale de `configuracion_boda`, los textos de `content/copy.es.json`
- [x] Test E2E incluido: camino feliz **y** al menos un caso de error
- [ ] CI verde entero: typecheck, lint, stylelint, formato, unitarios, migraciones y E2E — en local pasa todo (164 unitarios, 120 E2E de escritorio); pendiente de la ejecución en CI
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: la dirección es un enlace `mailto:` real, alcanzable por teclado y con foco visible
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview — no puedo: `vercel.app` está bloqueado por la política de salida de este contenedor

### Sobre los tests

**BODA-58** — Un token revocado y uno inventado devuelven el mismo estado y el mismo HTML, comparado entero y no sólo el rótulo visible. Hoy se cumple por construcción: la base guarda la huella y no el token, así que de uno revocado no queda ni rastro que pudiera delatarlo. El test está para que siga siendo así — el día que alguien añada una tabla de tokens retirados para dar un mensaje más amable, se pondrá rojo y explicará por qué eso permitiría adivinar tokens probando.

**BODA-56** — Editar cambia la respuesta y la anterior queda en el historial, que es lo único que contesta «¿desde cuándo?» cuando cambia un número que ya se le había dado al catering. Y para el plazo cerrado no se comprueba el botón: se llama a `registrar_confirmacion()` **como `anon`**, saltándose la pantalla entera, porque lo que cierra la puerta es el trigger de la base y no la interfaz.

Se añade `tests/e2e/utiles/plazo.ts` con un `finally` que devuelve la fecha original pase lo que pase: es estado global, y un test que falla a media no puede dejar la boda con el plazo cerrado para los demás.

## Base de datos

- [x] No la toca
- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [x] No hace falta — el §5 ya describe `fecha_limite_rsvp` y el contrato de «cero filas es un enlace que no vale»
- [ ] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_