### PR TITLE
feat(rsvp): acuse de recibo al confirmar

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -540,5 +540,19 @@
       "errorYaContesto": "Esa invitación ha contestado mientras mirabais la lista, así que no se le ha mandado nada.",
       "errorPlazo": "El plazo se ha cerrado: a estas alturas se llama, no se recuerda."
     }
+  },
+  "correoConfirmacion": {
+    "asuntoSi": "Apuntado: nos vemos en la boda",
+    "asuntoNo": "Recibido, os echaremos de menos",
+    "saludo": "Hola:",
+    "cuerpoSi": "Hemos apuntado vuestra respuesta. Esto es lo que nos habéis dicho:",
+    "cuerpoNo": "Hemos apuntado vuestra respuesta. Gracias por decírnoslo.",
+    "vienen": "Vienen",
+    "noVienen": "No vienen",
+    "cambiar": "¿Cambia algo? Podéis modificar la respuesta desde el mismo enlace:",
+    "plazo": "Podéis cambiarla hasta el {fecha}.",
+    "sinPlazo": "Podéis cambiarla cuando queráis.",
+    "despedida": "Un abrazo,",
+    "firma": "{novia} y {novio}"
   }
 }

--- a/docs/ENTORNO.md
+++ b/docs/ENTORNO.md
@@ -20,13 +20,15 @@ solo están los **nombres**.
 **Settings → Environment Variables.** Marcar las tres ramas (Production,
 Preview, Development) salvo que se indique otra cosa.
 
-| Variable                        | De dónde se saca                                                                          |
-| ------------------------------- | ----------------------------------------------------------------------------------------- |
-| `DATABASE_URL`                  | Botón **Connect** del dashboard → pestaña **Transaction pooler**                          |
-| `NEXT_PUBLIC_SUPABASE_URL`      | Botón **Connect** → pestaña de frameworks, o Settings → **API Keys**                      |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Igual que la anterior: salen juntas                                                       |
-| `SUPABASE_SERVICE_ROLE_KEY`     | Settings → **API Keys** → `service_role`. **Todavía no hace falta**: ningún código la usa |
-| `NEXT_PUBLIC_SITE_URL`          | El dominio final de la web                                                                |
+| Variable                        | De dónde se saca                                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                  | Botón **Connect** del dashboard → pestaña **Transaction pooler**                                           |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Botón **Connect** → pestaña de frameworks, o Settings → **API Keys**                                       |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Igual que la anterior: salen juntas                                                                        |
+| `SUPABASE_SERVICE_ROLE_KEY`     | Settings → **API Keys** → `service_role`. **Todavía no hace falta**: ningún código la usa                  |
+| `NEXT_PUBLIC_SITE_URL`          | El dominio final de la web                                                                                 |
+| `RESEND_API_KEY`                | [resend.com](https://resend.com) → **API Keys**. Sin ella no se manda el acuse de recibo, y no es un error |
+| `CORREO_REMITENTE`              | La dirección desde la que se escribe, en un dominio **verificado** en Resend                               |
 
 **El pooler, no la conexión directa.** Cada petición a la web arranca una
 función efímera; con conexión directa se agotan las conexiones del servidor en
@@ -170,3 +172,20 @@ uno por aquí, dalo por comprometido y rótalo.
 
 Rotar una clave cuesta dos minutos. Una lista de invitados filtrada no se
 recupera.
+
+## El correo del acuse de recibo
+
+Se manda con [Resend](https://resend.com) y hacen falta dos variables:
+`RESEND_API_KEY` y `CORREO_REMITENTE`. **Si faltan, no se manda nada y no pasa
+nada más**: la confirmación del invitado se guarda igual y la web no cambia. Es
+a propósito — un acuse de recibo no puede costar una respuesta.
+
+El remitente tiene que estar en un dominio verificado en Resend. Con una
+dirección de un dominio sin verificar, Resend acepta la petición y luego no
+entrega, que es la forma más silenciosa de que no llegue nada.
+
+Hay una tercera variable, `RESEND_URL`, que **no hay que poner en Vercel**: por
+defecto apunta a la API de Resend. Existe para que los tests puedan levantar un
+buzón de captura y leer el correo que sale de verdad, en lugar de simular
+nuestra propia función de envío —que probaría que sabemos llamarla, no que el
+correo sale—.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -80,6 +80,22 @@ export default defineConfig({
           NEXT_PUBLIC_SUPABASE_ANON_KEY:
             process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "clave-de-pruebas-sin-valor",
           NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL ?? URL_BASE,
+
+          /*
+            EL CORREO, APUNTANDO A UN PUERTO CERRADO POR DEFECTO.
+
+            Es deliberado, y es la misma idea que el Supabase inexistente de
+            arriba: así el camino de «el proveedor no responde» se recorre en
+            CADA ejecución de la suite, y no sólo en el test que lo busca. Si
+            algún día un fallo de correo tumbara una confirmación, se caerían
+            veinte tests a la vez en lugar de ninguno.
+
+            El test del acuse levanta un buzón de captura en ese puerto y lee
+            lo que se mandó de verdad.
+          */
+          RESEND_API_KEY: process.env.RESEND_API_KEY ?? "clave-de-pruebas-sin-valor",
+          CORREO_REMITENTE: process.env.CORREO_REMITENTE ?? "boda@ejemplo.test",
+          RESEND_URL: process.env.RESEND_URL ?? "http://127.0.0.1:54999",
         },
       },
 });

--- a/src/app/rsvp/[token]/acciones.ts
+++ b/src/app/rsvp/[token]/acciones.ts
@@ -3,12 +3,18 @@
 import { redirect } from "next/navigation";
 
 import { PASOS_RSVP, RUTA_RSVP, type PasoRsvp } from "@/config/constants";
+import { obtenerConfiguracion } from "@/lib/bbdd/landing";
 import {
+  destinatariosDeConfirmacion,
   obtenerInvitacion,
   registrarConfirmacion,
+  type Invitacion,
   type RespuestaInvitado,
 } from "@/lib/bbdd/rsvp";
+import { enviarCorreo } from "@/lib/correo";
+import { componerConfirmacion } from "@/lib/correo-confirmacion";
 import { borrarBorrador, guardarBorrador, leerBorrador } from "@/lib/rsvp-borrador";
+import { urlDelSitio } from "@/lib/url-sitio";
 
 /**
  * EL AVANCE DEL RSVP
@@ -134,6 +140,26 @@ export async function avanzar(datos: FormData): Promise<void> {
 
   // La respuesta ya está en la base: el borrador sobra y su cookie también.
   await borrarBorrador();
+
+  /*
+    Y AHORA, Y SÓLO AHORA, EL ACUSE DE RECIBO.
+
+    Después de guardar y con todo dentro de un `try`. Es el criterio del ticket
+    escrito en el orden de las líneas: «si el envío falla, la respuesta ya está
+    guardada». Un correo es el acuse, no la respuesta — que una caída de Resend
+    tumbara una confirmación sería perder el dato que importa por no poder
+    mandar el que no.
+
+    Nada de lo que pase aquí cambia lo que ve el invitado. Ya ha contestado, y
+    contarle que el acuse no ha salido sólo le daría un problema que no es suyo
+    y que no puede resolver.
+  */
+  try {
+    await mandarAcuseDeRecibo(token, invitacion, respuestas);
+  } catch (error) {
+    console.error("El acuse de recibo no salió; la respuesta sí está guardada:", error);
+  }
+
   redirect(`${base}?enviado=1`);
 }
 
@@ -166,4 +192,71 @@ export async function reabrir(datos: FormData): Promise<void> {
 
   await guardarBorrador(borrador);
   redirect(`${RUTA_RSVP}/${encodeURIComponent(token)}?paso=asistencia`);
+}
+
+/**
+ * BODA-57 · El acuse de recibo.
+ *
+ * Todo lo que puede fallar aquí ya está detrás del `try` de quien llama, y
+ * además cada paso devuelve en lugar de lanzar. Es cinturón y tirantes a
+ * propósito: esta función se ejecuta con un RSVP ya guardado detrás, y ninguna
+ * de las cosas que hace —leer un correo, componer una carta, hablar con
+ * Resend— merece poner en riesgo ese dato.
+ *
+ * SIN CORREO EN LA FICHA NO SE INTENTA, Y NO ES UN ERROR. Es el caso normal
+ * mientras las fichas no lleven correo, y anotarlo como fallo llenaría el
+ * registro de ruido que nadie puede arreglar.
+ */
+async function mandarAcuseDeRecibo(
+  token: string,
+  invitacion: Invitacion,
+  respuestas: RespuestaInvitado[],
+): Promise<void> {
+  const para = await destinatariosDeConfirmacion(token);
+  if (para.length === 0) return;
+
+  const configuracion = await obtenerConfiguracion();
+  if (!configuracion) return;
+
+  /*
+    QUIÉN VIENE SALE DE `respuestas`, NO DE `invitacion`.
+
+    `invitacion` se leyó al entrar en la acción, ANTES de escribir: sus estados
+    son los de antes de contestar. Componer la carta con ella mandaba «os
+    echaremos de menos» a quien acababa de confirmar — lo cazó el test del
+    buzón, y habría llegado a todos los invitados con correo en la ficha.
+
+    `respuestas` es literalmente lo que se acaba de guardar, así que la carta
+    dice lo mismo que la base. Los nombres sí salen de `invitacion`, que es
+    donde están, cruzándolos por id.
+  */
+  const nombrePorId = new Map(
+    invitacion.personas.map((persona) => [
+      persona.id,
+      [persona.nombre, persona.apellidos].filter(Boolean).join(" "),
+    ]),
+  );
+  const nombresCon = (estado: string) =>
+    respuestas
+      .filter((respuesta) => respuesta.estado === estado)
+      .map((respuesta) => nombrePorId.get(respuesta.invitado_id) ?? "")
+      .filter(Boolean);
+
+  const carta = componerConfirmacion({
+    vienen: nombresCon("confirmado"),
+    noVienen: nombresCon("rechazado"),
+    enlace: `${urlDelSitio()?.origin ?? ""}${RUTA_RSVP}/${encodeURIComponent(token)}`,
+    fechaLimite: configuracion.fechaLimiteRsvp,
+    nombreNovia: configuracion.nombreNovia,
+    nombreNovio: configuracion.nombreNovio,
+  });
+
+  const resultado = await enviarCorreo({ para, ...carta });
+
+  // Queda registrado, que es lo que pide el ticket. Un fallo del proveedor no
+  // se le cuenta al invitado —ya ha contestado, y no es problema suyo— pero
+  // tiene que poder verse en el registro del servidor.
+  if (resultado.estado === "fallo") {
+    console.error("El acuse de recibo no salió:", resultado.motivo);
+  }
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -148,3 +148,13 @@ export const MAXIMO_FILAS_IMPORTACION = 500;
 
 /** La lista de quien no ha contestado. La escriben el panel y su test. */
 export const RUTA_PENDIENTES = "/panel/invitados/pendientes";
+
+/**
+ * A dónde se mandan los correos.
+ *
+ * Configurable a propósito, y no porque vaya a cambiar de proveedor: es lo que
+ * permite que el test del camino feliz apunte a un buzón de pruebas y lea lo
+ * que se mandó de verdad. Sin esto, comprobar el envío exigiría una clave real
+ * en CI o un mock de nuestro propio código, que no probaría que el correo sale.
+ */
+export const URL_RESEND = process.env.RESEND_URL ?? "https://api.resend.com";

--- a/src/lib/bbdd/rsvp.ts
+++ b/src/lib/bbdd/rsvp.ts
@@ -236,3 +236,26 @@ function motivoDe(error: unknown): "plazo" | "intentos" | "respuestas" | "averia
 }
 
 export { ErrorDeLectura };
+
+/**
+ * A quién mandarle el acuse de recibo de este grupo.
+ *
+ * Devuelve lista vacía cuando nadie tiene correo en su ficha, que NO es un
+ * error: es el caso normal mientras los correos no se hayan ido rellenando. El
+ * ticket lo dice con todas las letras —«sin correo en la ficha, no se intenta
+ * enviar y no se marca como error»— y por eso esto no lanza.
+ */
+export async function destinatariosDeConfirmacion(token: string): Promise<string[]> {
+  try {
+    const filas = await llamarComoAnonimo(
+      (tx) => tx<{ destinatarios_confirmacion: string }[]>`
+        select public.destinatarios_confirmacion(${token})
+      `,
+    );
+    return filas.map((fila) => fila.destinatarios_confirmacion).filter(Boolean);
+  } catch (error) {
+    // Ni esto puede tumbar un RSVP ya guardado. Se anota y se sigue sin correo.
+    console.error("No se pudieron leer los destinatarios del acuse:", error);
+    return [];
+  }
+}

--- a/src/lib/correo-confirmacion.ts
+++ b/src/lib/correo-confirmacion.ts
@@ -1,0 +1,123 @@
+import { IDIOMA, ZONA_HORARIA } from "@/config/constants";
+import { t } from "@/lib/copy";
+
+/**
+ * BODA-57 · LA CARTA DEL ACUSE DE RECIBO
+ *
+ * Se compone aquí y no en la acción por una razón práctica: así se puede probar
+ * entera —qué pone, que lleva el enlace, que la versión de texto no se olvida
+ * nada— sin base de datos, sin navegador y sin mandar un solo correo.
+ *
+ * LAS DOS VERSIONES SE ESCRIBEN JUNTAS, y por eso no se separan en dos
+ * funciones. Un correo con HTML y sin texto plano se pinta mal en los clientes
+ * que no lo soportan y tiene bastantes más papeletas de acabar en spam; y dos
+ * funciones distintas acaban contando cosas distintas en cuanto una se toque.
+ * Aquí las dos salen del mismo dato, en el mismo sitio, o no salen.
+ */
+
+export interface DatosConfirmacion {
+  vienen: string[];
+  noVienen: string[];
+  enlace: string;
+  fechaLimite: Date | null;
+  nombreNovia: string;
+  nombreNovio: string;
+}
+
+export interface CartaConfirmacion {
+  asunto: string;
+  html: string;
+  texto: string;
+}
+
+const formatoFecha = new Intl.DateTimeFormat(IDIOMA, {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+  timeZone: ZONA_HORARIA,
+});
+
+/** Escapa lo que va dentro del HTML: los nombres los escribe cualquiera. */
+function seguro(texto: string): string {
+  return texto
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function componerConfirmacion(datos: DatosConfirmacion): CartaConfirmacion {
+  const alguienViene = datos.vienen.length > 0;
+
+  const plazo = datos.fechaLimite
+    ? t("correoConfirmacion.plazo", { fecha: formatoFecha.format(datos.fechaLimite) })
+    : t("correoConfirmacion.sinPlazo");
+
+  const firma = t("correoConfirmacion.firma", {
+    novia: datos.nombreNovia,
+    novio: datos.nombreNovio,
+  });
+
+  const lineas: string[] = [
+    t("correoConfirmacion.saludo"),
+    "",
+    alguienViene ? t("correoConfirmacion.cuerpoSi") : t("correoConfirmacion.cuerpoNo"),
+  ];
+
+  if (datos.vienen.length > 0) {
+    lineas.push("", `${t("correoConfirmacion.vienen")}: ${datos.vienen.join(", ")}`);
+  }
+  if (datos.noVienen.length > 0) {
+    lineas.push("", `${t("correoConfirmacion.noVienen")}: ${datos.noVienen.join(", ")}`);
+  }
+
+  lineas.push(
+    "",
+    t("correoConfirmacion.cambiar"),
+    datos.enlace,
+    "",
+    plazo,
+    "",
+    t("correoConfirmacion.despedida"),
+    firma,
+  );
+
+  const parrafos: string[] = [
+    `<p>${seguro(t("correoConfirmacion.saludo"))}</p>`,
+    `<p>${seguro(
+      alguienViene ? t("correoConfirmacion.cuerpoSi") : t("correoConfirmacion.cuerpoNo"),
+    )}</p>`,
+  ];
+
+  if (datos.vienen.length > 0) {
+    parrafos.push(
+      `<p><strong>${seguro(t("correoConfirmacion.vienen"))}:</strong> ${seguro(datos.vienen.join(", "))}</p>`,
+    );
+  }
+  if (datos.noVienen.length > 0) {
+    parrafos.push(
+      `<p><strong>${seguro(t("correoConfirmacion.noVienen"))}:</strong> ${seguro(datos.noVienen.join(", "))}</p>`,
+    );
+  }
+
+  /*
+    EL ENLACE VA COMO TEXTO ADEMÁS DE COMO ENLACE.
+
+    Muchos clientes de correo no pintan los `<a>` en la vista previa, y algunos
+    los desactivan del todo en remitentes desconocidos. Con la dirección escrita
+    entera se puede copiar a mano, que es feo pero funciona — y este enlace es
+    justo el que evita el «¿cómo cambio mi respuesta?».
+  */
+  parrafos.push(
+    `<p>${seguro(t("correoConfirmacion.cambiar"))}<br>` +
+      `<a href="${seguro(datos.enlace)}">${seguro(datos.enlace)}</a></p>`,
+    `<p>${seguro(plazo)}</p>`,
+    `<p>${seguro(t("correoConfirmacion.despedida"))}<br>${seguro(firma)}</p>`,
+  );
+
+  return {
+    asunto: alguienViene ? t("correoConfirmacion.asuntoSi") : t("correoConfirmacion.asuntoNo"),
+    texto: lineas.join("\n"),
+    html: parrafos.join("\n"),
+  };
+}

--- a/src/lib/correo.ts
+++ b/src/lib/correo.ts
@@ -1,0 +1,81 @@
+import "server-only";
+
+import { URL_RESEND } from "@/config/constants";
+
+/**
+ * MANDAR UN CORREO
+ *
+ * El transporte, y nada más: quién escribe y qué pone lo deciden otros. Aquí
+ * sólo se hace la petición y se cuenta si salió.
+ *
+ * NUNCA LANZA. Es la regla de este módulo y viene del criterio del ticket: «si
+ * el envío falla, la respuesta ya está guardada». Un correo es un acuse de
+ * recibo, no la respuesta — que una caída de Resend tumbara una confirmación
+ * sería perder el dato que importa por no poder mandar el que no.
+ *
+ * LA URL SALE DE LA CONFIGURACIÓN, y no es un capricho de arquitectura: es lo
+ * que permite que el test del camino feliz apunte a un buzón de pruebas y lea
+ * lo que se mandó de verdad. Sin eso, comprobar el envío exigiría o una clave
+ * real en CI o un mock de nuestro propio código —que probaría que sabemos
+ * llamar a nuestra función, no que el correo sale—.
+ */
+
+const CLAVE = process.env.RESEND_API_KEY;
+const REMITENTE = process.env.CORREO_REMITENTE;
+
+/** `false` si falta configuración: entonces no se intenta, y no es un error. */
+export const hayCorreo = Boolean(CLAVE && REMITENTE);
+
+export interface Correo {
+  para: string[];
+  asunto: string;
+  html: string;
+  /**
+   * La misma carta en texto plano. No es un extra: hay clientes que no pintan
+   * HTML, y un correo sin alternativa de texto tiene bastantes más papeletas de
+   * acabar en la carpeta de spam.
+   */
+  texto: string;
+}
+
+export type ResultadoCorreo =
+  | { estado: "enviado"; id: string }
+  | { estado: "sin-configurar" }
+  | { estado: "sin-destinatario" }
+  | { estado: "fallo"; motivo: string };
+
+export async function enviarCorreo(correo: Correo): Promise<ResultadoCorreo> {
+  if (!hayCorreo) return { estado: "sin-configurar" };
+  if (correo.para.length === 0) return { estado: "sin-destinatario" };
+
+  try {
+    const respuesta = await fetch(`${URL_RESEND}/emails`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${CLAVE}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        from: REMITENTE,
+        to: correo.para,
+        subject: correo.asunto,
+        html: correo.html,
+        text: correo.texto,
+      }),
+    });
+
+    if (!respuesta.ok) {
+      // El cuerpo del error entero: el motivo que da Resend —dominio sin
+      // verificar, clave caducada— es lo único que dice qué hay que arreglar.
+      const detalle = await respuesta.text().catch(() => "");
+      return { estado: "fallo", motivo: `${respuesta.status} ${detalle}`.trim() };
+    }
+
+    const datos = (await respuesta.json().catch(() => ({}))) as { id?: string };
+    return { estado: "enviado", id: datos.id ?? "" };
+  } catch (error) {
+    // Aquí caen las caídas de red y los tiempos de espera. Se convierte en
+    // resultado, no en excepción: quien llama está a medio guardar un RSVP.
+    return { estado: "fallo", motivo: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/supabase/migrations/20260810200000_correo_confirmacion.sql
+++ b/supabase/migrations/20260810200000_correo_confirmacion.sql
@@ -1,0 +1,40 @@
+-- ============================================================================
+-- BODA-57 · Correo de confirmación al invitado
+--
+-- El acuse de recibo que evita el «¿te llegó mi confirmación?».
+--
+-- HACE FALTA UNA PUERTA NUEVA Y ESTRECHA. `obtener_invitacion()` enumera sus
+-- columnas a mano y NO devuelve los correos, y está bien que no lo haga: es lo
+-- que impide que un invitado reciba los datos de contacto de sus coinvitados
+-- sólo por abrir su enlace. Pero para mandar el acuse hace falta una dirección.
+--
+-- Así que esto devuelve UNA COSA Y NADA MÁS: las direcciones del grupo de ese
+-- token. Sin nombres, sin decir de quién es cada una, y sólo del propio grupo.
+-- Quien tiene el token es de la familia; lo que no puede es enterarse de nada
+-- que no supiera ya.
+--
+-- Rollback: supabase/migrations/rollback/20260810200000_correo_confirmacion.sql
+-- ============================================================================
+
+create or replace function public.destinatarios_confirmacion(p_token text)
+returns setof text
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  select distinct i.correo_electronico
+    from public.invitados as i
+    join public.grupos_invitacion as g on g.id = i.grupo_id
+   where g.huella_token = public.huella_token(p_token)
+     and i.correo_electronico is not null;
+$function$;
+
+comment on function public.destinatarios_confirmacion(text) is
+  'Las direcciones a las que mandar el acuse de recibo de un grupo, y nada más: '
+  'ni nombres ni de quién es cada una. `obtener_invitacion()` no las devuelve a '
+  'propósito —un invitado no tiene por qué recibir los datos de contacto de sus '
+  'coinvitados— y esta puerta existe para el envío, no para la pantalla.';
+
+revoke all on function public.destinatarios_confirmacion(text) from public, anon, authenticated;
+grant execute on function public.destinatarios_confirmacion(text) to anon, authenticated;

--- a/supabase/migrations/rollback/20260810200000_correo_confirmacion.sql
+++ b/supabase/migrations/rollback/20260810200000_correo_confirmacion.sql
@@ -1,0 +1,7 @@
+-- Rollback de 20260810200000_correo_confirmacion.sql
+--
+-- Sólo quita la función. Sin ella el acuse de recibo no encuentra a quién
+-- escribir y no se manda nada, que es exactamente lo que hace hoy cuando la
+-- ficha no tiene correo: no es un error, es que no hay a quién.
+
+drop function if exists public.destinatarios_confirmacion(text);

--- a/tests/e2e/correo-confirmacion.spec.ts
+++ b/tests/e2e/correo-confirmacion.spec.ts
@@ -1,0 +1,201 @@
+import { createServer, type Server } from "node:http";
+
+import { expect, test } from "@playwright/test";
+import postgres from "postgres";
+
+import copy from "../../content/copy.es.json";
+import { RUTA_RSVP } from "../../src/config/constants";
+
+/**
+ * BODA-57 · Correo de confirmación al invitado
+ *
+ * EL BUZÓN DE CAPTURA NO ES UN MOCK. Es un servidor HTTP de verdad escuchando
+ * en el puerto al que apunta `RESEND_URL` durante los tests: la aplicación hace
+ * su petición real, con su cabecera de autorización y su cuerpo JSON, y aquí se
+ * lee exactamente lo que salió. Simular `enviarCorreo()` probaría que sabemos
+ * llamar a nuestra propia función; esto prueba que el correo sale y qué lleva.
+ *
+ * El caso de error —proveedor caído— no necesita nada: el puerto está cerrado
+ * por defecto en toda la suite, así que basta con no levantar el buzón.
+ */
+
+const cadena = process.env.DATABASE_URL;
+const PUERTO_BUZON = 54999;
+
+interface CorreoCapturado {
+  from: string;
+  to: string[];
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const recibidos: CorreoCapturado[] = [];
+let buzon: Server | undefined;
+
+async function levantarBuzon(): Promise<void> {
+  recibidos.length = 0;
+  buzon = createServer((peticion, respuesta) => {
+    let cuerpo = "";
+    peticion.on("data", (trozo) => (cuerpo += trozo));
+    peticion.on("end", () => {
+      try {
+        recibidos.push(JSON.parse(cuerpo) as CorreoCapturado);
+      } catch {
+        // Un cuerpo ilegible es un fallo del test, no del envío: se ignora
+        // aquí y lo delata la comprobación de que no llegó nada.
+      }
+      respuesta.writeHead(200, { "content-type": "application/json" });
+      respuesta.end(JSON.stringify({ id: "correo-de-pruebas" }));
+    });
+  });
+
+  await new Promise<void>((listo) => buzon!.listen(PUERTO_BUZON, "127.0.0.1", listo));
+}
+
+async function bajarBuzon(): Promise<void> {
+  if (!buzon) return;
+  await new Promise<void>((listo) => buzon!.close(() => listo()));
+  buzon = undefined;
+}
+
+async function conBase<T>(trabajo: (sql: postgres.Sql) => Promise<T>): Promise<T> {
+  const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
+  try {
+    return await trabajo(sql);
+  } finally {
+    await sql.end();
+  }
+}
+
+/** Un grupo sin contestar. Con correo en la ficha, o sin él. */
+async function crearGrupo(sufijo: string, correo: string | null): Promise<string> {
+  const token = `desarrollo-correo-${sufijo}-000000`;
+  await conBase(async (sql) => {
+    const [grupo] = await sql<{ id: string }[]>`
+      insert into public.grupos_invitacion (nombre, huella_token)
+      values (${`(DES) Correo ${sufijo}`}, public.huella_token(${token}))
+      returning id
+    `;
+    await sql`
+      insert into public.invitados (grupo_id, nombre, apellidos, correo_electronico)
+      values (${grupo.id}, ${`(DES) Persona ${sufijo}`}, '(DES)', ${correo})
+    `;
+  });
+  return token;
+}
+
+async function contarConfirmados(token: string): Promise<number> {
+  const [fila] = await conBase(
+    (sql) => sql<{ cuantos: number }[]>`
+      select count(*)::int as cuantos
+        from public.confirmaciones as c
+        join public.invitados as i on i.id = c.invitado_id
+        join public.grupos_invitacion as g on g.id = i.grupo_id
+       where g.huella_token = public.huella_token(${token})
+         and c.es_vigente
+         and c.estado = 'confirmado'
+    `,
+  );
+  return fila.cuantos;
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("El acuse de recibo", () => {
+  test.skip(!cadena, "Hace falta DATABASE_URL.");
+
+  test.afterEach(async () => {
+    await bajarBuzon();
+  });
+
+  test("al confirmar sale el correo, con lo respondido y el enlace para cambiarlo", async ({
+    browser,
+  }) => {
+    await levantarBuzon();
+
+    const correo = `invitada-${Date.now()}@ejemplo.test`;
+    const token = await crearGrupo(`feliz-${Date.now()}`, correo);
+
+    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const pagina = await contexto.newPage();
+    await pagina.goto(`${RUTA_RSVP}/${token}`);
+    await pagina.locator('input[value="confirmado"]').first().check();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.enviar }).click();
+    await expect(pagina.getByRole("heading", { level: 1 })).toHaveText(copy.rsvp.graciasSi);
+    await contexto.close();
+
+    // El envío va después de redirigir, así que se espera a que llegue.
+    await expect(() => expect(recibidos).toHaveLength(1)).toPass({ timeout: 10_000 });
+
+    const [enviado] = recibidos;
+    expect(enviado.to).toContain(correo);
+    expect(enviado.subject).toBe(copy.correoConfirmacion.asuntoSi);
+
+    // Lleva quién viene, el enlace para cambiarlo y la fecha límite.
+    expect(enviado.html).toContain("(DES) Persona");
+    expect(enviado.html).toContain(`${RUTA_RSVP}/${token}`);
+
+    // Y la misma carta en texto plano, que no es un extra: hay clientes que no
+    // pintan HTML, y un correo sin ella tiene más papeletas de acabar en spam.
+    expect(enviado.text).toContain(`${RUTA_RSVP}/${token}`);
+    expect(enviado.text).toContain(copy.correoConfirmacion.despedida);
+    expect(enviado.text).not.toContain("<p>");
+  });
+
+  /**
+   * CASO DE ERROR · CON EL PROVEEDOR CAÍDO, LA RESPUESTA SE GUARDA IGUAL.
+   *
+   * No se levanta el buzón: el puerto de `RESEND_URL` está cerrado, así que la
+   * petición falla de verdad. Es el criterio del ticket, y el que de verdad
+   * protege algo: un acuse de recibo no puede costar una confirmación.
+   */
+  test("con el proveedor caído, la confirmación se guarda igual", async ({ browser }) => {
+    const token = await crearGrupo(`caido-${Date.now()}`, `caido-${Date.now()}@ejemplo.test`);
+
+    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const pagina = await contexto.newPage();
+    await pagina.goto(`${RUTA_RSVP}/${token}`);
+    await pagina.locator('input[value="confirmado"]').first().check();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.enviar }).click();
+
+    // El invitado ve lo de siempre: ya ha contestado, y que el acuse no salga
+    // no es un problema suyo ni puede resolverlo.
+    await expect(pagina.getByRole("heading", { level: 1 })).toHaveText(copy.rsvp.graciasSi);
+    await contexto.close();
+
+    // Y lo que importa está en la base.
+    expect(await contarConfirmados(token)).toBe(1);
+  });
+
+  /**
+   * CASO DE ERROR · Sin correo en la ficha no se intenta, y no es un fallo.
+   */
+  test("sin correo en la ficha no se manda nada, y la respuesta se guarda", async ({
+    browser,
+  }) => {
+    await levantarBuzon();
+
+    const token = await crearGrupo(`sin-correo-${Date.now()}`, null);
+
+    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const pagina = await contexto.newPage();
+    await pagina.goto(`${RUTA_RSVP}/${token}`);
+    await pagina.locator('input[value="confirmado"]').first().check();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.siguiente }).click();
+    await pagina.getByRole("button", { name: copy.rsvp.enviar }).click();
+    await expect(pagina.getByRole("heading", { level: 1 })).toHaveText(copy.rsvp.graciasSi);
+    await contexto.close();
+
+    expect(await contarConfirmados(token)).toBe(1);
+
+    // El buzón está levantado y escuchando: si llegara algo, sería a una
+    // dirección que nadie ha escrito.
+    expect(recibidos, "sin correo en la ficha no se manda nada").toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Qué cambia

Al confirmar, quien tenga correo en su ficha recibe un acuse de recibo con lo que ha respondido y el enlace para cambiarlo.

Closes #44

## Cómo probarlo en el preview

Hace falta poner `RESEND_API_KEY` y `CORREO_REMITENTE` en Vercel (ver `docs/ENTORNO.md`). Sin ellas no se manda nada y no pasa nada más — es el comportamiento correcto, no un fallo.

1. Poner un correo en la ficha de una persona, desde el panel.
2. Contestar desde el enlace de esa invitación.
3. Llega el correo con quién viene, el enlace para cambiar la respuesta y la fecha límite.
4. Contestar desde una invitación **sin** correo en la ficha: la respuesta se guarda y no se manda nada.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: el cuerpo del correo en `content/copy.es.json`, la URL del proveedor en `src/config/constants.ts`
- [x] Test E2E incluido: camino feliz **y** dos casos de error
- [ ] CI verde entero — en local pasan 186 unitarios y 123 E2E de escritorio, incluidos los tres de este ticket
- [x] Responsive: no toca pantallas
- [x] Accesible: el correo va en HTML **y** en texto plano
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview — no puedo: `vercel.app` está bloqueado por la política de salida de este contenedor

### El buzón de captura no es un mock, y menos mal

El test del camino feliz levanta un **servidor HTTP de verdad** en el puerto al que apunta `RESEND_URL` durante los tests. La aplicación hace su petición real, con su cabecera de autorización y su cuerpo JSON, y el test lee exactamente lo que salió. Simular `enviarCorreo()` habría probado que sabemos llamar a nuestra propia función.

Y sirvió para algo: **cazó un fallo que habría llegado a todos los invitados con correo en la ficha**. La carta se componía con la invitación leída al *entrar* en la acción —o sea, antes de escribir— así que sus estados eran los de antes de contestar, y el asunto que salía era «Recibido, os echaremos de menos» para quien acababa de confirmar. Ahora se compone con lo que se acaba de guardar.

### El orden de las líneas es el criterio del ticket

El envío va **después** de guardar y entero dentro de un `try`. Un correo es el acuse, no la respuesta: que una caída de Resend tumbara una confirmación sería perder el dato que importa por no poder mandar el que no. Al invitado no se le cuenta nada — ya ha contestado, y un fallo del proveedor no es un problema suyo ni puede resolverlo. El fallo queda en el registro del servidor.

Por defecto **toda la suite apunta a un puerto cerrado**. Es deliberado: así el camino de «el proveedor no responde» se recorre en cada ejecución y no sólo en el test que lo busca. Si algún día un fallo de correo tumbara una confirmación, se caerían veinte tests a la vez en lugar de ninguno.

### Una puerta nueva, y estrecha

`obtener_invitacion()` no devuelve los correos a propósito: es lo que impide que un invitado reciba los datos de contacto de sus coinvitados sólo por abrir su enlace. Esa decisión no se toca. `destinatarios_confirmacion()` devuelve **las direcciones del grupo y nada más** —sin nombres y sin decir de quién es cada una— y existe para el envío, no para la pantalla.

## Base de datos

- [ ] No la toca
- [x] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [ ] No hace falta
- [x] `docs/ENTORNO.md` actualizado en esta misma PR, con las dos variables y por qué `RESEND_URL` **no** hay que ponerla en Vercel

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_