### PR TITLE
feat(invitados): importar la lista desde un CSV y repartirla por WhatsApp

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -430,7 +430,8 @@
       "si": "Sí",
       "no": "No",
       "pendienteRespuesta": "Sin contestar",
-      "nombreFichero": "invitados-{fecha}.csv"
+      "nombreFichero": "invitados-{fecha}.csv",
+      "avisoImportados": "Importados. Ya están en la lista."
     },
     "mensajes": {
       "titulo": "Lo que escriben los invitados",
@@ -458,6 +459,54 @@
       "cancionMostrada": "Canción devuelta a la web.",
       "errorSinPermiso": "Sólo un editor puede moderar la playlist o marcar mensajes.",
       "errorGuardar": "No hemos podido guardar. Inténtalo de nuevo."
+    },
+    "importar": {
+      "titulo": "Importar invitados",
+      "descripcion": "Subid la hoja de cálculo tal cual. Antes de dar de alta a nadie se enseña qué va a entrar, y si hay una fila mal no se importa ninguna.",
+      "enlaceDesdeLista": "Importar desde CSV",
+      "volver": "Volver a las invitaciones",
+      "fichero": "Fichero CSV",
+      "ficheroAyuda": "Exportado de Excel, de Numbers o de Google Sheets. Da igual el separador y da igual la codificación.",
+      "analizar": "Ver qué se va a importar",
+      "plantilla": "Descargar plantilla de ejemplo",
+      "plantillaAyuda": "Una hoja con las columnas puestas y una fila de muestra, por si es más cómodo empezar de ahí.",
+      "nombreFicheroPlantilla": "plantilla-invitados.csv",
+      "columnasEsperadas": "Columnas",
+      "columnasAyuda": "Hacen falta «Grupo» y «Nombre». «Apellidos», «Lado» y «Niño» son opcionales. El orden no importa y las columnas que no se entiendan se ignoran.",
+      "columna": {
+        "grupo": "Grupo",
+        "lado": "Lado",
+        "nombre": "Nombre",
+        "apellidos": "Apellidos",
+        "nino": "Niño"
+      },
+      "ignoradas": "Estas columnas no se entienden y se van a ignorar: {columnas}.",
+      "previaTitulo": "Esto es lo que se va a dar de alta",
+      "previaResumen": "{personas} personas en {grupos} invitaciones.",
+      "previaResumenUna": "1 persona en 1 invitación.",
+      "grupoNuevo": "invitación nueva",
+      "grupoExistente": "ya existía",
+      "confirmar": "Importar",
+      "cancelar": "Cancelar",
+      "erroresTitulo": "Hay {cuantos} filas con problemas",
+      "erroresTituloUna": "Hay una fila con problemas",
+      "erroresAyuda": "No se ha importado nada. Arregladlas en la hoja y volved a subirla: media importación es peor que ninguna.",
+      "errorLinea": "Fila {linea}",
+      "errorVacio": "El fichero está vacío.",
+      "errorFaltaColumna": "Falta la columna {columnas}.",
+      "errorDemasiadas": "El fichero trae {traidas} filas y el tope son {tope}. ¿Seguro que es la lista de invitados?",
+      "errorSinGrupo": "Falta el grupo: hay que decir de qué invitación es esta persona.",
+      "errorSinNombre": "Falta el nombre.",
+      "errorLado": "«{valor}» no es un lado. Escribid novia, novio o ambos.",
+      "errorDuplicado": "{persona} ya está en «{grupo}».",
+      "errorSinFichero": "No habéis elegido ningún fichero.",
+      "errorNadaQueImportar": "No hay ninguna fila que dar de alta.",
+      "errorImportando": "No se ha podido importar. No se ha dado de alta a nadie.",
+      "importados": "Importados: {personas} personas en {grupos} invitaciones.",
+      "sinJavascript": "Esta pantalla necesita JavaScript para enseñaros qué se va a importar antes de dar de alta a nadie. Si no podéis activarlo, se pueden añadir personas una a una desde la ficha de cada invitación.",
+      "muestraGrupo": "Familia Zubeldía",
+      "muestraNombre": "Ainhoa",
+      "muestraApellidos": "Zubeldía Gorroño"
     }
   }
 }

--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -431,7 +431,16 @@
       "no": "No",
       "pendienteRespuesta": "Sin contestar",
       "nombreFichero": "invitados-{fecha}.csv",
-      "avisoImportados": "Importados. Ya están en la lista."
+      "avisoImportados": "Importados. Ya están en la lista.",
+      "repartirTitulo": "Mandar la invitación",
+      "repartirAyuda": "Se abre WhatsApp con el mensaje escrito y el enlace de ESTA invitación dentro. Podéis retocar el texto antes.",
+      "repartirMensaje": "Mensaje",
+      "repartirBoton": "Abrir WhatsApp",
+      "repartirPlantilla": "¡Nos casamos! Aquí tenéis toda la información y el enlace para confirmar: {enlace}",
+      "repartirEnviadaEn": "Invitación mandada el {fecha}.",
+      "repartirNunca": "Todavía no se ha mandado.",
+      "repartirRecordadaEn": "Último recordatorio: {fecha}.",
+      "repartirSoloConEnlace": "Para mandar la invitación hace falta un enlace en claro, y sólo se enseña en el momento de emitirlo. Emitid uno nuevo y se manda desde aquí mismo."
     },
     "mensajes": {
       "titulo": "Lo que escriben los invitados",

--- a/docs/PLAN-MAESTRO.md
+++ b/docs/PLAN-MAESTRO.md
@@ -265,6 +265,7 @@ Sobre `grupos_invitacion`, `invitados` y `confirmaciones`, `anon` **no tiene nad
 - **`sugerir_cancion(token, texto)`** → añade a la playlist, con tope de diez por grupo.
 - **`datos_para_regalos()`** → el IBAN y su titular, o cero filas. Es la única puerta por la que sale un dato de `configuracion_privada`, y sólo se abre con la sección `regalos` visible.
 - **`crear_grupo_invitacion(...)`** y **`rotar_token_invitacion(grupo)`** → del panel, devuelven el token en claro una sola vez.
+- **`importar_invitados(filas)`** → da de alta en bloque la gente de un CSV, en **una** transacción: o entran todas o no entra ninguna. Reutiliza el grupo cuando ya existe uno con ese nombre, porque un CSV trae una fila por persona y una invitación son varias. No emite enlaces: importar da de alta gente, no reparte invitaciones.
 
 El plazo lo aplica un trigger contra `now()`, nunca contra una fecha enviada por el cliente. El cupo de intentos lo aplica **`exigir_cupo_rsvp()`** por origen.
 

--- a/src/app/panel/invitados/[id]/page.tsx
+++ b/src/app/panel/invitados/[id]/page.tsx
@@ -16,7 +16,7 @@ import { t } from "@/lib/copy";
 import { accesoActual } from "@/lib/sesion";
 import { urlDelSitio } from "@/lib/url-sitio";
 
-import { anadirPersona, emitirEnlace, quitarPersona } from "../acciones";
+import { anadirPersona, emitirEnlace, quitarPersona, repartirPorWhatsApp } from "../acciones";
 import { AvisoEstado } from "../aviso";
 
 /**
@@ -121,6 +121,78 @@ export default async function PaginaInvitacion({ params, searchParams }: Paramet
             aria-label={t("panel.invitados.copiarEnlace")}
             className="mt-pila min-h-campo w-full rounded-campo border border-borde bg-superficie px-interno font-codigo text-pequeno text-tinta"
           />
+
+          {/*
+            BODA-110 · Y desde aquí mismo se manda.
+
+            Va DENTRO del bloque del enlace, y no en una sección aparte, porque
+            depende de lo mismo: el token en claro sólo existe en esta pantalla
+            y sólo ahora. Ponerlo abajo, separado, invitaría a pulsarlo cuando
+            ya no hay enlace que mandar.
+
+            El texto es un `<textarea>` y no una cadena fija: el mensaje que se
+            le manda a una tía abuela no es el que se le manda a un amigo, y
+            retocarlo antes de enviar es el criterio del ticket. Funciona sin
+            JavaScript — es un formulario que va a una acción de servidor y de
+            ahí a WhatsApp.
+          */}
+          {puedeEditar ? (
+            <form action={repartirPorWhatsApp} className="mt-elemento grid gap-interno">
+              <input type="hidden" name="grupo_id" value={grupo.id} />
+              {grupo.invitacionEnviadaEn ? (
+                <input type="hidden" name="recordatorio" value="1" />
+              ) : null}
+
+              <div className="grid gap-interno-compacto">
+                <label
+                  htmlFor="mensaje-whatsapp"
+                  className="text-etiqueta uppercase tracking-etiqueta text-tinta-suave"
+                >
+                  {t("panel.invitados.repartirMensaje")}
+                </label>
+                <textarea
+                  id="mensaje-whatsapp"
+                  name="mensaje"
+                  rows={3}
+                  required
+                  defaultValue={t("panel.invitados.repartirPlantilla", { enlace })}
+                  className="w-full rounded-campo border border-borde bg-superficie p-interno text-pequeno text-tinta"
+                />
+                <p className="text-pequeno text-tinta-tenue">
+                  {t("panel.invitados.repartirAyuda")}
+                </p>
+              </div>
+
+              <div>
+                <Boton type="submit">{t("panel.invitados.repartirBoton")}</Boton>
+              </div>
+            </form>
+          ) : null}
+        </section>
+      ) : null}
+
+      {/*
+        Y si no hay enlace en claro, se dice por qué no se puede mandar. Un
+        hueco donde debería estar el botón se lee como una avería.
+      */}
+      {!enlace && puedeEditar ? (
+        <section className="mt-elemento max-w-texto">
+          <Titulo3 como="h2">{t("panel.invitados.repartirTitulo")}</Titulo3>
+          <Cuerpo className="mt-pila text-pequeno text-tinta-suave">
+            {grupo.invitacionEnviadaEn
+              ? t("panel.invitados.repartirEnviadaEn", {
+                  fecha: formatoFecha.format(grupo.invitacionEnviadaEn),
+                })
+              : t("panel.invitados.repartirNunca")}
+            {grupo.recordatorioEnviadoEn
+              ? ` ${t("panel.invitados.repartirRecordadaEn", {
+                  fecha: formatoFecha.format(grupo.recordatorioEnviadoEn),
+                })}`
+              : ""}
+          </Cuerpo>
+          <Cuerpo className="mt-pila text-pequeno text-tinta-tenue">
+            {t("panel.invitados.repartirSoloConEnlace")}
+          </Cuerpo>
         </section>
       ) : null}
 

--- a/src/app/panel/invitados/acciones.ts
+++ b/src/app/panel/invitados/acciones.ts
@@ -197,3 +197,56 @@ export async function quitarPersona(datos: FormData): Promise<void> {
   revalidatePath(`${RUTA_INVITADOS}/${grupoId}`);
   volver("persona-quitada", grupoId);
 }
+
+/**
+ * BODA-110 · REPARTIR LA INVITACIÓN POR WHATSAPP
+ *
+ * Marca que se ha mandado y lleva a WhatsApp con el mensaje puesto. Las dos
+ * cosas en el mismo paso porque son el mismo acto: si fueran dos botones, el
+ * segundo se olvidaría y la lista de «a quién le falta» dejaría de valer justo
+ * cuando más falta hace.
+ *
+ * EL ENLACE VIENE DEL FORMULARIO Y NO SE BUSCA EN LA BASE, y no es un atajo: la
+ * base guarda la HUELLA del token, no el token. El texto en claro sólo existe
+ * en la pantalla que acaba de emitirlo, así que o se manda desde ahí o hay que
+ * emitir uno nuevo. Es incómodo a propósito — es lo que hace que un enlace
+ * filtrado no se pueda recuperar de la base ni por quien entra al panel.
+ *
+ * POR ESO NO SE PUEDE MANDAR EL ENLACE DE OTRO GRUPO: el que viaja es el que
+ * pintó esta ficha, y al cambiar de grupo la URL pierde el `?token=` y el
+ * formulario desaparece. No hay estado que arrastrar de una ficha a la
+ * siguiente.
+ */
+export async function repartirPorWhatsApp(datos: FormData): Promise<void> {
+  const grupoId = texto(datos, "grupo_id");
+  const mensaje = texto(datos, "mensaje");
+  const esRecordatorio = datos.get("recordatorio") !== null;
+
+  if (!grupoId) volver("no-existe");
+  if (mensaje === "") volver("error", grupoId);
+
+  const supabase = await cliente();
+  const { error } = await supabase.rpc("marcar_invitacion_repartida", {
+    p_grupo_id: grupoId,
+    p_recordatorio: esRecordatorio,
+  });
+
+  if (error) {
+    if (error.message.includes("RSV06")) volver("sin-permiso", grupoId);
+    if (error.message.includes("RSV01")) volver("no-existe");
+    console.error("No se pudo anotar el reparto:", error);
+    volver("error", grupoId);
+  }
+
+  revalidatePath(`${RUTA_INVITADOS}/${grupoId}`);
+
+  /*
+    A WhatsApp, con el mensaje ya escrito.
+
+    `wa.me` sin número abre el selector de contacto, que es lo que hace falta:
+    los teléfonos de los invitados no están en la base —nadie los ha metido— y
+    quien reparte los tiene en su agenda. Pedirlos sólo para esto sería recoger
+    doscientos datos personales para ahorrarse un toque en la pantalla.
+  */
+  redirect(`https://wa.me/?text=${encodeURIComponent(mensaje)}`);
+}

--- a/src/app/panel/invitados/aviso.tsx
+++ b/src/app/panel/invitados/aviso.tsx
@@ -14,6 +14,7 @@ import { t, type ClaveCopy } from "@/lib/copy";
 
 const AVISOS: Record<string, { clave: ClaveCopy; error: boolean }> = {
   creada: { clave: "panel.invitados.creada", error: false },
+  importados: { clave: "panel.invitados.avisoImportados", error: false },
   "enlace-emitido": { clave: "panel.invitados.enlaceEmitido", error: false },
   "persona-anadida": { clave: "panel.invitados.personaAnadida", error: false },
   "persona-quitada": { clave: "panel.invitados.personaQuitada", error: false },

--- a/src/app/panel/invitados/importar/acciones.ts
+++ b/src/app/panel/invitados/importar/acciones.ts
@@ -6,14 +6,11 @@ import { redirect } from "next/navigation";
 import { RUTA_ACCESO, RUTA_INVITADOS } from "@/config/constants";
 import { obtenerGruposConGente } from "@/lib/bbdd/invitados";
 import { decodificar } from "@/lib/csv";
-import {
-  clavePersona,
-  leerImportacion,
-  type ErrorDeFila,
-  type FilaImportada,
-} from "@/lib/importacion-invitados";
+import { clavePersona, leerImportacion, type FilaImportada } from "@/lib/importacion-invitados";
 import { t } from "@/lib/copy";
 import { clienteServidor, hayAutenticacion } from "@/lib/supabase/servidor";
+
+import { ESTADO_INICIAL, type EstadoImportacion } from "./estado";
 
 /**
  * BODA-53 · IMPORTAR INVITADOS, EN DOS PASOS
@@ -29,29 +26,6 @@ import { clienteServidor, hayAutenticacion } from "@/lib/supabase/servidor";
  * no podría cumplir el criterio del ticket —o entran todas o ninguna— porque
  * cada llamada sería su propia transacción.
  */
-
-export interface EstadoImportacion {
-  /** Qué pantalla toca: el formulario de subida o la vista previa. */
-  fase: "subir" | "previa";
-  filas: FilaImportada[];
-  errores: ErrorDeFila[];
-  columnasIgnoradas: string[];
-  /** Invitaciones que se van a crear, para poder decirlo antes de crearlas. */
-  gruposNuevos: string[];
-  /** El CSV ya decodificado, que viaja al paso de confirmar. */
-  contenido: string;
-  /** Un fallo que no es de ninguna fila en concreto. */
-  aviso?: string;
-}
-
-export const ESTADO_INICIAL: EstadoImportacion = {
-  fase: "subir",
-  filas: [],
-  errores: [],
-  columnasIgnoradas: [],
-  gruposNuevos: [],
-  contenido: "",
-};
 
 async function cliente() {
   if (!hayAutenticacion) redirect(RUTA_ACCESO);

--- a/src/app/panel/invitados/importar/acciones.ts
+++ b/src/app/panel/invitados/importar/acciones.ts
@@ -1,0 +1,196 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { RUTA_ACCESO, RUTA_INVITADOS } from "@/config/constants";
+import { obtenerGruposConGente } from "@/lib/bbdd/invitados";
+import { decodificar } from "@/lib/csv";
+import {
+  clavePersona,
+  leerImportacion,
+  type ErrorDeFila,
+  type FilaImportada,
+} from "@/lib/importacion-invitados";
+import { t } from "@/lib/copy";
+import { clienteServidor, hayAutenticacion } from "@/lib/supabase/servidor";
+
+/**
+ * BODA-53 · IMPORTAR INVITADOS, EN DOS PASOS
+ *
+ * Primero se mira y luego se escribe, y las dos cosas usan **el mismo**
+ * `leerImportacion()`. Que sea el mismo no es economía de código: es lo que
+ * hace que la vista previa sea de fiar. Con dos caminos distintos —uno para
+ * enseñar y otro para guardar— la pantalla acabaría prometiendo una cosa y la
+ * base haciendo otra, y el fallo sólo se vería con los invitados ya dentro.
+ *
+ * LA ESCRITURA ES UNA SOLA LLAMADA. `importar_invitados()` mete las doscientas
+ * filas en una transacción; aquí no hay bucle. Un bucle de doscientas llamadas
+ * no podría cumplir el criterio del ticket —o entran todas o ninguna— porque
+ * cada llamada sería su propia transacción.
+ */
+
+export interface EstadoImportacion {
+  /** Qué pantalla toca: el formulario de subida o la vista previa. */
+  fase: "subir" | "previa";
+  filas: FilaImportada[];
+  errores: ErrorDeFila[];
+  columnasIgnoradas: string[];
+  /** Invitaciones que se van a crear, para poder decirlo antes de crearlas. */
+  gruposNuevos: string[];
+  /** El CSV ya decodificado, que viaja al paso de confirmar. */
+  contenido: string;
+  /** Un fallo que no es de ninguna fila en concreto. */
+  aviso?: string;
+}
+
+export const ESTADO_INICIAL: EstadoImportacion = {
+  fase: "subir",
+  filas: [],
+  errores: [],
+  columnasIgnoradas: [],
+  gruposNuevos: [],
+  contenido: "",
+};
+
+async function cliente() {
+  if (!hayAutenticacion) redirect(RUTA_ACCESO);
+  return clienteServidor();
+}
+
+/**
+ * Todo lo que ya está dado de alta, en forma de clave de duplicado.
+ *
+ * Se lee con la sesión de quien importa, así que RLS decide qué ve. Si no
+ * pudiera ver a nadie, no detectaría duplicados — pero tampoco podría importar,
+ * porque la función exige `puede_editar()`.
+ */
+async function personasExistentes(): Promise<Set<string>> {
+  const grupos = await obtenerGruposConGente();
+  const claves = new Set<string>();
+  for (const grupo of grupos) {
+    for (const persona of grupo.gente) {
+      claves.add(clavePersona(grupo.nombre, persona.nombre, persona.apellidos));
+    }
+  }
+  return claves;
+}
+
+/** Los nombres de grupo del fichero que todavía no existen en la base. */
+function gruposPorCrear(filas: FilaImportada[], existentes: string[]): string[] {
+  const yaHay = new Set(existentes.map((nombre) => nombre.trim().toLowerCase()));
+  const nuevos: string[] = [];
+  for (const fila of filas) {
+    const clave = fila.grupo.trim().toLowerCase();
+    if (!yaHay.has(clave)) {
+      yaHay.add(clave);
+      nuevos.push(fila.grupo);
+    }
+  }
+  return nuevos;
+}
+
+/**
+ * PASO 1 · Leer el fichero y enseñar qué saldría de él.
+ *
+ * No escribe nada. Devuelve además el contenido ya decodificado para que el
+ * paso de confirmar no tenga que volver a subir el fichero: lo que se confirma
+ * es exactamente lo que se ha visto, y no un segundo fichero que a lo mejor no
+ * es el mismo.
+ */
+export async function analizarFichero(
+  _previo: EstadoImportacion,
+  datos: FormData,
+): Promise<EstadoImportacion> {
+  const fichero = datos.get("fichero");
+
+  if (!(fichero instanceof File) || fichero.size === 0) {
+    return { ...ESTADO_INICIAL, aviso: t("panel.importar.errorSinFichero") };
+  }
+
+  const contenido = decodificar(await fichero.arrayBuffer());
+
+  const grupos = await obtenerGruposConGente();
+  const existentes = new Set<string>();
+  for (const grupo of grupos) {
+    for (const persona of grupo.gente) {
+      existentes.add(clavePersona(grupo.nombre, persona.nombre, persona.apellidos));
+    }
+  }
+
+  const lectura = leerImportacion(contenido, existentes);
+
+  return {
+    fase: "previa",
+    filas: lectura.filas,
+    errores: lectura.errores,
+    columnasIgnoradas: lectura.columnasIgnoradas,
+    gruposNuevos: gruposPorCrear(
+      lectura.filas,
+      grupos.map((grupo) => grupo.nombre),
+    ),
+    contenido,
+  };
+}
+
+/**
+ * PASO 2 · Darlos de alta.
+ *
+ * Se vuelve a validar contra la base antes de escribir, y no por desconfiar de
+ * la pantalla: entre mirar la vista previa y pulsar el botón puede haber pasado
+ * cualquier cosa —la otra familia importando su parte, alguien dando de alta a
+ * mano—. La comprobación definitiva está dentro de la función, donde nadie
+ * puede colarse en medio; ésta es para poder contarlo en castellano.
+ */
+export async function importar(
+  _previo: EstadoImportacion,
+  datos: FormData,
+): Promise<EstadoImportacion> {
+  const contenido = String(datos.get("contenido") ?? "");
+  if (contenido.trim() === "") {
+    return { ...ESTADO_INICIAL, aviso: t("panel.importar.errorSinFichero") };
+  }
+
+  const lectura = leerImportacion(contenido, await personasExistentes());
+
+  // NADA A MEDIAS: si sobrevivió un error, no se escribe una sola fila.
+  if (lectura.errores.length > 0) {
+    const grupos = await obtenerGruposConGente();
+    return {
+      fase: "previa",
+      filas: lectura.filas,
+      errores: lectura.errores,
+      columnasIgnoradas: lectura.columnasIgnoradas,
+      gruposNuevos: gruposPorCrear(
+        lectura.filas,
+        grupos.map((grupo) => grupo.nombre),
+      ),
+      contenido,
+    };
+  }
+
+  if (lectura.filas.length === 0) {
+    return { ...ESTADO_INICIAL, aviso: t("panel.importar.errorNadaQueImportar") };
+  }
+
+  const supabase = await cliente();
+  const { error } = await supabase.rpc("importar_invitados", { p_filas: lectura.filas });
+
+  if (error) {
+    console.error("No se pudo importar:", error);
+    return {
+      fase: "previa",
+      filas: lectura.filas,
+      errores: [],
+      columnasIgnoradas: lectura.columnasIgnoradas,
+      gruposNuevos: [],
+      contenido,
+      aviso: error.message.includes("RSV06")
+        ? t("panel.invitados.errorSinPermiso")
+        : t("panel.importar.errorImportando"),
+    };
+  }
+
+  revalidatePath(RUTA_INVITADOS);
+  redirect(`${RUTA_INVITADOS}?estado=importados`);
+}

--- a/src/app/panel/invitados/importar/estado.ts
+++ b/src/app/panel/invitados/importar/estado.ts
@@ -1,0 +1,34 @@
+import type { ErrorDeFila, FilaImportada } from "@/lib/importacion-invitados";
+
+/**
+ * EL ESTADO QUE COMPARTEN LOS DOS PASOS DE LA IMPORTACIÓN
+ *
+ * Vive en su propio fichero y no junto a las acciones por una regla del
+ * framework que no perdona: un módulo `"use server"` **sólo puede exportar
+ * funciones asíncronas**. Un tipo o una constante ahí dentro compilan sin
+ * quejarse y luego revientan al abrir la página, que es la peor forma de
+ * enterarse — pasó, y lo cazó el trabajo de CI que levanta Supabase.
+ */
+
+export interface EstadoImportacion {
+  /** Qué pantalla toca: el formulario de subida o la vista previa. */
+  fase: "subir" | "previa";
+  filas: FilaImportada[];
+  errores: ErrorDeFila[];
+  columnasIgnoradas: string[];
+  /** Invitaciones que se van a crear, para poder decirlo antes de crearlas. */
+  gruposNuevos: string[];
+  /** El CSV ya decodificado, que viaja al paso de confirmar. */
+  contenido: string;
+  /** Un fallo que no es de ninguna fila en concreto. */
+  aviso?: string;
+}
+
+export const ESTADO_INICIAL: EstadoImportacion = {
+  fase: "subir",
+  filas: [],
+  errores: [],
+  columnasIgnoradas: [],
+  gruposNuevos: [],
+  contenido: "",
+};

--- a/src/app/panel/invitados/importar/formulario.tsx
+++ b/src/app/panel/invitados/importar/formulario.tsx
@@ -7,7 +7,8 @@ import { Cuerpo, Etiqueta, Titulo3 } from "@/components/ui/tipografia";
 import { RUTA_INVITADOS } from "@/config/constants";
 import { t } from "@/lib/copy";
 
-import { analizarFichero, importar, ESTADO_INICIAL } from "./acciones";
+import { analizarFichero, importar } from "./acciones";
+import { ESTADO_INICIAL } from "./estado";
 
 /**
  * BODA-53 · SUBIR, MIRAR, IMPORTAR

--- a/src/app/panel/invitados/importar/formulario.tsx
+++ b/src/app/panel/invitados/importar/formulario.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { Boton, BotonEnlace } from "@/components/ui/boton";
+import { Cuerpo, Etiqueta, Titulo3 } from "@/components/ui/tipografia";
+import { RUTA_INVITADOS } from "@/config/constants";
+import { t } from "@/lib/copy";
+
+import { analizarFichero, importar, ESTADO_INICIAL } from "./acciones";
+
+/**
+ * BODA-53 · SUBIR, MIRAR, IMPORTAR
+ *
+ * Dos pasos con el mismo estado: se sube un fichero, se enseña qué saldría de
+ * él, y sólo entonces aparece el botón de dar de alta. El botón NO aparece si
+ * hay una sola fila con problemas — que es el criterio del ticket hecho
+ * interfaz: no hay forma de importar media lista aunque se quiera.
+ *
+ * POR QUÉ ESTA PANTALLA SÍ NECESITA JAVASCRIPT, Y EL RSVP NO.
+ *
+ * La vista previa es una respuesta del servidor que hay que enseñar sin haber
+ * escrito nada todavía, y eso son dos pasos que comparten un estado que no
+ * cabe en una URL. El RSVP no puede permitírselo: lo abre un invitado desde
+ * WhatsApp, en un móvil prestado, y por eso allí cada paso es una navegación
+ * completa. Aquí entran dos personas desde su portátil, con sesión iniciada.
+ *
+ * Aun así no se deja a nadie mirando una pantalla muerta: sin JavaScript, el
+ * `<noscript>` dice qué pasa y ofrece la otra vía, que existe y funciona.
+ */
+/** «1 persona en 1 invitación» y no «1 personas en 1 invitaciones». */
+function resumen(filas: { grupo: string }[]): string {
+  const grupos = new Set(filas.map((fila) => fila.grupo.toLowerCase())).size;
+  return filas.length === 1 && grupos === 1
+    ? t("panel.importar.previaResumenUna")
+    : t("panel.importar.previaResumen", { personas: filas.length, grupos });
+}
+
+export function FormularioImportacion() {
+  const [analisis, analizar, analizando] = useActionState(analizarFichero, ESTADO_INICIAL);
+  const [envio, enviar, enviando] = useActionState(importar, ESTADO_INICIAL);
+
+  // El resultado de importar manda sobre el del análisis: es el más reciente.
+  const estado = envio.fase === "previa" || envio.aviso ? envio : analisis;
+  const hayErrores = estado.errores.length > 0;
+
+  return (
+    <>
+      <noscript>
+        <p className="mt-elemento rounded-tarjeta border border-borde-marca bg-superficie-tenue p-interno text-pequeno text-tinta">
+          {t("panel.importar.sinJavascript")}
+        </p>
+      </noscript>
+
+      <form action={analizar} className="mt-bloque grid max-w-texto gap-interno">
+        <div className="grid gap-interno-compacto">
+          <label
+            htmlFor="fichero"
+            className="text-etiqueta uppercase tracking-etiqueta text-tinta-suave"
+          >
+            {t("panel.importar.fichero")}
+          </label>
+          <input
+            id="fichero"
+            name="fichero"
+            type="file"
+            accept=".csv,text/csv,text/plain"
+            required
+            className="min-h-campo w-full rounded-campo border border-borde bg-superficie px-interno py-linea text-pequeno text-tinta file:mr-interno file:rounded-boton file:border-0 file:bg-superficie-hundida file:px-interno file:py-linea file:text-etiqueta file:uppercase file:tracking-boton file:text-tinta-marca"
+          />
+          <p className="text-pequeno text-tinta-tenue">{t("panel.importar.ficheroAyuda")}</p>
+        </div>
+        <div>
+          <Boton type="submit" disabled={analizando}>
+            {t("panel.importar.analizar")}
+          </Boton>
+        </div>
+      </form>
+
+      {estado.aviso ? (
+        <p
+          role="alert"
+          className="mt-elemento rounded-campo bg-error-fondo p-interno text-pequeno text-error-tinta"
+        >
+          {estado.aviso}
+        </p>
+      ) : null}
+
+      {estado.columnasIgnoradas.length > 0 ? (
+        <Cuerpo className="mt-elemento max-w-texto text-pequeno text-tinta-tenue">
+          {t("panel.importar.ignoradas", { columnas: estado.columnasIgnoradas.join(", ") })}
+        </Cuerpo>
+      ) : null}
+
+      {/*
+        LOS ERRORES VAN PRIMERO Y CON SU NÚMERO DE FILA.
+
+        El número es el de la hoja de cálculo —la cabecera es la 1— para poder
+        abrirla, ir a esa fila y arreglarla sin contar líneas a mano.
+      */}
+      {hayErrores ? (
+        <section className="mt-bloque rounded-tarjeta border border-borde bg-error-fondo p-interno">
+          <Titulo3 como="h2">
+            {estado.errores.length === 1
+              ? t("panel.importar.erroresTituloUna")
+              : t("panel.importar.erroresTitulo", { cuantos: estado.errores.length })}
+          </Titulo3>
+          <Cuerpo className="mt-pila max-w-texto text-pequeno">
+            {t("panel.importar.erroresAyuda")}
+          </Cuerpo>
+          <ul className="mt-elemento grid gap-linea">
+            {estado.errores.map((error) => (
+              <li key={`${error.linea}-${error.motivo}`} className="text-pequeno text-tinta">
+                <span className="text-tinta-tenue tabular-nums">
+                  {t("panel.importar.errorLinea", { linea: error.linea })}
+                </span>{" "}
+                · {error.motivo}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {estado.fase === "previa" && estado.filas.length > 0 ? (
+        <section className="mt-bloque">
+          <Titulo3 como="h2">{t("panel.importar.previaTitulo")}</Titulo3>
+          <Cuerpo className="mt-pila max-w-texto">{resumen(estado.filas)}</Cuerpo>
+
+          <div className="mt-elemento overflow-x-auto">
+            <table className="w-full border-collapse text-pequeno">
+              <thead>
+                <tr className="border-b border-borde text-left">
+                  <th className="py-linea pr-interno font-normal text-tinta-tenue">
+                    {t("panel.importar.columna.grupo")}
+                  </th>
+                  <th className="py-linea pr-interno font-normal text-tinta-tenue">
+                    {t("panel.importar.columna.nombre")}
+                  </th>
+                  <th className="py-linea pr-interno font-normal text-tinta-tenue">
+                    {t("panel.importar.columna.lado")}
+                  </th>
+                  <th className="py-linea font-normal text-tinta-tenue">
+                    {t("panel.importar.columna.nino")}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {estado.filas.map((fila, indice) => (
+                  <tr
+                    key={`${fila.grupo}-${fila.nombre}-${indice}`}
+                    className="border-b border-borde"
+                  >
+                    <td className="py-linea pr-interno text-tinta">
+                      {fila.grupo}
+                      {estado.gruposNuevos.includes(fila.grupo) ? (
+                        <span className="ml-interno-compacto text-tinta-tenue">
+                          {t("panel.importar.grupoNuevo")}
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="py-linea pr-interno text-tinta">
+                      {[fila.nombre, fila.apellidos].filter(Boolean).join(" ")}
+                    </td>
+                    <td className="py-linea pr-interno text-tinta-suave">
+                      {t(`panel.invitados.lados.${fila.lado}` as "panel.invitados.lados.ambos")}
+                    </td>
+                    <td className="py-linea text-tinta-suave">
+                      {fila.nino ? t("panel.invitados.si") : t("panel.invitados.no")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/*
+            El botón sólo existe si no hay ni un error. No se deshabilita: se
+            quita. Un botón gris que no se sabe por qué no responde es peor que
+            no tenerlo, y la lista de arriba ya dice exactamente qué arreglar.
+          */}
+          {hayErrores ? (
+            <Etiqueta className="mt-elemento block">
+              {t("panel.importar.erroresAyuda")}
+            </Etiqueta>
+          ) : (
+            <form action={enviar} className="mt-elemento flex flex-wrap gap-interno">
+              <input type="hidden" name="contenido" value={estado.contenido} />
+              <Boton type="submit" disabled={enviando}>
+                {t("panel.importar.confirmar")}
+              </Boton>
+              <BotonEnlace href={RUTA_INVITADOS} jerarquia="terciario">
+                {t("panel.importar.cancelar")}
+              </BotonEnlace>
+            </form>
+          )}
+        </section>
+      ) : null}
+    </>
+  );
+}

--- a/src/app/panel/invitados/importar/page.tsx
+++ b/src/app/panel/invitados/importar/page.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { Cuerpo, Etiqueta, Titulo2, Titulo3 } from "@/components/ui/tipografia";
+import { RUTA_ACCESO, RUTA_INVITADOS } from "@/config/constants";
+import { t } from "@/lib/copy";
+import { accesoActual } from "@/lib/sesion";
+
+import { FormularioImportacion } from "./formulario";
+
+/**
+ * BODA-53 · IMPORTAR INVITADOS DESDE CSV
+ *
+ * La lista nace siempre en una hoja de cálculo que se pasan las dos familias.
+ * Teclear doscientos nombres en el formulario de uno en uno no es una opción, y
+ * el resultado de intentarlo es que falte gente.
+ *
+ * UN LECTOR NO IMPORTA. La protección de verdad es `puede_editar()` dentro de
+ * la función de la base; esto es no enseñar una pantalla que va a fallar.
+ */
+export const dynamic = "force-dynamic";
+
+export default async function PaginaImportar() {
+  const acceso = await accesoActual();
+  if (!acceso) redirect(RUTA_ACCESO);
+
+  if (acceso.rol === "lector") {
+    return (
+      <>
+        <Titulo2 como="h1">{t("panel.importar.titulo")}</Titulo2>
+        <Etiqueta className="mt-bloque block">{t("panel.invitados.errorSinPermiso")}</Etiqueta>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <header className="max-w-texto">
+        <Titulo2 como="h1">{t("panel.importar.titulo")}</Titulo2>
+        <Cuerpo className="mt-pila">{t("panel.importar.descripcion")}</Cuerpo>
+      </header>
+
+      <section className="mt-bloque max-w-texto rounded-tarjeta border border-borde p-interno">
+        <Titulo3 como="h2">{t("panel.importar.columnasEsperadas")}</Titulo3>
+        <Cuerpo className="mt-pila text-pequeno">{t("panel.importar.columnasAyuda")}</Cuerpo>
+        <Cuerpo className="mt-pila text-pequeno text-tinta-tenue">
+          {t("panel.importar.plantillaAyuda")}
+        </Cuerpo>
+        <p className="mt-elemento">
+          <a
+            href={`${RUTA_INVITADOS}/importar/plantilla`}
+            className="text-pequeno text-tinta-marca underline decoration-borde-fuerte underline-offset-4 transicion-color hover:decoration-borde-marca"
+          >
+            {t("panel.importar.plantilla")}
+          </a>
+        </p>
+      </section>
+
+      <FormularioImportacion />
+
+      <p className="mt-bloque">
+        <Link
+          href={RUTA_INVITADOS}
+          className="text-pequeno text-tinta-suave underline decoration-borde underline-offset-4 transicion-color hover:text-tinta"
+        >
+          {t("panel.importar.volver")}
+        </Link>
+      </p>
+    </>
+  );
+}

--- a/src/app/panel/invitados/importar/plantilla/route.ts
+++ b/src/app/panel/invitados/importar/plantilla/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { RUTA_ACCESO } from "@/config/constants";
+import { t } from "@/lib/copy";
+import { accesoActual } from "@/lib/sesion";
+
+/**
+ * BODA-53 · LA PLANTILLA DE EJEMPLO
+ *
+ * Una hoja con las columnas puestas y una fila de muestra. Es lo que evita la
+ * primera importación fallida: sin ella, quien rellena la hoja tiene que
+ * adivinar cómo se llaman las columnas y en qué orden van.
+ *
+ * SE GENERA, NO SE GUARDA EN `/public`. Los rótulos son los mismos que usa la
+ * pantalla y salen del mismo sitio, así que el día que uno cambie, la plantilla
+ * cambia con él. Un fichero estático se quedaría con los rótulos viejos y nadie
+ * se enteraría hasta que una importación fallara por una columna que ya no se
+ * llama así.
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET(peticion: NextRequest) {
+  const acceso = await accesoActual();
+  if (!acceso) return NextResponse.redirect(new URL(RUTA_ACCESO, peticion.url));
+
+  const columnas = [
+    t("panel.importar.columna.grupo"),
+    t("panel.importar.columna.nombre"),
+    t("panel.importar.columna.apellidos"),
+    t("panel.importar.columna.lado"),
+    t("panel.importar.columna.nino"),
+  ];
+
+  /*
+    La fila de muestra lleva acento y ñ a propósito: es la comprobación de que
+    la codificación sobrevive al viaje de ida y vuelta por Excel. Si alguien
+    abre la plantilla y ve «ZubeldÃ­a», el problema está en su Excel y no en su
+    lista, y es mucho mejor descubrirlo aquí que con doscientos apellidos rotos.
+  */
+  const muestra = [
+    t("panel.importar.muestraGrupo"),
+    t("panel.importar.muestraNombre"),
+    t("panel.importar.muestraApellidos"),
+    t("panel.invitados.lados.novia"),
+    t("panel.invitados.no"),
+  ];
+
+  const celda = (valor: string) => `"${valor.replaceAll('"', '""')}"`;
+  const csv = [columnas, muestra].map((fila) => fila.map(celda).join(";")).join("\r\n");
+
+  // El BOM y el `;`, por lo mismo que en la exportación: es lo que espera Excel
+  // en configuración regional española, y sin el BOM abre los acentos rotos.
+  return new NextResponse(`﻿${csv}`, {
+    headers: {
+      "content-type": "text/csv; charset=utf-8",
+      "content-disposition": `attachment; filename="${t("panel.importar.nombreFicheroPlantilla")}"`,
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/src/app/panel/invitados/page.tsx
+++ b/src/app/panel/invitados/page.tsx
@@ -240,6 +240,20 @@ export default async function PaginaInvitados({ searchParams }: Parametros) {
               <Boton type="submit">{t("panel.invitados.crear")}</Boton>
             </div>
           </form>
+
+          {/*
+            Y la otra vía, para cuando la lista ya existe en una hoja: teclear
+            doscientos nombres de uno en uno en el formulario de arriba no es
+            una opción, y el resultado de intentarlo es que falte gente.
+          */}
+          <Cuerpo className="mt-elemento max-w-texto text-pequeno text-tinta-tenue">
+            <Link
+              href={`${RUTA_INVITADOS}/importar`}
+              className="text-tinta-marca underline decoration-borde-fuerte underline-offset-4 transicion-color hover:decoration-borde-marca"
+            >
+              {t("panel.importar.enlaceDesdeLista")}
+            </Link>
+          </Cuerpo>
         </section>
       ) : (
         <Etiqueta className="mt-bloque">{t("panel.invitados.errorSinPermiso")}</Etiqueta>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -134,3 +134,14 @@ export const LONGITUD_MINIMA_NOMBRE = 2;
  * ponía lo mismo.
  */
 export const DURACION_AVISO_COPIADO = 2000;
+
+/**
+ * Cuántas filas se admiten en una importación de invitados.
+ *
+ * No es un límite técnico —la función de la base importa en una transacción y
+ * aguantaría muchas más— sino un cortafuegos: doscientas es de largo la boda
+ * más grande imaginable, así que un fichero con miles de filas no es la lista
+ * de invitados, es el CSV equivocado. Mejor decirlo antes de dar de alta a
+ * cinco mil desconocidos.
+ */
+export const MAXIMO_FILAS_IMPORTACION = 500;

--- a/src/lib/bbdd/invitados.ts
+++ b/src/lib/bbdd/invitados.ts
@@ -21,6 +21,9 @@ export interface GrupoInvitacion {
   lado: "novia" | "novio" | "ambos";
   maximoAcompanantes: number;
   tokenEmitidoEn: Date | null;
+  /** Cuándo se repartió la invitación, y cuándo se recordó por última vez. */
+  invitacionEnviadaEn: Date | null;
+  recordatorioEnviadoEn: Date | null;
   personas: number;
   confirmados: number;
   rechazados: number;
@@ -68,6 +71,8 @@ interface FilaGrupo {
   lado: string;
   maximo_acompanantes: number;
   token_emitido_en: string | null;
+  invitacion_enviada_en: string | null;
+  recordatorio_enviado_en: string | null;
   /** En la lista se piden menos columnas de cada persona que en la ficha. */
   invitados: Partial<FilaPersona>[];
 }
@@ -92,6 +97,7 @@ export async function obtenerGrupos(): Promise<GrupoInvitacion[]> {
     .from("grupos_invitacion")
     .select(
       `id, nombre, lado, maximo_acompanantes, token_emitido_en,
+       invitacion_enviada_en, recordatorio_enviado_en,
        invitados ( nombre, apellidos, confirmaciones ( estado, es_vigente ) )`,
     )
     .order("nombre");
@@ -108,6 +114,12 @@ export async function obtenerGrupos(): Promise<GrupoInvitacion[]> {
       lado: fila.lado as GrupoInvitacion["lado"],
       maximoAcompanantes: fila.maximo_acompanantes,
       tokenEmitidoEn: fila.token_emitido_en ? new Date(fila.token_emitido_en) : null,
+      invitacionEnviadaEn: fila.invitacion_enviada_en
+        ? new Date(fila.invitacion_enviada_en)
+        : null,
+      recordatorioEnviadoEn: fila.recordatorio_enviado_en
+        ? new Date(fila.recordatorio_enviado_en)
+        : null,
       personas: personas.length,
       confirmados: estados.filter((estado) => estado === "confirmado").length,
       rechazados: estados.filter((estado) => estado === "rechazado").length,
@@ -134,6 +146,7 @@ export async function obtenerGrupo(id: string): Promise<DetalleGrupo | null> {
     .from("grupos_invitacion")
     .select(
       `id, nombre, lado, maximo_acompanantes, token_emitido_en,
+       invitacion_enviada_en, recordatorio_enviado_en,
        invitados ( id, nombre, apellidos, es_nino, es_acompanante, tipo_menu, alergias,
                    confirmaciones ( estado, es_vigente ) )`,
     )
@@ -174,6 +187,12 @@ function componerGrupo(
     lado: fila.lado as GrupoInvitacion["lado"],
     maximoAcompanantes: fila.maximo_acompanantes,
     tokenEmitidoEn: fila.token_emitido_en ? new Date(fila.token_emitido_en) : null,
+    invitacionEnviadaEn: fila.invitacion_enviada_en
+      ? new Date(fila.invitacion_enviada_en)
+      : null,
+    recordatorioEnviadoEn: fila.recordatorio_enviado_en
+      ? new Date(fila.recordatorio_enviado_en)
+      : null,
     personas: gente.length,
     confirmados: gente.filter((persona) => persona.estado === "confirmado").length,
     rechazados: gente.filter((persona) => persona.estado === "rechazado").length,
@@ -200,6 +219,7 @@ export async function obtenerGruposConGente(): Promise<DetalleGrupo[]> {
     .from("grupos_invitacion")
     .select(
       `id, nombre, lado, maximo_acompanantes, token_emitido_en,
+       invitacion_enviada_en, recordatorio_enviado_en,
        invitados ( id, nombre, apellidos, es_nino, es_acompanante, tipo_menu, alergias,
                    confirmaciones ( estado, es_vigente ) )`,
     )

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,173 @@
+/**
+ * LEER UN CSV QUE VIENE DE EXCEL
+ *
+ * No se usa una librería porque el problema no es analizar CSV —eso son treinta
+ * líneas— sino las dos cosas que hace Excel y que ninguna librería adivina por
+ * ti: el separador y la codificación. Las dos están resueltas aquí, y las dos
+ * tienen test.
+ *
+ * Este módulo no sabe nada de invitados: entra texto o bytes y salen filas de
+ * cadenas. Quién es «nombre» y quién «apellidos» lo decide
+ * `lib/importacion-invitados.ts`.
+ */
+
+/** Los separadores que se prueban, en orden de probabilidad en España. */
+const SEPARADORES = [";", ",", "\t"] as const;
+
+/**
+ * Con qué está separado el fichero.
+ *
+ * NO SE PUEDE FIJAR EN `;` Y YA. Excel en configuración regional española
+ * exporta con punto y coma, porque la coma es el separador decimal; el mismo
+ * Excel en inglés, y cualquier herramienta que siga el estándar, exporta con
+ * coma. Un fichero llega de una familia y otro de la otra.
+ *
+ * Se elige mirando la primera línea: gana el separador que produce más
+ * columnas. Es una heurística, pero es la que acierta con los dos casos reales
+ * — y con un fichero de una sola columna da igual cuál se elija.
+ */
+export function detectarSeparador(texto: string): string {
+  const primera = texto.split(/\r?\n/, 1)[0] ?? "";
+
+  let mejor: string = SEPARADORES[0];
+  let columnas = 0;
+  for (const separador of SEPARADORES) {
+    const cuantas = analizarLinea(primera, separador).length;
+    if (cuantas > columnas) {
+      columnas = cuantas;
+      mejor = separador;
+    }
+  }
+  return mejor;
+}
+
+/**
+ * De bytes a texto, aguantando lo que suelte Excel.
+ *
+ * «Zubeldía» se rompe de las dos maneras posibles, así que hay que acertar:
+ * leer un fichero Latin-1 como UTF-8 da «ZubeldÃ­a», y al revés da un rombo con
+ * una interrogación. Ninguno de los dos se puede arreglar después.
+ *
+ * Se intenta UTF-8 en modo estricto: si los bytes no son UTF-8 válido, el
+ * decodificador LANZA en lugar de meter caracteres de reemplazo, y ese fallo es
+ * justo la señal que hace falta para caer a Windows-1252 —que es lo que Excel
+ * llama «Latin-1» y es un superconjunto suyo—. Sin `fatal: true` no habría
+ * fallo que detectar: saldría el texto roto y tan tranquilos.
+ *
+ * El BOM se quita si viene: es una marca de codificación, no un carácter del
+ * primer rótulo, y sin quitarlo la primera columna nunca casa con su nombre.
+ */
+export function decodificar(bytes: ArrayBuffer): string {
+  let texto: string;
+  try {
+    texto = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    texto = new TextDecoder("windows-1252").decode(bytes);
+  }
+  return texto.replace(/^﻿/, "");
+}
+
+/**
+ * Una línea, respetando las comillas.
+ *
+ * Dentro de comillas, el separador es un carácter más —«Zubeldía, Ainhoa» es
+ * UNA celda— y dos comillas seguidas son una comilla literal. Es el mismo
+ * formato que escribe la exportación de este panel, así que lo que sale se
+ * puede volver a meter.
+ */
+function analizarLinea(linea: string, separador: string): string[] {
+  const celdas: string[] = [];
+  let actual = "";
+  let entreComillas = false;
+
+  for (let i = 0; i < linea.length; i += 1) {
+    const caracter = linea[i];
+
+    if (entreComillas) {
+      if (caracter === '"') {
+        if (linea[i + 1] === '"') {
+          actual += '"';
+          i += 1;
+        } else {
+          entreComillas = false;
+        }
+      } else {
+        actual += caracter;
+      }
+      continue;
+    }
+
+    if (caracter === '"') {
+      entreComillas = true;
+    } else if (caracter === separador) {
+      celdas.push(actual);
+      actual = "";
+    } else {
+      actual += caracter;
+    }
+  }
+
+  celdas.push(actual);
+  return celdas;
+}
+
+/**
+ * El fichero entero en filas de celdas.
+ *
+ * Las líneas se parten a mano y no con `split("\n")` sobre todo el texto:
+ * una celda entrecomillada puede contener un salto de línea —un campo de
+ * alergias escrito en dos renglones— y partir por saltos lo rompería en dos
+ * filas inservibles.
+ *
+ * Las filas completamente vacías se descartan: una hoja de cálculo casi siempre
+ * termina con una línea en blanco, y no es una persona sin nombre.
+ */
+export function analizarCsv(texto: string, separador = detectarSeparador(texto)): string[][] {
+  const filas: string[][] = [];
+  let celdas: string[] = [];
+  let actual = "";
+  let entreComillas = false;
+
+  const cerrarFila = () => {
+    celdas.push(actual);
+    actual = "";
+    if (celdas.some((celda) => celda.trim() !== "")) filas.push(celdas);
+    celdas = [];
+  };
+
+  for (let i = 0; i < texto.length; i += 1) {
+    const caracter = texto[i];
+
+    if (entreComillas) {
+      if (caracter === '"') {
+        if (texto[i + 1] === '"') {
+          actual += '"';
+          i += 1;
+        } else {
+          entreComillas = false;
+        }
+      } else {
+        actual += caracter;
+      }
+      continue;
+    }
+
+    if (caracter === '"') {
+      entreComillas = true;
+    } else if (caracter === separador) {
+      celdas.push(actual);
+      actual = "";
+    } else if (caracter === "\n") {
+      cerrarFila();
+    } else if (caracter === "\r") {
+      // Se ignora: los finales de Windows son `\r\n` y el `\n` ya cierra.
+    } else {
+      actual += caracter;
+    }
+  }
+
+  // La última fila, si el fichero no termina en salto de línea.
+  if (actual !== "" || celdas.length > 0) cerrarFila();
+
+  return filas;
+}

--- a/src/lib/importacion-invitados.ts
+++ b/src/lib/importacion-invitados.ts
@@ -1,0 +1,222 @@
+import { LONGITUD_MINIMA_NOMBRE, MAXIMO_FILAS_IMPORTACION } from "@/config/constants";
+import { analizarCsv } from "@/lib/csv";
+import { t, type ClaveCopy } from "@/lib/copy";
+
+/**
+ * BODA-53 · DE UN CSV A UNA LISTA DE INVITADOS
+ *
+ * Lo que hace este módulo es decidir, fila a fila, si algo se puede dar de alta
+ * y por qué no. NO escribe en la base: se ejecuta igual para pintar la vista
+ * previa que para preparar el envío, y por eso la vista previa enseña
+ * exactamente lo que va a pasar en lugar de una aproximación.
+ *
+ * EL ERROR ES POR FILA Y BLOQUEA LA IMPORTACIÓN ENTERA. Es el criterio del
+ * ticket, y no es cautela de más: una importación a medias deja la lista con
+ * gente dentro y gente fuera, sin ninguna marca que distinga a quién faltó — y
+ * la única salida es repasar doscientos nombres a mano contra la hoja original.
+ * Todo o nada es más fácil de explicar y más fácil de arreglar.
+ */
+
+/** Las columnas que se entienden, con los nombres que puede traer cada una. */
+const COLUMNAS = {
+  grupo: ["grupo", "invitacion", "invitación", "familia"],
+  lado: ["lado", "parte"],
+  nombre: ["nombre"],
+  apellidos: ["apellidos", "apellido"],
+  nino: ["nino", "niño", "es nino", "es niño", "menor"],
+} as const;
+
+type Columna = keyof typeof COLUMNAS;
+
+const OBLIGATORIAS: Columna[] = ["grupo", "nombre"];
+
+const LADOS: Record<string, "novia" | "novio" | "ambos"> = {
+  novia: "novia",
+  novio: "novio",
+  ambos: "ambos",
+  "los dos": "ambos",
+};
+
+/** Lo afirmativo que puede escribir alguien en una hoja de cálculo. */
+const AFIRMATIVOS = new Set(["si", "sí", "s", "x", "true", "1", "verdadero"]);
+
+export interface FilaImportada {
+  grupo: string;
+  lado: "novia" | "novio" | "ambos";
+  nombre: string;
+  apellidos: string | null;
+  nino: boolean;
+}
+
+export interface ErrorDeFila {
+  /** Número de fila tal y como lo ve quien abre el fichero: la 1 es la cabecera. */
+  linea: number;
+  motivo: string;
+}
+
+export interface Lectura {
+  filas: FilaImportada[];
+  errores: ErrorDeFila[];
+  /** Rótulos que traía el fichero y no se entienden. Se ignoran, y se dice. */
+  columnasIgnoradas: string[];
+}
+
+/**
+ * Compara rótulos sin que un acento o una mayúscula rompan la importación.
+ * «Niño», «nino» y «NIÑO» son la misma columna, y quien rellena la hoja no
+ * tiene por qué saberlo.
+ */
+function normalizar(texto: string): string {
+  return texto
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "");
+}
+
+/** En qué posición viene cada columna, o `-1` si no viene. */
+function situarColumnas(cabecera: string[]): {
+  posiciones: Record<Columna, number>;
+  ignoradas: string[];
+} {
+  const posiciones = {} as Record<Columna, number>;
+  const usadas = new Set<number>();
+
+  for (const columna of Object.keys(COLUMNAS) as Columna[]) {
+    const alias = COLUMNAS[columna].map(normalizar);
+    posiciones[columna] = cabecera.findIndex((rotulo) => alias.includes(normalizar(rotulo)));
+    if (posiciones[columna] >= 0) usadas.add(posiciones[columna]);
+  }
+
+  const ignoradas = cabecera.filter(
+    (rotulo, indice) => !usadas.has(indice) && rotulo.trim() !== "",
+  );
+
+  return { posiciones, ignoradas };
+}
+
+/** Una clave única de persona, para cazar duplicados sin distinguir formas. */
+export function clavePersona(grupo: string, nombre: string, apellidos: string | null): string {
+  return [normalizar(grupo), normalizar(nombre), normalizar(apellidos ?? "")].join("|");
+}
+
+/**
+ * Lee el contenido de un CSV y devuelve qué se daría de alta y qué falla.
+ *
+ * `yaExisten` son las claves de la gente que ya está en la base. Se pasa desde
+ * fuera en lugar de consultarla aquí para que este módulo siga siendo una
+ * función pura: así se prueba entero sin base de datos, que es lo que permite
+ * tener test de los quince casos raros de un CSV.
+ */
+export function leerImportacion(
+  contenido: string,
+  yaExisten: Set<string> = new Set(),
+): Lectura {
+  const filas = analizarCsv(contenido);
+  const errores: ErrorDeFila[] = [];
+
+  if (filas.length === 0) {
+    return {
+      filas: [],
+      errores: [{ linea: 1, motivo: t("panel.importar.errorVacio") }],
+      columnasIgnoradas: [],
+    };
+  }
+
+  const [cabecera, ...cuerpo] = filas;
+  const { posiciones, ignoradas } = situarColumnas(cabecera);
+
+  const faltan = OBLIGATORIAS.filter((columna) => posiciones[columna] < 0);
+  if (faltan.length > 0) {
+    return {
+      filas: [],
+      errores: [
+        {
+          linea: 1,
+          motivo: t("panel.importar.errorFaltaColumna", {
+            columnas: faltan
+              .map((columna) => t(`panel.importar.columna.${columna}` as ClaveCopy))
+              .join(", "),
+          }),
+        },
+      ],
+      columnasIgnoradas: ignoradas,
+    };
+  }
+
+  if (cuerpo.length > MAXIMO_FILAS_IMPORTACION) {
+    return {
+      filas: [],
+      errores: [
+        {
+          linea: 1,
+          motivo: t("panel.importar.errorDemasiadas", {
+            tope: MAXIMO_FILAS_IMPORTACION,
+            traidas: cuerpo.length,
+          }),
+        },
+      ],
+      columnasIgnoradas: ignoradas,
+    };
+  }
+
+  const celda = (fila: string[], columna: Columna): string =>
+    posiciones[columna] >= 0 ? (fila[posiciones[columna]] ?? "").trim() : "";
+
+  const listas: FilaImportada[] = [];
+  // Los duplicados se miran contra lo que ya hay Y contra lo que lleva el
+  // propio fichero: una hoja compartida entre dos familias trae a la misma
+  // persona dos veces con muchísima naturalidad.
+  const vistas = new Set(yaExisten);
+
+  cuerpo.forEach((fila, indice) => {
+    // +2: la cabecera es la línea 1 y este índice empieza en cero. Quien abra
+    // el fichero para arreglarlo tiene que encontrar la fila donde se le dice.
+    const linea = indice + 2;
+
+    const grupo = celda(fila, "grupo");
+    const nombre = celda(fila, "nombre");
+    const apellidos = celda(fila, "apellidos") || null;
+
+    if (grupo === "") {
+      errores.push({ linea, motivo: t("panel.importar.errorSinGrupo") });
+      return;
+    }
+    if (nombre.length < LONGITUD_MINIMA_NOMBRE) {
+      errores.push({ linea, motivo: t("panel.importar.errorSinNombre") });
+      return;
+    }
+
+    const ladoBruto = normalizar(celda(fila, "lado"));
+    if (ladoBruto !== "" && !(ladoBruto in LADOS)) {
+      errores.push({
+        linea,
+        motivo: t("panel.importar.errorLado", { valor: celda(fila, "lado") }),
+      });
+      return;
+    }
+
+    const clave = clavePersona(grupo, nombre, apellidos);
+    if (vistas.has(clave)) {
+      errores.push({
+        linea,
+        motivo: t("panel.importar.errorDuplicado", {
+          persona: [nombre, apellidos].filter(Boolean).join(" "),
+          grupo,
+        }),
+      });
+      return;
+    }
+    vistas.add(clave);
+
+    listas.push({
+      grupo,
+      lado: ladoBruto === "" ? "ambos" : LADOS[ladoBruto],
+      nombre,
+      apellidos,
+      nino: AFIRMATIVOS.has(normalizar(celda(fila, "nino"))),
+    });
+  });
+
+  return { filas: listas, errores, columnasIgnoradas: ignoradas };
+}

--- a/supabase/migrations/20260810160000_importar_invitados.sql
+++ b/supabase/migrations/20260810160000_importar_invitados.sql
@@ -1,0 +1,131 @@
+-- ============================================================================
+-- BODA-53 · Importar invitados desde CSV
+--
+-- La lista de invitados nace siempre en una hoja de cálculo que se pasan las
+-- dos familias. Teclear doscientos nombres a mano en el panel no es una opción,
+-- y copiarlos de uno en uno es la mejor forma de que falte gente el día de la
+-- boda.
+--
+-- POR QUÉ ESTO ES UNA FUNCIÓN Y NO UN BUCLE EN EL SERVIDOR
+--
+-- El criterio del ticket es «no se importa nada hasta que se resuelven los
+-- errores: media importación es peor que ninguna». Un bucle de doscientas
+-- llamadas desde el servidor no puede cumplirlo: cada llamada es su propia
+-- transacción, así que un fallo en la fila ciento veinte deja ciento diecinueve
+-- personas dadas de alta y ninguna forma de saber cuáles. Y deshacerlo a mano
+-- es peor todavía, porque hay que distinguir a quién había ya de antes.
+--
+-- Dentro de una función es UNA transacción: o entran las doscientas o no entra
+-- ninguna, y lo garantiza PostgreSQL y no nuestro cuidado al escribir el bucle.
+--
+-- LOS GRUPOS SE REUTILIZAN POR NOMBRE. Un CSV trae una fila por persona, y las
+-- cuatro personas de «Familia Zubeldía» son UNA invitación. Si cada fila creara
+-- su grupo, importar sería fabricar doscientas invitaciones de una persona —y
+-- doscientos enlaces que mandar— en lugar de las treinta que de verdad hay.
+--
+-- SIN ENLACE. Los grupos entran con su huella aleatoria de siempre, que no
+-- corresponde a ningún token conocido: importar da de alta a la gente, no
+-- reparte invitaciones. El enlace lo emite quien organiza cuando va a mandarlo.
+--
+-- Rollback: supabase/migrations/rollback/20260810160000_importar_invitados.sql
+-- ============================================================================
+
+create or replace function public.importar_invitados(p_filas jsonb)
+returns table (grupos_creados integer, personas_creadas integer)
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_fila        jsonb;
+  v_indice      integer := 0;
+  v_grupo_id    uuid;
+  v_nombre_gr   text;
+  v_lado        public.lado_invitacion;
+  v_nombre      text;
+  v_apellidos   text;
+  v_nino        boolean;
+  v_grupos      integer := 0;
+  v_personas    integer := 0;
+begin
+  if not public.puede_editar() then
+    raise exception 'RSV06'
+      using errcode = 'insufficient_privilege',
+            hint    = 'Sólo un editor puede importar invitados.';
+  end if;
+
+  if jsonb_typeof(p_filas) is distinct from 'array' then
+    raise exception 'IMP01'
+      using errcode = 'invalid_parameter_value',
+            hint    = 'Se esperaba una lista de filas.';
+  end if;
+
+  for v_fila in select * from jsonb_array_elements(p_filas) loop
+    v_indice := v_indice + 1;
+
+    v_nombre_gr := btrim(coalesce(v_fila ->> 'grupo', ''));
+    v_nombre    := btrim(coalesce(v_fila ->> 'nombre', ''));
+    v_apellidos := nullif(btrim(coalesce(v_fila ->> 'apellidos', '')), '');
+    v_nino      := coalesce((v_fila ->> 'nino')::boolean, false);
+    v_lado      := coalesce((v_fila ->> 'lado')::public.lado_invitacion, 'ambos');
+
+    -- La pantalla ya valida fila a fila y en castellano; esto es la red de
+    -- seguridad, y el número de fila va en el detalle para poder señalarla.
+    if v_nombre_gr = '' or v_nombre = '' then
+      raise exception 'IMP02'
+        using errcode = 'check_violation',
+              detail  = format('fila=%s', v_indice),
+              hint    = 'Cada fila necesita grupo y nombre.';
+    end if;
+
+    -- Un grupo por nombre, sin distinguir mayúsculas ni acentos de más: quien
+    -- rellena la hoja escribe «Familia Zubeldía» y «familia zubeldía» sin
+    -- pensar que son dos invitaciones distintas.
+    select g.id into v_grupo_id
+      from public.grupos_invitacion as g
+     where lower(btrim(g.nombre)) = lower(v_nombre_gr)
+     limit 1;
+
+    if v_grupo_id is null then
+      insert into public.grupos_invitacion (nombre, lado)
+      values (v_nombre_gr, v_lado)
+      returning id into v_grupo_id;
+      v_grupos := v_grupos + 1;
+    end if;
+
+    -- DUPLICADOS. La pantalla los enseña en la vista previa, pero entre mirar
+    -- y confirmar puede haber pasado cualquier cosa —otra importación, alguien
+    -- dando de alta a mano—, así que la comprobación de verdad va aquí dentro,
+    -- donde nadie puede colarse en medio.
+    if exists (
+      select 1
+        from public.invitados as i
+       where i.grupo_id = v_grupo_id
+         and lower(btrim(i.nombre)) = lower(v_nombre)
+         and lower(btrim(coalesce(i.apellidos, ''))) = lower(coalesce(v_apellidos, ''))
+    ) then
+      raise exception 'IMP03'
+        using errcode = 'unique_violation',
+              detail  = format('fila=%s', v_indice),
+              hint    = 'Esa persona ya está en esa invitación.';
+    end if;
+
+    insert into public.invitados (grupo_id, nombre, apellidos, es_nino)
+    values (v_grupo_id, v_nombre, v_apellidos, v_nino);
+    v_personas := v_personas + 1;
+  end loop;
+
+  grupos_creados   := v_grupos;
+  personas_creadas := v_personas;
+  return next;
+end;
+$function$;
+
+comment on function public.importar_invitados(jsonb) is
+  'Da de alta en bloque a la gente de un CSV, en UNA transacción: o entran todas '
+  'o no entra ninguna. Reutiliza el grupo cuando ya existe uno con ese nombre, '
+  'porque un CSV trae una fila por persona y una invitación son varias. No emite '
+  'enlaces: eso lo hace quien organiza cuando va a mandarlos.';
+
+revoke all on function public.importar_invitados(jsonb) from public, anon, authenticated;
+grant execute on function public.importar_invitados(jsonb) to authenticated;

--- a/supabase/migrations/20260810170000_reparto_invitaciones.sql
+++ b/supabase/migrations/20260810170000_reparto_invitaciones.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- BODA-110 · Repartir invitaciones por WhatsApp
+--
+-- Nadie va a mandar doscientos correos. Las invitaciones de boda se reparten
+-- por WhatsApp, de una en una y a mano, y lo que se puede automatizar no es el
+-- envío: es **no equivocarse de enlace**. Mandarle a una familia el enlace de
+-- otra le deja ver quién viene, qué come y qué escribieron.
+--
+-- LO QUE SE GUARDA ES QUE SE MANDÓ, NO QUE SE ENTREGÓ. WhatsApp se abre en otra
+-- aplicación y desde aquí no hay forma de saber si el mensaje llegó a salir; lo
+-- que se registra es que quien organiza pulsó el botón. Es exactamente la
+-- información que hace falta —«¿a quién le falta que le mande la invitación?»—
+-- y fingir más certeza de la que hay sería peor que no guardar nada.
+--
+-- DOS FECHAS Y NO UNA. La primera vez que se manda algo es una invitación; la
+-- segunda es un recordatorio, y quien lo recibe lo lee muy distinto. Separarlas
+-- es lo que permite ordenar la lista de pendientes por cuánto hace que se les
+-- escribió (BODA-111) sin que un recordatorio de ayer disfrace una invitación
+-- de hace tres meses.
+--
+-- Rollback: supabase/migrations/rollback/20260810170000_reparto_invitaciones.sql
+-- ============================================================================
+
+alter table public.grupos_invitacion
+  add column if not exists invitacion_enviada_en  timestamptz,
+  add column if not exists recordatorio_enviado_en timestamptz;
+
+comment on column public.grupos_invitacion.invitacion_enviada_en is
+  'Cuándo se repartió la invitación de este grupo. Lo marca quien organiza al '
+  'abrir WhatsApp desde la ficha: es «lo mandé», no «le llegó», porque el envío '
+  'ocurre en otra aplicación y desde aquí no se puede saber más que eso.';
+
+comment on column public.grupos_invitacion.recordatorio_enviado_en is
+  'Cuándo se le recordó por última vez. Separado de la invitación porque un '
+  'recordatorio de ayer no puede disfrazar una invitación de hace tres meses '
+  'cuando se ordena la lista de pendientes.';
+
+-- ----------------------------------------------------------------------------
+-- Marcar el reparto
+-- ----------------------------------------------------------------------------
+--
+-- Función y no un UPDATE desde el panel por una razón concreta: las columnas de
+-- `grupos_invitacion` que puede tocar el público están acotadas por RLS y por
+-- el trigger de privilegios, y abrir la tabla a un UPDATE genérico desde el
+-- panel para escribir una fecha sería aflojar eso. Aquí se escribe una columna,
+-- se comprueba el permiso y no hay más superficie.
+
+create or replace function public.marcar_invitacion_repartida(
+  p_grupo_id uuid,
+  p_recordatorio boolean default false
+)
+returns timestamptz
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_cuando timestamptz := now();
+begin
+  if not public.puede_editar() then
+    raise exception 'RSV06'
+      using errcode = 'insufficient_privilege',
+            hint    = 'Sólo un editor puede repartir invitaciones.';
+  end if;
+
+  if p_recordatorio then
+    update public.grupos_invitacion
+       set recordatorio_enviado_en = v_cuando
+     where id = p_grupo_id;
+  else
+    update public.grupos_invitacion
+       set invitacion_enviada_en = v_cuando
+     where id = p_grupo_id;
+  end if;
+
+  if not found then
+    raise exception 'RSV01'
+      using errcode = 'no_data_found',
+            hint    = 'Esa invitación no existe.';
+  end if;
+
+  return v_cuando;
+end;
+$function$;
+
+comment on function public.marcar_invitacion_repartida(uuid, boolean) is
+  'Anota que la invitación de un grupo se ha repartido, o que se le ha recordado. '
+  'Escribe una fecha y nada más: no abre `grupos_invitacion` a un UPDATE genérico '
+  'desde el panel, que aflojaría lo que protegen RLS y el trigger de privilegios.';
+
+revoke all on function public.marcar_invitacion_repartida(uuid, boolean)
+  from public, anon, authenticated;
+grant execute on function public.marcar_invitacion_repartida(uuid, boolean) to authenticated;

--- a/supabase/migrations/rollback/20260810160000_importar_invitados.sql
+++ b/supabase/migrations/rollback/20260810160000_importar_invitados.sql
@@ -1,0 +1,8 @@
+-- Rollback de 20260810160000_importar_invitados.sql
+--
+-- Sólo quita la función. Lo que se haya importado con ella son invitados
+-- normales y corrientes —filas de `grupos_invitacion` y de `invitados`, iguales
+-- que las creadas a mano— y no se tocan: borrarlas sería tirar la lista de
+-- invitados de la boda por deshacer una migración.
+
+drop function if exists public.importar_invitados(jsonb);

--- a/supabase/migrations/rollback/20260810170000_reparto_invitaciones.sql
+++ b/supabase/migrations/rollback/20260810170000_reparto_invitaciones.sql
@@ -1,0 +1,16 @@
+-- Rollback de 20260810170000_reparto_invitaciones.sql
+--
+-- OJO: quitar las columnas borra el registro de a quién se le mandó ya la
+-- invitación. No es un dato que se pueda reconstruir —vive en el WhatsApp de
+-- quien organiza— así que, si hay repartos anotados, conviene copiárselos antes
+-- de ejecutar esto:
+--
+--   select nombre, invitacion_enviada_en, recordatorio_enviado_en
+--     from public.grupos_invitacion
+--    where invitacion_enviada_en is not null;
+
+drop function if exists public.marcar_invitacion_repartida(uuid, boolean);
+
+alter table public.grupos_invitacion
+  drop column if exists invitacion_enviada_en,
+  drop column if exists recordatorio_enviado_en;

--- a/tests/e2e/panel-importar.spec.ts
+++ b/tests/e2e/panel-importar.spec.ts
@@ -45,6 +45,18 @@ async function cuantasPersonas(nombre: string): Promise<number> {
   }
 }
 
+/**
+ * El botón de confirmar, EXACTO.
+ *
+ * Sin `exact`, «Importar» casa también con «Ver qué se va a importar», que
+ * está en la misma pantalla: Playwright encuentra dos botones y se niega a
+ * elegir. Peor todavía en las comprobaciones de que el botón NO está — sin
+ * `exact` contarían uno y darían por bueno lo contrario de lo que preguntan.
+ */
+function botonImportar(pagina: Page) {
+  return pagina.getByRole("button", { name: copy.panel.importar.confirmar, exact: true });
+}
+
 async function subir(pagina: Page, contenido: string) {
   await pagina.getByLabel(copy.panel.importar.fichero).setInputFiles({
     name: "invitados.csv",
@@ -108,7 +120,7 @@ test.describe("Importar invitados", () => {
     // Y hasta aquí, nada dado de alta.
     expect(await cuantasPersonas(nombre)).toBe(0);
 
-    await page.getByRole("button", { name: copy.panel.importar.confirmar }).click();
+    await botonImportar(page).click();
     await expect(page).toHaveURL(/estado=importados/);
 
     expect(await cuantasPersonas(nombre)).toBe(1);
@@ -150,9 +162,7 @@ test.describe("Importar invitados", () => {
     await expect(page.getByText(copy.panel.importar.errorSinGrupo)).toBeVisible();
 
     // Y no hay forma de importar: el botón no está, no es que esté apagado.
-    await expect(page.getByRole("button", { name: copy.panel.importar.confirmar })).toHaveCount(
-      0,
-    );
+    await expect(botonImportar(page)).toHaveCount(0);
 
     // Lo que de verdad importa: la fila buena TAMPOCO ha entrado.
     expect(await cuantasPersonas(buena)).toBe(0);
@@ -172,7 +182,7 @@ test.describe("Importar invitados", () => {
     );
 
     await subir(page, csv);
-    await page.getByRole("button", { name: copy.panel.importar.confirmar }).click();
+    await botonImportar(page).click();
     await expect(page).toHaveURL(/estado=importados/);
     expect(await cuantasPersonas(nombre)).toBe(1);
 
@@ -180,9 +190,7 @@ test.describe("Importar invitados", () => {
     await subir(page, csv);
 
     await expect(page.getByText(copy.panel.importar.erroresTituloUna)).toBeVisible();
-    await expect(page.getByRole("button", { name: copy.panel.importar.confirmar })).toHaveCount(
-      0,
-    );
+    await expect(botonImportar(page)).toHaveCount(0);
 
     // Y sigue habiendo una, no dos.
     expect(await cuantasPersonas(nombre)).toBe(1);

--- a/tests/e2e/panel-importar.spec.ts
+++ b/tests/e2e/panel-importar.spec.ts
@@ -1,0 +1,205 @@
+import { expect, test, type Page } from "@playwright/test";
+import postgres from "postgres";
+
+import copy from "../../content/copy.es.json";
+import { RUTA_ACCESO, RUTA_INVITADOS, RUTA_PANEL } from "../../src/config/constants";
+
+/**
+ * BODA-53 · Importar invitados desde CSV
+ *
+ * Los quince casos raros de un CSV —separadores, comillas, acentos rotos de
+ * Excel— viven en `tests/unidad/importacion.test.ts`, que los prueba en
+ * milisegundos. Aquí se prueba lo que sólo se puede probar con la base delante:
+ * que la importación **escribe de verdad**, y que cuando una fila está mal no
+ * escribe **nada**.
+ *
+ * Esa segunda parte es el criterio del ticket y el único que puede fallar en
+ * silencio: una importación a medias deja la lista con gente dentro y gente
+ * fuera, sin ninguna marca que distinga a quién faltó.
+ */
+
+const CORREO_CON_ACCESO = process.env.CORREO_CON_ACCESO;
+const CONTRASENA = process.env.CONTRASENA_PRUEBAS;
+const cadena = process.env.DATABASE_URL;
+
+const MARCA = "(DES) E2E Importar";
+
+async function entrar(pagina: Page) {
+  await pagina.goto(RUTA_ACCESO);
+  await pagina.getByLabel(copy.acceso.correo).fill(CORREO_CON_ACCESO!);
+  await pagina.getByLabel(copy.acceso.contrasena).fill(CONTRASENA!);
+  await pagina.getByRole("button", { name: copy.acceso.entrar }).click();
+  await expect(pagina).toHaveURL(new RegExp(RUTA_PANEL));
+}
+
+/** Cuántas personas hay con ese nombre. La base es la que dice la verdad. */
+async function cuantasPersonas(nombre: string): Promise<number> {
+  const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
+  try {
+    const [fila] = await sql<{ cuantas: number }[]>`
+      select count(*)::int as cuantas from public.invitados where nombre = ${nombre}
+    `;
+    return fila.cuantas;
+  } finally {
+    await sql.end();
+  }
+}
+
+async function subir(pagina: Page, contenido: string) {
+  await pagina.getByLabel(copy.panel.importar.fichero).setInputFiles({
+    name: "invitados.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(contenido, "utf8"),
+  });
+  await pagina.getByRole("button", { name: copy.panel.importar.analizar }).click();
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Importar invitados", () => {
+  test.skip(
+    !CORREO_CON_ACCESO || !CONTRASENA,
+    "Necesita el Supabase local: solo corre en el trabajo de CI que lo levanta.",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await entrar(page);
+    await page.goto(`${RUTA_INVITADOS}/importar`);
+  });
+
+  test("se llega desde la lista de invitaciones", async ({ page }) => {
+    await page.goto(RUTA_INVITADOS);
+    await page.getByRole("link", { name: copy.panel.importar.enlaceDesdeLista }).click();
+    await expect(page).toHaveURL(new RegExp(`${RUTA_INVITADOS}/importar`));
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+      copy.panel.importar.titulo,
+    );
+  });
+
+  /**
+   * EL CAMINO FELIZ. Un CSV con dos familias da de alta a las cuatro personas
+   * en DOS invitaciones, no en cuatro: un CSV trae una fila por persona, y las
+   * personas de una familia comparten invitación y enlace.
+   */
+  test("un CSV válido da de alta a todos, agrupados por invitación", async ({ page }) => {
+    const sello = Date.now();
+    const familia = `${MARCA} Zubeldía ${sello}`;
+    const otra = `${MARCA} Gorroño ${sello}`;
+    const nombre = `(DES) Ainhoa ${sello}`;
+
+    await subir(
+      page,
+      [
+        "Grupo;Nombre;Apellidos;Lado;Niño",
+        `${familia};${nombre};Zubeldía;novia;no`,
+        `${familia};(DES) Unai ${sello};Zubeldía;novia;sí`,
+        `${otra};(DES) Uxue ${sello};Gorroño;novio;no`,
+      ].join("\n"),
+    );
+
+    // Antes de escribir nada se enseña qué va a entrar. Es el criterio de la
+    // vista previa: cuatro filas repartidas en dos invitaciones nuevas.
+    await expect(
+      page.getByRole("heading", { name: copy.panel.importar.previaTitulo }),
+    ).toBeVisible();
+    await expect(page.getByText(nombre)).toBeVisible();
+    await expect(page.getByText(copy.panel.importar.grupoNuevo).first()).toBeVisible();
+
+    // Y hasta aquí, nada dado de alta.
+    expect(await cuantasPersonas(nombre)).toBe(0);
+
+    await page.getByRole("button", { name: copy.panel.importar.confirmar }).click();
+    await expect(page).toHaveURL(/estado=importados/);
+
+    expect(await cuantasPersonas(nombre)).toBe(1);
+
+    // Dos invitaciones, no tres: la familia comparte la suya.
+    await page.goto(`${RUTA_INVITADOS}?buscar=${encodeURIComponent(String(sello))}`);
+    await expect(page.getByRole("link", { name: familia })).toContainText(
+      copy.panel.invitados.personasCuenta.replace("{personas}", "2"),
+    );
+    await expect(page.getByRole("link", { name: otra })).toBeVisible();
+  });
+
+  /**
+   * CASO DE ERROR · UNA FILA MAL Y NO ENTRA NINGUNA.
+   *
+   * Lo que se comprueba no es que salga el aviso: es que la persona de la fila
+   * BUENA tampoco está en la base. Media importación es peor que ninguna,
+   * porque no deja rastro de por dónde se quedó.
+   */
+  test("una fila mal señala su línea y no importa ninguna", async ({ page }) => {
+    const sello = Date.now();
+    const buena = `(DES) Buena ${sello}`;
+
+    await subir(
+      page,
+      [
+        "Grupo;Nombre;Apellidos",
+        `${MARCA} ${sello};${buena};Primera`,
+        // Sin grupo: es la línea 3 del fichero, contando la cabecera.
+        `;(DES) Huérfana ${sello};Segunda`,
+        `${MARCA} ${sello};(DES) Tercera ${sello};Tercera`,
+      ].join("\n"),
+    );
+
+    await expect(page.getByText(copy.panel.importar.erroresTituloUna)).toBeVisible();
+    await expect(
+      page.getByText(copy.panel.importar.errorLinea.replace("{linea}", "3")),
+    ).toBeVisible();
+    await expect(page.getByText(copy.panel.importar.errorSinGrupo)).toBeVisible();
+
+    // Y no hay forma de importar: el botón no está, no es que esté apagado.
+    await expect(page.getByRole("button", { name: copy.panel.importar.confirmar })).toHaveCount(
+      0,
+    );
+
+    // Lo que de verdad importa: la fila buena TAMPOCO ha entrado.
+    expect(await cuantasPersonas(buena)).toBe(0);
+  });
+
+  /**
+   * CASO DE ERROR · Quien ya está no entra dos veces.
+   *
+   * Se importa una vez y se vuelve a subir el mismo fichero: la segunda tiene
+   * que quedarse en la vista previa señalando el duplicado.
+   */
+  test("detecta a quien ya está dado de alta", async ({ page }) => {
+    const sello = Date.now();
+    const nombre = `(DES) Repetida ${sello}`;
+    const csv = ["Grupo;Nombre;Apellidos", `${MARCA} repes ${sello};${nombre};Pérez`].join(
+      "\n",
+    );
+
+    await subir(page, csv);
+    await page.getByRole("button", { name: copy.panel.importar.confirmar }).click();
+    await expect(page).toHaveURL(/estado=importados/);
+    expect(await cuantasPersonas(nombre)).toBe(1);
+
+    await page.goto(`${RUTA_INVITADOS}/importar`);
+    await subir(page, csv);
+
+    await expect(page.getByText(copy.panel.importar.erroresTituloUna)).toBeVisible();
+    await expect(page.getByRole("button", { name: copy.panel.importar.confirmar })).toHaveCount(
+      0,
+    );
+
+    // Y sigue habiendo una, no dos.
+    expect(await cuantasPersonas(nombre)).toBe(1);
+  });
+
+  test("la plantilla se descarga con el BOM y los rótulos de la pantalla", async ({ page }) => {
+    // `page.request` y no el fixture `request`: el fixture es un contexto de
+    // red aparte y llegaría sin sesión, así que descargaría la pantalla de
+    // acceso en lugar del fichero.
+    const respuesta = await page.request.get(`${RUTA_INVITADOS}/importar/plantilla`);
+    const bytes = await respuesta.body();
+
+    expect([bytes[0], bytes[1], bytes[2]]).toEqual([0xef, 0xbb, 0xbf]);
+
+    const texto = bytes.toString("utf8");
+    expect(texto).toContain(copy.panel.importar.columna.grupo);
+    // Con acento y ñ: si esto llega roto, el problema es la codificación.
+    expect(texto).toContain(copy.panel.importar.muestraApellidos);
+  });
+});

--- a/tests/e2e/panel-invitados.spec.ts
+++ b/tests/e2e/panel-invitados.spec.ts
@@ -416,3 +416,107 @@ test.describe("Exportar invitados", () => {
     await contexto.close();
   });
 });
+
+/**
+ * BODA-110 · Repartir invitaciones por WhatsApp
+ *
+ * Nadie manda doscientos correos: las invitaciones se reparten por WhatsApp, de
+ * una en una. Lo que se automatiza no es el envío —ocurre en otra aplicación—
+ * sino no equivocarse de enlace, que es el fallo con consecuencias: mandarle a
+ * una familia el enlace de otra le deja ver quién viene, qué come y qué
+ * escribieron.
+ */
+test.describe("Repartir la invitación", () => {
+  test.skip(
+    !CORREO_CON_ACCESO || !CONTRASENA,
+    "Necesita el Supabase local: solo corre en el trabajo de CI que lo levanta.",
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await entrar(page);
+  });
+
+  /** Crea una invitación y devuelve su ficha ya abierta, con el enlace puesto. */
+  async function crearConEnlace(page: Page, sufijo: string): Promise<string> {
+    await page.goto(RUTA_INVITADOS);
+    await page.getByLabel(copy.panel.invitados.nombreGrupo).fill(sufijo);
+    await page.getByRole("button", { name: copy.panel.invitados.crear }).click();
+    await expect(page).toHaveURL(FICHA);
+    return page.getByLabel(copy.panel.invitados.copiarEnlace).inputValue();
+  }
+
+  test("el mensaje lleva el enlace de esta invitación y el texto de los copys", async ({
+    page,
+  }) => {
+    const enlace = await crearConEnlace(page, `${MARCA} reparto ${Date.now()}`);
+    const token = new URL(enlace).pathname.split("/").pop()!;
+
+    const mensaje = await page.locator('textarea[name="mensaje"]').inputValue();
+
+    // El texto sale de los copys, con el enlace dentro.
+    expect(mensaje).toContain(enlace);
+    expect(mensaje).toContain(
+      copy.panel.invitados.repartirPlantilla
+        .replace("{enlace}", "")
+        .trim()
+        .split("{")[0]
+        .trim(),
+    );
+
+    // Y al mandarlo se va a WhatsApp con ese mismo texto codificado.
+    const [destino] = await Promise.all([
+      page.waitForRequest((peticion) => peticion.url().startsWith("https://wa.me/")),
+      page.getByRole("button", { name: copy.panel.invitados.repartirBoton }).click(),
+    ]);
+    expect(decodeURIComponent(destino.url())).toContain(token);
+  });
+
+  /**
+   * CASO DE ERROR · El token de otro grupo no se arrastra jamás.
+   *
+   * Es el fallo que este ticket existe para evitar. Se comprueba abriendo una
+   * segunda invitación: su formulario tiene que llevar SU token, y la ficha de
+   * un grupo cuyo enlace ya no está en la URL no puede ofrecer el botón, porque
+   * no tiene ningún enlace que mandar.
+   */
+  test("cambiar de invitación cambia el enlace, y sin enlace no hay botón", async ({
+    page,
+  }) => {
+    const sello = Date.now();
+    const primero = await crearConEnlace(page, `${MARCA} reparto A ${sello}`);
+    const fichaPrimera = page.url();
+
+    const segundo = await crearConEnlace(page, `${MARCA} reparto B ${sello}`);
+    expect(segundo).not.toBe(primero);
+
+    // El formulario de la segunda ficha lleva el enlace de la segunda.
+    const mensaje = await page.locator('textarea[name="mensaje"]').inputValue();
+    expect(mensaje).toContain(segundo);
+    expect(mensaje).not.toContain(primero);
+
+    // Y al volver a la primera SIN el `?token=`, no hay nada que mandar: la
+    // base guarda la huella, no el token, así que no se puede recuperar.
+    await page.goto(fichaPrimera.split("?")[0]);
+    await expect(page.locator('textarea[name="mensaje"]')).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: copy.panel.invitados.repartirBoton }),
+    ).toHaveCount(0);
+    await expect(page.getByText(copy.panel.invitados.repartirSoloConEnlace)).toBeVisible();
+  });
+
+  test("queda anotado a quién se le ha mandado ya", async ({ page }) => {
+    await crearConEnlace(page, `${MARCA} anotado ${Date.now()}`);
+    const ficha = page.url().split("?")[0];
+
+    await expect(page.getByText(copy.panel.invitados.repartirNunca)).toHaveCount(0);
+
+    await Promise.all([
+      page.waitForRequest((peticion) => peticion.url().startsWith("https://wa.me/")),
+      page.getByRole("button", { name: copy.panel.invitados.repartirBoton }).click(),
+    ]);
+
+    // De vuelta en la ficha, sin enlace en la URL: dice cuándo se mandó.
+    await page.goto(ficha);
+    await expect(page.getByText(/Invitación mandada el/)).toBeVisible();
+  });
+});

--- a/tests/unidad/acciones-servidor.test.ts
+++ b/tests/unidad/acciones-servidor.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * UN MÓDULO `"use server"` SÓLO PUEDE EXPORTAR FUNCIONES ASÍNCRONAS
+ *
+ * Es una regla del framework, no una preferencia. Y no la vigila nadie: un
+ * `export const` o un `export interface` en un fichero de acciones **compila
+ * sin una queja**, pasa el typecheck, pasa el lint, y luego la pantalla que lo
+ * importa revienta al abrirla con un «Algo no ha ido bien» que no dice por qué.
+ *
+ * Pasó de verdad, en `panel/invitados/importar/acciones.ts`, y lo cazó el
+ * único trabajo de CI que abre esa pantalla con sesión — seis minutos después
+ * de subirlo y sin más pista que un `<h1>` de error. Este test lo dice en
+ * milisegundos y señalando la línea.
+ *
+ * Los tipos y las constantes que comparten una acción y su pantalla van a un
+ * módulo aparte, como `importar/estado.ts`.
+ */
+
+const RAIZ = join(__dirname, "..", "..");
+
+/** Todos los `.ts` y `.tsx` de `src/`, sin depender de ninguna librería. */
+function fuentes(directorio: string): string[] {
+  const encontradas: string[] = [];
+  for (const entrada of readdirSync(directorio, { withFileTypes: true })) {
+    const ruta = join(directorio, entrada.name);
+    if (entrada.isDirectory()) encontradas.push(...fuentes(ruta));
+    else if (/\.tsx?$/.test(entrada.name)) encontradas.push(ruta);
+  }
+  return encontradas;
+}
+
+/** Ficheros que declaran `"use server"` en su primera línea útil. */
+function modulosDeServidor(): string[] {
+  return fuentes(join(RAIZ, "src")).filter((ruta) =>
+    /^\s*["']use server["']/.test(readFileSync(ruta, "utf8")),
+  );
+}
+
+/**
+ * Exportaciones que NO son una función asíncrona.
+ *
+ * `export type` y `export interface` cuentan igual: aunque desaparecen al
+ * compilar, el fichero que los reexporta arrastra el módulo entero al cliente
+ * y el error es el mismo. Se escriben en su sitio y no aquí.
+ */
+const PROHIBIDAS = /^\s*export\s+(const|let|var|class|interface|type|enum)\s/gm;
+
+describe("Los módulos de acciones de servidor", () => {
+  it("hay alguno que vigilar", () => {
+    // Si esto baja a cero, el glob ha dejado de encontrarlos y el test se
+    // estaría dando por bueno sin mirar nada.
+    expect(modulosDeServidor().length).toBeGreaterThan(0);
+  });
+
+  it("sólo exportan funciones asíncronas", () => {
+    const culpables: string[] = [];
+
+    for (const ruta of modulosDeServidor()) {
+      const contenido = readFileSync(ruta, "utf8");
+      const relativa = ruta.slice(RAIZ.length + 1);
+
+      for (const coincidencia of contenido.matchAll(PROHIBIDAS)) {
+        const linea = contenido.slice(0, coincidencia.index).split("\n").length;
+        culpables.push(`${relativa}:${linea} → ${coincidencia[0].trim()}`);
+      }
+
+      // Y las funciones exportadas, asíncronas: una función síncrona exportada
+      // desde aquí falla igual, y con el mismo silencio.
+      for (const coincidencia of contenido.matchAll(/^\s*export\s+function\s/gm)) {
+        const linea = contenido.slice(0, coincidencia.index).split("\n").length;
+        culpables.push(`${relativa}:${linea} → export function (tiene que ser async)`);
+      }
+    }
+
+    expect(
+      culpables,
+      'un módulo "use server" sólo exporta funciones asíncronas: lleva tipos y ' +
+        "constantes a un fichero aparte",
+    ).toEqual([]);
+  });
+});

--- a/tests/unidad/importacion.test.ts
+++ b/tests/unidad/importacion.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import copy from "../../content/copy.es.json";
+import { analizarCsv, decodificar, detectarSeparador } from "../../src/lib/csv";
+import { clavePersona, leerImportacion } from "../../src/lib/importacion-invitados";
+
+/**
+ * BODA-53 · LO QUE UN CSV DE VERDAD LE HACE A UN PARSER
+ *
+ * Estos casos no son inventados: son lo que sale de Excel, de Numbers y de una
+ * hoja compartida entre dos familias. Van en test unitario y no en E2E porque
+ * son quince variantes de la misma pantalla, y quince recorridos de navegador
+ * para probar quince cadenas de texto es tardar diez minutos en saber algo que
+ * se puede saber en diez milisegundos.
+ */
+
+describe("Leer el CSV que suelta una hoja de cálculo", () => {
+  it("acierta el separador tanto con punto y coma como con coma", () => {
+    // Excel en español exporta con `;` porque la coma es el decimal.
+    expect(detectarSeparador("Grupo;Nombre;Apellidos")).toBe(";");
+    // El mismo Excel en inglés, y cualquier cosa que siga el estándar.
+    expect(detectarSeparador("Grupo,Nombre,Apellidos")).toBe(",");
+    expect(detectarSeparador("Grupo\tNombre\tApellidos")).toBe("\t");
+  });
+
+  it("una coma dentro de comillas es texto, no un separador", () => {
+    const filas = analizarCsv('Grupo,Nombre\n"Zubeldía, familia",Ainhoa');
+    expect(filas[1]).toEqual(["Zubeldía, familia", "Ainhoa"]);
+  });
+
+  it("dos comillas seguidas son una comilla", () => {
+    const filas = analizarCsv('Nombre\n"Ana ""la peque"""');
+    expect(filas[1]).toEqual(['Ana "la peque"']);
+  });
+
+  it("un salto de línea dentro de una celda no parte la fila", () => {
+    // Pasa de verdad: un campo escrito en dos renglones en la hoja.
+    const filas = analizarCsv('Grupo;Nota\nFamilia;"Primera línea\nSegunda línea"');
+    expect(filas).toHaveLength(2);
+    expect(filas[1][1]).toBe("Primera línea\nSegunda línea");
+  });
+
+  it("las líneas en blanco del final no son personas sin nombre", () => {
+    // Una hoja de cálculo casi siempre termina así.
+    expect(analizarCsv("Grupo;Nombre\nFamilia;Ana\n\n\n")).toHaveLength(2);
+  });
+
+  it("aguanta los finales de línea de Windows", () => {
+    expect(analizarCsv("Grupo;Nombre\r\nFamilia;Ana\r\n")).toEqual([
+      ["Grupo", "Nombre"],
+      ["Familia", "Ana"],
+    ]);
+  });
+
+  /**
+   * EL CASO QUE ROMPE TODAS LAS IMPORTACIONES DE ESPAÑA.
+   *
+   * Excel en Windows guarda en Windows-1252 salvo que le insistas. Leer esos
+   * bytes como UTF-8 convierte «Zubeldía» en «ZubeldÃ­a», y una vez dentro de
+   * la base ya no hay forma de saber si el apellido era así.
+   */
+  it("lee «Zubeldía» venga en UTF-8 o en el Latin-1 de Excel", () => {
+    const enUtf8 = new TextEncoder().encode("Zubeldía");
+    expect(decodificar(enUtf8.buffer as ArrayBuffer)).toBe("Zubeldía");
+
+    // Los mismos caracteres en Windows-1252: la í es un solo byte, 0xED.
+    const enLatin1 = Uint8Array.from([0x5a, 0x75, 0x62, 0x65, 0x6c, 0x64, 0xed, 0x61]);
+    expect(decodificar(enLatin1.buffer as ArrayBuffer)).toBe("Zubeldía");
+  });
+
+  it("se come el BOM, que si no la primera columna nunca casa", () => {
+    const conBom = new TextEncoder().encode("﻿Grupo;Nombre");
+    expect(decodificar(conBom.buffer as ArrayBuffer)).toBe("Grupo;Nombre");
+  });
+});
+
+describe("Decidir qué se da de alta y qué no", () => {
+  const CABECERA = "Grupo;Nombre;Apellidos;Lado;Niño";
+
+  it("un fichero bueno sale entero y con sus tipos puestos", () => {
+    const lectura = leerImportacion(
+      `${CABECERA}\nFamilia Zubeldía;Ainhoa;Zubeldía;novia;no\nFamilia Zubeldía;Unai;Zubeldía;novia;sí`,
+    );
+
+    expect(lectura.errores).toEqual([]);
+    expect(lectura.filas).toHaveLength(2);
+    expect(lectura.filas[0]).toEqual({
+      grupo: "Familia Zubeldía",
+      lado: "novia",
+      nombre: "Ainhoa",
+      apellidos: "Zubeldía",
+      nino: false,
+    });
+    expect(lectura.filas[1].nino).toBe(true);
+  });
+
+  it("los rótulos valen con acentos, sin ellos y en mayúsculas", () => {
+    const lectura = leerImportacion("GRUPO;nombre;NIÑO\nFamilia;Ana;x");
+    expect(lectura.errores).toEqual([]);
+    expect(lectura.filas[0].nino).toBe(true);
+  });
+
+  it("el orden de las columnas da igual", () => {
+    const lectura = leerImportacion("Nombre;Grupo\nAna;Familia");
+    expect(lectura.errores).toEqual([]);
+    expect(lectura.filas[0]).toMatchObject({ grupo: "Familia", nombre: "Ana" });
+  });
+
+  it("sin las columnas obligatorias no se lee nada, y se dice cuál falta", () => {
+    const lectura = leerImportacion("Nombre;Apellidos\nAna;Pérez");
+    expect(lectura.filas).toEqual([]);
+    expect(lectura.errores[0].motivo).toContain(copy.panel.importar.columna.grupo);
+  });
+
+  it("una columna que no se entiende se ignora, y se avisa", () => {
+    const lectura = leerImportacion("Grupo;Nombre;Talla de camiseta\nFamilia;Ana;M");
+    expect(lectura.errores).toEqual([]);
+    expect(lectura.columnasIgnoradas).toEqual(["Talla de camiseta"]);
+  });
+
+  /**
+   * EL CRITERIO DEL TICKET. Una fila mal no importa media lista: el error se
+   * señala con su número de fila y la importación entera se queda parada.
+   */
+  it("señala la fila mala por su número, el de la hoja", () => {
+    const lectura = leerImportacion(`${CABECERA}\nFamilia;Ana;;;\n;Unai;;;\nFamilia;Uxue;;;`);
+
+    // La cabecera es la 1, así que la fila sin grupo es la 3.
+    expect(lectura.errores).toHaveLength(1);
+    expect(lectura.errores[0].linea).toBe(3);
+    expect(lectura.errores[0].motivo).toBe(copy.panel.importar.errorSinGrupo);
+  });
+
+  it("un lado que no existe es un error, no un valor por defecto silencioso", () => {
+    // Poner «ambos» y seguir sería decidir por los novios de qué lado va
+    // alguien, y eso se nota luego en la mesa presidencial.
+    const lectura = leerImportacion(`${CABECERA}\nFamilia;Ana;;primos;`);
+    expect(lectura.filas).toEqual([]);
+    expect(lectura.errores[0].motivo).toContain("primos");
+  });
+
+  it("sin lado se asume «ambos», que es el valor por defecto de la base", () => {
+    const lectura = leerImportacion("Grupo;Nombre\nFamilia;Ana");
+    expect(lectura.filas[0].lado).toBe("ambos");
+  });
+
+  it("caza a quien viene dos veces en el mismo fichero", () => {
+    // Una hoja compartida entre dos familias trae repetidos con naturalidad.
+    const lectura = leerImportacion(`${CABECERA}\nFamilia;Ana;Pérez;;\nFamilia;ana;pérez;;`);
+    expect(lectura.filas).toHaveLength(1);
+    expect(lectura.errores).toHaveLength(1);
+    expect(lectura.errores[0].linea).toBe(3);
+  });
+
+  it("caza a quien ya estaba en la base", () => {
+    const yaHay = new Set([clavePersona("Familia", "Ana", "Pérez")]);
+    const lectura = leerImportacion(`${CABECERA}\nFamilia;Ana;Pérez;;`, yaHay);
+    expect(lectura.filas).toEqual([]);
+    expect(lectura.errores[0].motivo).toContain("Ana Pérez");
+  });
+
+  it("un fichero vacío lo dice en vez de importar cero personas en silencio", () => {
+    const lectura = leerImportacion("");
+    expect(lectura.errores[0].motivo).toBe(copy.panel.importar.errorVacio);
+  });
+
+  it("por encima del tope no se lee: ése no es el fichero de la boda", () => {
+    const filas = Array.from({ length: 600 }, (_, i) => `Familia ${i};Persona ${i}`).join("\n");
+    const lectura = leerImportacion(`Grupo;Nombre\n${filas}`);
+    expect(lectura.filas).toEqual([]);
+    expect(lectura.errores[0].motivo).toContain("600");
+  });
+});


### PR DESCRIPTION
## Qué cambia

Se puede subir la hoja de cálculo de los invitados y darlos de alta en bloque (#40), y mandar la invitación de cada grupo por WhatsApp sin riesgo de equivocarse de enlace (#72).

Closes #40
Closes #72

> **Dos tickets en una PR, y lo digo en voz alta.** La convención del proyecto es una rama por ticket. #40 ya estaba abierto aquí cuando el CI encontró el fallo del `"use server"`, y #72 es camino crítico y bloquea a #73. Están en **dos commits separados y coherentes**, que es lo que la convención protege de verdad. Si preferís que lo parta en dos PR, lo hago.

## Cómo probarlo en el preview

**Importar (#40)**
1. Panel → Invitaciones → **Importar desde CSV**.
2. Descargar la plantilla y comprobar que «Zubeldía Gorroño» se lee bien al abrirla en Excel.
3. Subir un CSV con dos personas de la misma familia y una de otra: la vista previa enseña **dos** invitaciones, no tres. Todavía no se ha escrito nada.
4. Importar, volver a subir el mismo fichero: ahora señala los duplicados y **el botón de importar no aparece**.
5. Subir un CSV con una fila sin grupo: dice «Fila 3» y no importa ninguna — comprobad que la persona de la fila buena tampoco está.

**Repartir (#72)**
6. Crear una invitación: en el bloque del enlace hay un mensaje editable y un botón de WhatsApp.
7. Retocar el texto y pulsar: se abre WhatsApp con ese texto y el enlace de **esta** invitación.
8. Volver a la ficha sin el `?token=` en la URL: ya no hay botón, y se explica por qué.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: el tope de filas en `src/config/constants.ts`, el mensaje de WhatsApp y los rótulos en `content/copy.es.json`
- [x] Test E2E incluido: camino feliz **y** casos de error en los dos tickets
- [ ] CI verde entero — pendiente de esta ejecución; en local pasan 186 unitarios y 120 E2E de escritorio
- [x] Responsive: la tabla de la vista previa hace scroll dentro de su caja
- [x] Accesible: `<label>` unido a cada campo, errores con `role="alert"`, el botón se quita en vez de deshabilitarse
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview — no puedo: `vercel.app` está bloqueado por la política de salida de este contenedor

### Lo que el CI encontró y yo no

El primer intento reventaba al abrir la pantalla de importar con un «Algo no ha ido bien». La causa: un módulo `"use server"` **sólo puede exportar funciones asíncronas**, y yo tenía ahí un `export const ESTADO_INICIAL` y dos tipos. Pasó el typecheck, el lint y el build sin una queja — sólo falla al abrir la página, y el único trabajo que la abre con sesión es el de Supabase.

Va con cepo: `tests/unidad/acciones-servidor.test.ts` recorre los módulos `"use server"` y falla señalando fichero y línea. Comprobado que muerde antes de darlo por bueno — con un `export const` metido a mano se pone rojo.

### Lo que no es obvio

**La escritura de la importación es una función de la base, no un bucle.** El criterio es «no se importa nada hasta que se resuelven los errores», y un bucle de doscientas llamadas no puede cumplirlo: cada llamada es su propia transacción, así que un fallo en la fila 120 deja 119 personas dentro y ninguna forma de saber cuáles. Comprobado contra la base: con una fila duplicada al final, ni las dos filas buenas ni la invitación que habrían creado quedan en la tabla.

**Los grupos se reutilizan por nombre.** Un CSV trae una fila por persona, pero las cuatro de «Familia Zubeldía» son *una* invitación. Sin esto, importar fabricaría doscientas invitaciones de una persona y doscientos enlaces que mandar.

**La codificación.** Leer un fichero Latin-1 como UTF-8 convierte «Zubeldía» en «ZubeldÃa» y dentro de la base ya no se puede saber cuál era el apellido. Se decodifica con `fatal: true` para que el decodificador **lance** en lugar de meter caracteres de reemplazo. Hay test con los bytes de las dos codificaciones.

**Por qué el botón de WhatsApp sólo está justo tras emitir el enlace.** La base guarda la huella del token, no el token: el texto en claro sólo existe en la pantalla que acaba de emitirlo. Es incómodo a propósito, y es lo que hace imposible mandar el enlace de otro grupo — al cambiar de ficha la URL pierde el `?token=` y el formulario desaparece con él. No hay estado que arrastrar.

**`wa.me` sin número** abre el selector de contacto. Los teléfonos de los invitados no están en la base y quien reparte los tiene en su agenda; pedirlos sólo para esto sería recoger doscientos datos personales para ahorrarse un toque.

**Se anotan dos fechas.** La primera vez que se manda algo es una invitación; la segunda, un recordatorio. Separarlas es lo que permitirá ordenar la lista de pendientes de #73 sin que un recordatorio de ayer disfrace una invitación de hace tres meses.

**Esta pantalla de importar necesita JavaScript, y se dice** en un `<noscript>` con la vía alternativa. La garantía de funcionar sin JavaScript es del RSVP —lo abre un invitado desde WhatsApp en un móvil prestado— y no se toca.

## Base de datos

- [ ] No la toca
- [x] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

`importar_invitados(jsonb)` y `marcar_invitacion_repartida(uuid, boolean)`, más dos columnas de fecha en `grupos_invitacion`. El rollback de la importación sólo quita la función: lo importado con ella son invitados normales, y borrarlos sería tirar la lista de la boda por deshacer una migración. El del reparto avisa de que quitar las columnas borra el registro de a quién se le mandó ya, que no se puede reconstruir.

## Documentación

- [ ] No hace falta
- [x] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR