### PR TITLE
Producción: IBAN fuera del HTML, buscadores, toque a la base y copias

### DIFF
--- a/.github/workflows/copia-seguridad.yml
+++ b/.github/workflows/copia-seguridad.yml
@@ -1,0 +1,85 @@
+# BODA-94 · Copia de seguridad diaria
+#
+# La lista de invitados con sus alergias y sus teléfonos no se puede volver a
+# pedir: son doscientas conversaciones. El plan gratuito de Supabase no guarda
+# copias por ti.
+#
+# EL DESTINO ES UN REPOSITORIO PRIVADO Y VA POR VARIABLES, nunca escrito aquí.
+# Hacen falta dos cosas configuradas en este repositorio:
+#
+#   · Variable  REPO_COPIAS   → «usuario/repo-privado-de-copias»
+#   · Secreto   TOKEN_COPIAS  → un token con permiso de escritura en ese repo
+#   · Secreto   DATABASE_URL  → la conexión a la base de producción
+#
+# Sin ellos el flujo falla y lo dice. No se salta en silencio: una copia que no
+# se hace y no avisa es exactamente lo mismo que no tener copia, sólo que con
+# la tranquilidad de creer que se tiene.
+name: Copia de seguridad
+
+on:
+  schedule:
+    # De madrugada, cuando nadie está tocando el panel.
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  copia:
+    name: Volcar y guardar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Comprobar que hay a dónde copiar
+        env:
+          REPO_COPIAS: ${{ vars.REPO_COPIAS }}
+          TOKEN_COPIAS: ${{ secrets.TOKEN_COPIAS }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          faltan=""
+          [ -z "$REPO_COPIAS" ]  && faltan="$faltan REPO_COPIAS(variable)"
+          [ -z "$TOKEN_COPIAS" ] && faltan="$faltan TOKEN_COPIAS(secreto)"
+          [ -z "$DATABASE_URL" ] && faltan="$faltan DATABASE_URL(secreto)"
+          if [ -n "$faltan" ]; then
+            echo "Falta configurar:$faltan" >&2
+            echo "Ver docs/ENTORNO.md, apartado «Copia de seguridad»." >&2
+            exit 1
+          fi
+
+      - name: Instalar PostgreSQL
+        # Para tener `pg_dump`, y de la misma versión mayor que el servidor:
+        # un `pg_dump` más viejo que la base se niega a volcarla.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Traer el repositorio de copias
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.REPO_COPIAS }}
+          token: ${{ secrets.TOKEN_COPIAS }}
+          path: destino
+
+      - name: Volcar
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECTORIO_COPIAS: destino/copias
+        run: ./scripts/copia-de-seguridad.sh
+
+      - name: Guardar los últimos treinta días
+        working-directory: destino
+        run: |
+          # Varios días y no sólo el último: un borrado se detecta tarde, y una
+          # copia que sobrescribe la de ayer copia también el borrado.
+          ls -1 copias/*.dump 2>/dev/null | sort | head -n -30 | xargs -r rm --
+
+          git config user.name "Copias de la boda"
+          git config user.email "copias@users.noreply.github.com"
+          git add copias
+          # Sin cambios no se commitea: el volcado del mismo día se repite igual
+          # si el flujo se lanza dos veces, y un commit vacío falla.
+          if git diff --cached --quiet; then
+            echo "La copia de hoy ya estaba guardada."
+          else
+            git commit -m "Copia de $(date -u +%Y-%m-%d)"
+            git push
+          fi

--- a/.github/workflows/mantener-viva.yml
+++ b/.github/workflows/mantener-viva.yml
@@ -1,0 +1,40 @@
+# BODA-95 · Que Supabase no pause el proyecto
+#
+# El plan gratuito pausa los proyectos que pasan una semana sin actividad, y
+# entre la reserva de fecha y las primeras confirmaciones puede haber meses de
+# silencio. Este flujo le da un toque a la base para que ese contador no llegue
+# nunca a la semana.
+#
+# CADA TRES DÍAS Y NO CADA SEIS. El límite es de siete, así que con seis un
+# solo fallo —GitHub retrasa los flujos programados cuando hay carga, y puede
+# saltárselos— dejaría pasar la semana. Con tres, tienen que fallar dos
+# seguidos para que haya problema.
+name: Mantener viva la base
+
+on:
+  schedule:
+    # Minuto 17 y no en punto: las horas redondas son cuando GitHub tiene la
+    # cola llena de flujos de todo el mundo y más retrasa los programados.
+    - cron: "17 6 */3 * *"
+  # Para poder comprobarlo a mano sin esperar tres días, que es el camino
+  # feliz que pide el ticket.
+  workflow_dispatch:
+
+jobs:
+  toque:
+    name: Dar un toque a la base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Leer una fila
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: node scripts/mantener-viva-la-base.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ next-env.d.ts
 /playwright-report
 /test-results
 /.playwright
+copias-de-prueba/
+copias/

--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -112,7 +112,11 @@
     "etiquetaCuenta": "Número de cuenta",
     "copiar": "Copiar",
     "copiado": "Copiado",
-    "buzon": "También habrá un buzón en la entrada del invernadero."
+    "buzon": "También habrá un buzón en la entrada del invernadero.",
+    "revelar": "Ver el número de cuenta",
+    "revelando": "Un momento…",
+    "errorRevelar": "No hemos podido cargarlo. Probad de nuevo en un momento.",
+    "sinJavascript": "Para ver el número de cuenta hace falta JavaScript. Si no podéis activarlo, escribidnos y os lo mandamos."
   },
   "dresscode": {
     "etiqueta": "Qué ponerse",

--- a/docs/ENTORNO.md
+++ b/docs/ENTORNO.md
@@ -189,3 +189,35 @@ defecto apunta a la API de Resend. Existe para que los tests puedan levantar un
 buzón de captura y leer el correo que sale de verdad, en lugar de simular
 nuestra propia función de envío —que probaría que sabemos llamarla, no que el
 correo sale—.
+
+## Copia de seguridad
+
+El flujo `copia-seguridad.yml` vuelca la base cada madrugada a un repositorio
+**privado** aparte. Hace falta configurar tres cosas en este repositorio:
+
+| Dónde                | Nombre         | Qué es                                           |
+| -------------------- | -------------- | ------------------------------------------------ |
+| Settings → Variables | `REPO_COPIAS`  | `usuario/repo-privado`, el destino de las copias |
+| Settings → Secrets   | `TOKEN_COPIAS` | Un token con permiso de escritura en ese repo    |
+| Settings → Secrets   | `DATABASE_URL` | La conexión a la base de producción              |
+
+**El repositorio de destino tiene que ser privado.** Un volcado lleva los
+nombres, los teléfonos y las alergias de doscientas personas: en un repositorio
+público, eso es publicarlo.
+
+Se guardan los treinta últimos días y no sólo el último, porque un borrado se
+detecta tarde — y una copia que sobrescribe la de ayer copia también el
+borrado.
+
+Si falta cualquiera de las tres, el flujo **falla y lo dice**. No se salta en
+silencio: una copia que no se hace y no avisa es lo mismo que no tener copia,
+sólo que con la tranquilidad de creer que se tiene.
+
+### Restaurar
+
+`pg_restore --no-owner --no-privileges --dbname="<destino>" copias/boda-<fecha>.dump`
+
+La restauración está probada en `tests/unidad/copia-seguridad.test.ts`, y no
+sólo el volcado: el test restaura en una base vacía y comprueba que vuelven las
+filas **y las políticas RLS**. Sin esa segunda mitad, una copia podría devolver
+la lista de invitados a una base donde la lee cualquiera.

--- a/scripts/copia-de-seguridad.sh
+++ b/scripts/copia-de-seguridad.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# BODA-94 · La copia de seguridad
+#
+# La lista de invitados con sus alergias y sus teléfonos no se puede volver a
+# pedir: son doscientas conversaciones. El plan gratuito de Supabase no guarda
+# copias por ti, así que si alguien borra una tabla sin querer, no hay a dónde
+# volver.
+#
+# EL VOLCADO ES DE ESQUEMA **Y** DATOS, y ahí está la diferencia entre una copia
+# y una copia que sirve. Un volcado de sólo datos restaura los invitados en una
+# base sin políticas RLS: la lista estaría ahí, y también a la vista de
+# cualquiera. Lo que hay que poder reconstruir es la base entera, protecciones
+# incluidas.
+#
+# EN FORMATO PERSONALIZADO (`-Fc`) y no en SQL plano: `pg_restore` puede
+# entonces restaurar tabla a tabla, que es lo que hace falta cuando lo que se
+# perdió fue una sola. Con un `.sql` la única opción es todo o nada.
+#
+# Se imprime por la salida estándar la ruta del fichero, para poder hacer:
+#
+#     FICHERO="$(./scripts/copia-de-seguridad.sh)"
+
+set -euo pipefail
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "Falta DATABASE_URL: no hay base que copiar." >&2
+  exit 1
+fi
+
+DESTINO="${DIRECTORIO_COPIAS:-copias}"
+BIN="$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | sort -V | tail -1 || true)"
+[ -n "$BIN" ] && export PATH="$BIN:$PATH"
+
+mkdir -p "$DESTINO"
+
+# La fecha va en el nombre y en UTC: un fichero por día, ordenable por nombre,
+# y sin depender de la zona horaria de quien lo ejecute.
+FECHA="$(date -u +%Y-%m-%d)"
+FICHERO="$DESTINO/boda-$FECHA.dump"
+
+# `--no-owner` y `--no-privileges`: los roles de Supabase no existen en la base
+# donde se restaure, y sin esto `pg_restore` se llena de errores por cada
+# `alter owner` que no puede aplicar. Las POLÍTICAS RLS sí van dentro —son
+# parte del esquema— que es lo que de verdad hay que recuperar.
+pg_dump "$DATABASE_URL" \
+  --format=custom \
+  --no-owner \
+  --no-privileges \
+  --schema=public \
+  --file="$FICHERO" >&2
+
+# Un volcado vacío es el fallo silencioso de este guion: el comando sale con
+# cero, el fichero existe, y dentro no hay nada. Se comprueba que pesa algo
+# antes de dar la copia por buena.
+TAMANO="$(wc -c <"$FICHERO")"
+if [ "$TAMANO" -lt 1024 ]; then
+  echo "La copia pesa $TAMANO bytes: eso no es una base de datos." >&2
+  exit 1
+fi
+
+echo "$FICHERO"

--- a/scripts/mantener-viva-la-base.mjs
+++ b/scripts/mantener-viva-la-base.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * BODA-95 · QUE SUPABASE NO PAUSE EL PROYECTO
+ *
+ * El plan gratuito pausa los proyectos que pasan una semana sin actividad.
+ * Entre que se manda la reserva de fecha y que empiezan a llegar las
+ * confirmaciones puede haber meses de silencio — y la web se caería justo
+ * cuando alguien por fin entra a confirmar. Esto le da un toque a la base cada
+ * pocos días para que el contador no llegue nunca a la semana.
+ *
+ * LA CONSULTA NO ESCRIBE NADA, y es a propósito. Un `insert` de prueba dejaría
+ * basura que alguien tendría que limpiar, y un `update` sobre una fila de
+ * verdad tocaría `actualizado_en` y ensuciaría cualquier consulta que mire
+ * cuándo cambió algo. Se lee una fila y se tira.
+ *
+ * Y SE LEE UNA TABLA DEL PROYECTO, no `select 1`. Un `select 1` lo contesta
+ * PostgreSQL sin tocar nada nuestro: diría que la base responde aunque el
+ * esquema estuviera vacío o los permisos rotos. Leer `configuracion_boda` es
+ * la comprobación mínima que además significa algo.
+ *
+ * FALLA RUIDOSAMENTE. Si esto no puede conectarse, lo más probable es que el
+ * proyecto YA esté pausado, que es exactamente lo que hay que saber. Salir con
+ * cero y un mensajito en el registro convertiría el aviso en nada: el flujo
+ * saldría verde y nadie miraría.
+ */
+
+import postgres from "postgres";
+
+const cadena = process.env.DATABASE_URL;
+
+if (!cadena) {
+  console.error(
+    "Falta DATABASE_URL. Sin ella no hay base a la que dar el toque: " +
+      "configúrala como secreto del repositorio.",
+  );
+  process.exit(1);
+}
+
+const sql = postgres(cadena, {
+  max: 1,
+  prepare: false,
+  // Corto a propósito: si la base no contesta en diez segundos, no es lentitud,
+  // es que no está. Esperar más sólo retrasa el aviso.
+  connect_timeout: 10,
+  idle_timeout: 5,
+  onnotice: () => {},
+});
+
+try {
+  const filas = await sql`select 1 as vive from public.configuracion_boda limit 1`;
+
+  // Cero filas no es un fallo de conexión: la base respondió. Pero sí es raro
+  // —la configuración de la boda no se borra— y merece decirse sin tumbar el
+  // flujo, que lo que vigila es que el proyecto siga despierto.
+  if (filas.length === 0) {
+    console.warn("La base responde, pero `configuracion_boda` está vacía.");
+  }
+
+  console.log("La base está despierta.");
+} catch (error) {
+  console.error(
+    "No se ha podido leer de la base. Si el proyecto es del plan gratuito, " +
+      "lo más probable es que Supabase lo haya pausado y haya que reactivarlo " +
+      "a mano desde su panel.",
+  );
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+} finally {
+  await sql.end({ timeout: 5 });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { Navegacion } from "@/components/marketing/navegacion";
 import { Pie } from "@/components/marketing/pie";
 import { CuentaAtras } from "@/components/marketing/cuenta-atras";
 import { BotonEnlace } from "@/components/ui/boton";
+import { DatosEstructurados } from "@/components/datos-estructurados";
 import { CuentaRegalos } from "@/components/ui/cuenta-regalos";
 import {
   Cita,
@@ -187,6 +188,9 @@ export default async function PaginaInicio() {
 
   return (
     <>
+      {/* Los datos del evento para buscadores y asistentes de voz. */}
+      <DatosEstructurados configuracion={configuracion} nombres={nombres} />
+
       {/* Primer elemento enfocable del documento: quien navega con teclado no
           debería tener que recorrer once enlaces para llegar al contenido. */}
       <a

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { Navegacion } from "@/components/marketing/navegacion";
 import { Pie } from "@/components/marketing/pie";
 import { CuentaAtras } from "@/components/marketing/cuenta-atras";
 import { BotonEnlace } from "@/components/ui/boton";
-import { CampoCopiable } from "@/components/ui/campo-copiable";
+import { CuentaRegalos } from "@/components/ui/cuenta-regalos";
 import {
   Cita,
   Conector,
@@ -33,7 +33,6 @@ import {
   obtenerSecciones,
   type ConfiguracionBoda,
   type ConsejoVestimenta,
-  type CuentaRegalos,
   type Medio,
 } from "@/lib/bbdd/landing";
 import { t } from "@/lib/copy";
@@ -172,7 +171,7 @@ export default async function PaginaInicio() {
       preguntas.length > 0 ? <Preguntas preguntas={preguntas} /> : undefined,
     playlist: <Playlist canciones={canciones} />,
     // Sin cuenta no hay sección: ver el comentario de `Regalos`.
-    regalos: cuentaRegalos ? <Regalos cuenta={cuentaRegalos} /> : undefined,
+    regalos: cuentaRegalos ? <Regalos /> : undefined,
     dresscode: consejos.length > 0 ? <DressCode consejos={consejos} /> : undefined,
     rsvp: <Rsvp configuracion={configuracion} />,
   };
@@ -682,7 +681,7 @@ function Playlist({ canciones }: { canciones: { id: string; texto: string }[] })
  * Una sección de regalos con un hueco donde va el número es peor que no
  * tenerla.
  */
-function Regalos({ cuenta }: { cuenta: CuentaRegalos }) {
+function Regalos() {
   return (
     <Bloque
       seccion="regalos"
@@ -692,16 +691,13 @@ function Regalos({ cuenta }: { cuenta: CuentaRegalos }) {
       realzada
     >
       <div className="mx-auto max-w-estrecho rounded-tarjeta border border-borde bg-superficie-tenue p-elemento">
-        {cuenta.titular ? (
-          <Etiqueta>{t("regalos.titular", { titular: cuenta.titular })}</Etiqueta>
-        ) : null}
-
-        <CampoCopiable
-          valor={cuenta.iban}
-          etiqueta={t("regalos.etiquetaCuenta")}
-          textoCopiar={t("regalos.copiar")}
-          textoCopiado={t("regalos.copiado")}
-        />
+        {/*
+          EL NÚMERO NO ESTÁ AQUÍ, y es el ticket entero. Este componente pinta
+          un botón; el IBAN se pide a `/regalos/cuenta` cuando alguien lo
+          pulsa. Lo que el servidor decide es sólo SI hay cuenta —para no
+          enseñar un botón que no lleva a nada— y eso no revela el número.
+        */}
+        <CuentaRegalos />
 
         <Cuerpo className="mt-elemento text-pequeno">{t("regalos.buzon")}</Cuerpo>
       </div>

--- a/src/app/regalos/cuenta/route.ts
+++ b/src/app/regalos/cuenta/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import { obtenerCuentaRegalos } from "@/lib/bbdd/landing";
+
+/**
+ * BODA-28 · EL NÚMERO DE CUENTA, SÓLO CUANDO SE PIDE
+ *
+ * El criterio del ticket es que el IBAN **no aparezca en el HTML entregado**
+ * hasta que alguien pulse. No es cosmético: un número de cuenta escrito en el
+ * HTML lo indexan los buscadores y lo recogen los rastreadores sin que nadie
+ * haya mirado la página. Pedirlo aparte deja fuera a todo lo que no es una
+ * persona delante de la web.
+ *
+ * NO ES UN SECRETO Y NO SE PRETENDE QUE LO SEA. Quien conozca esta ruta puede
+ * pedirla, igual que cualquiera que abra la sección. Lo que se evita es la
+ * recogida automática y sin intención, que es de lo que se protege un dato así
+ * en una web pública.
+ *
+ * La autorización, como siempre, la hace la base: `datos_para_regalos()`
+ * devuelve cero filas si la sección está apagada o si no hay IBAN, y entonces
+ * esto responde 404. Aquí no se decide nada.
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const cuenta = await obtenerCuentaRegalos();
+
+  if (!cuenta) {
+    return NextResponse.json({ error: "sin-cuenta" }, { status: 404 });
+  }
+
+  return NextResponse.json(cuenta, {
+    headers: {
+      // Ni cachés intermedias ni buscadores: es un dato bancario.
+      "cache-control": "no-store",
+      "x-robots-tag": "noindex, nofollow",
+    },
+  });
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from "next";
+
+import { RUTA_ACCESO, RUTA_PANEL, RUTA_RSVP } from "@/config/constants";
+import { urlDelSitio } from "@/lib/url-sitio";
+
+/**
+ * BODA-92 · LO PÚBLICO SÍ, LO PRIVADO NO
+ *
+ * ESTO ES UNA PETICIÓN, NO UNA INSTRUCCIÓN, y por eso no viene solo. Un
+ * `robots.txt` es un cartel de «no pasar» que cada rastreador decide si
+ * respeta; los que van a por datos personales no lo respetan. Lo que de verdad
+ * cierra la puerta es la cabecera `X-Robots-Tag` que pone `next.config.ts`
+ * sobre estas mismas rutas, y antes que ella el middleware y RLS.
+ *
+ * Entonces, ¿para qué sirve? Para los que sí lo respetan, que son los
+ * buscadores grandes — precisamente los que harían daño de verdad si indexaran
+ * un enlace de invitación. Un token en un resultado de búsqueda es la
+ * invitación de una familia a la vista de cualquiera.
+ *
+ * SE NIEGA POR PREFIJO Y NO POR RUTA EXACTA: `/rsvp/` cubre todos los tokens,
+ * que es justo lo que no se puede enumerar.
+ */
+export default function robots(): MetadataRoute.Robots {
+  const sitio = urlDelSitio();
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [`${RUTA_PANEL}/`, `${RUTA_RSVP}/`, `${RUTA_ACCESO}/`, "/cocina"],
+    },
+    // Sin dominio configurado no se apunta a un sitemap inventado: mejor no
+    // decir nada que mandar a los rastreadores a una URL que no existe.
+    ...(sitio ? { sitemap: new URL("/sitemap.xml", sitio).toString() } : {}),
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,62 @@
+import type { MetadataRoute } from "next";
+
+import { esAncla, rutaDe, type SeccionConRuta } from "@/config/secciones";
+import { obtenerSecciones } from "@/lib/bbdd/landing";
+import { urlDelSitio } from "@/lib/url-sitio";
+
+/**
+ * BODA-92 · EL SITEMAP LLEVA LO PÚBLICO, Y NADA MÁS
+ *
+ * Dos páginas: la landing y la reserva de fecha. El RSVP no está —cada
+ * invitación es una URL distinta con un token dentro, y enumerarlas sería
+ * publicarlas— y el panel tampoco.
+ *
+ * NO ES UNA LISTA ESCRITA A MANO. Las páginas propias salen de
+ * `secciones_landing`, que es quien decide si la reserva de fecha existe: si
+ * está apagada, su ruta devuelve 404 y un sitemap que la citara mandaría a los
+ * buscadores contra una página que no está. Una lista fija se separaría de la
+ * base el primer día que alguien apagara una sección.
+ */
+/**
+ * DINÁMICO, y no por capricho: las páginas salen de `secciones_landing`. Si se
+ * generara en el build, apagar una sección la dejaría en el sitemap hasta el
+ * siguiente despliegue — mandando a los buscadores contra una ruta que ya
+ * devuelve 404. Lo cazó el test.
+ */
+export const dynamic = "force-dynamic";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const sitio = urlDelSitio();
+
+  // Sin dominio no hay URL absoluta que dar, y un sitemap con rutas relativas
+  // no vale para nada. Mejor vacío que mal.
+  if (!sitio) return [];
+
+  const ahora = new Date();
+  const entradas: MetadataRoute.Sitemap = [
+    { url: sitio.origin, lastModified: ahora, changeFrequency: "weekly", priority: 1 },
+  ];
+
+  let secciones;
+  try {
+    secciones = await obtenerSecciones();
+  } catch {
+    // Sin base, al menos la portada. Un sitemap que falla entero deja a la web
+    // sin indexar por una caída de un minuto.
+    return entradas;
+  }
+
+  for (const seccion of secciones) {
+    // Las anclas viven dentro de la landing: no son páginas y no van aquí.
+    // El descarte es además lo que estrecha el tipo: lo que queda tiene ruta.
+    if (esAncla(seccion)) continue;
+    entradas.push({
+      url: new URL(rutaDe(seccion as SeccionConRuta), sitio).toString(),
+      lastModified: ahora,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    });
+  }
+
+  return entradas;
+}

--- a/src/components/datos-estructurados.tsx
+++ b/src/components/datos-estructurados.tsx
@@ -1,0 +1,81 @@
+import { IDIOMA } from "@/config/constants";
+import type { ConfiguracionBoda } from "@/lib/bbdd/landing";
+
+/**
+ * BODA-92 · LOS DATOS DEL EVENTO, EN LENGUAJE DE MÁQUINA
+ *
+ * El mismo dato que ya está en la página, dicho otra vez en un formato que
+ * entienden los buscadores y los asistentes de voz. Sirve para que «¿cuándo es
+ * la boda de Paloma y David?» tenga respuesta sin que nadie abra la web.
+ *
+ * SALE DE `configuracion_boda`, COMO TODO LO DEMÁS. Si la fecha cambia, esto
+ * cambia con ella; no hay una segunda copia que se pueda quedar vieja — que es
+ * exactamente lo que pasa cuando los datos estructurados se escriben a mano.
+ *
+ * `eventAttendanceMode` es presencial y `eventStatus` programado: son los
+ * valores que evitan que un buscador la presente como un evento en línea o
+ * cancelado, que es lo que hacen por defecto con la información incompleta.
+ *
+ * NO SE PUBLICA NADA QUE NO ESTÉ YA A LA VISTA. Ni el enlace del RSVP, ni el
+ * correo de contacto, ni la cuenta: aquí sólo va lo que cualquiera lee al
+ * entrar. Un dato estructurado es más fácil de recolectar, no menos.
+ */
+export function DatosEstructurados({
+  configuracion,
+  nombres,
+}: {
+  configuracion: ConfiguracionBoda;
+  nombres: string;
+}) {
+  const lugar = configuracion.lugarCeremonia ?? configuracion.lugarBanquete;
+
+  const datos = {
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: nombres,
+    startDate: configuracion.fechaCeremonia.toISOString(),
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    eventStatus: "https://schema.org/EventScheduled",
+    inLanguage: IDIOMA,
+    ...(lugar
+      ? {
+          location: {
+            "@type": "Place",
+            name: lugar,
+            ...(configuracion.direccionCeremonia
+              ? {
+                  address: {
+                    "@type": "PostalAddress",
+                    streetAddress: configuracion.direccionCeremonia,
+                  },
+                }
+              : {}),
+            ...(configuracion.latitud !== null && configuracion.longitud !== null
+              ? {
+                  geo: {
+                    "@type": "GeoCoordinates",
+                    latitude: configuracion.latitud,
+                    longitude: configuracion.longitud,
+                  },
+                }
+              : {}),
+          },
+        }
+      : {}),
+  };
+
+  /*
+    `JSON.stringify` y no una plantilla de texto: los nombres y el lugar los
+    escribe quien organiza desde el panel, y una comilla suelta en «Finca "El
+    Robledal"» rompería el bloque entero. Al serializar, se escapa solo.
+
+    El `</` se parte además a mano: un `</script>` dentro de una cadena cierra
+    la etiqueta antes de tiempo y lo que venga detrás se ejecuta. Es el único
+    sitio de la web donde eso puede pasar.
+  */
+  const serializado = JSON.stringify(datos).replaceAll("</", "<\\/");
+
+  return (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: serializado }} />
+  );
+}

--- a/src/components/ui/cuenta-regalos.tsx
+++ b/src/components/ui/cuenta-regalos.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+
+import { Boton } from "@/components/ui/boton";
+import { CampoCopiable } from "@/components/ui/campo-copiable";
+import { Etiqueta } from "@/components/ui/tipografia";
+import { RUTA_CUENTA_REGALOS } from "@/config/constants";
+import { t } from "@/lib/copy";
+
+/**
+ * BODA-28 · EL NÚMERO DE CUENTA SE REVELA AL PULSAR
+ *
+ * El IBAN no viaja en el HTML de la landing. Se pide a `/regalos/cuenta`
+ * cuando alguien pulsa, y hasta entonces lo que hay aquí es un botón.
+ *
+ * POR QUÉ, QUE NO ES OBVIO. Un número de cuenta escrito en el HTML lo indexan
+ * los buscadores y lo recogen los rastreadores sin que nadie haya abierto la
+ * página siquiera. Pedirlo aparte no lo convierte en un secreto —quien conozca
+ * la ruta puede pedirla— pero deja fuera todo lo que no es una persona mirando
+ * la web, que es de lo que hay que proteger un dato así en un sitio público.
+ *
+ * Y HAY UNA RAZÓN DE FONDO ADEMÁS DE LA TÉCNICA: la sección dice «vuestra
+ * presencia ya es el regalo». Un número de cuenta a la vista contradice esa
+ * frase por mucho que la frase esté encima. Detrás de un botón, quien no
+ * quiera contribuir no lo ve, y ésa es la intención de todo el bloque.
+ */
+
+interface Cuenta {
+  iban: string;
+  titular: string | null;
+}
+
+type Estado =
+  | { fase: "oculta" }
+  | { fase: "pidiendo" }
+  | { fase: "visible"; cuenta: Cuenta }
+  | { fase: "fallo" };
+
+export function CuentaRegalos() {
+  const [estado, setEstado] = useState<Estado>({ fase: "oculta" });
+
+  async function revelar() {
+    setEstado({ fase: "pidiendo" });
+    try {
+      const respuesta = await fetch(RUTA_CUENTA_REGALOS);
+      if (!respuesta.ok) throw new Error(String(respuesta.status));
+      setEstado({ fase: "visible", cuenta: (await respuesta.json()) as Cuenta });
+    } catch {
+      // Sin detalles: quien lo lee no puede arreglar nada, y el motivo real
+      // —la base, la red— no le dice nada útil.
+      setEstado({ fase: "fallo" });
+    }
+  }
+
+  if (estado.fase === "visible") {
+    return (
+      <>
+        {estado.cuenta.titular ? (
+          <Etiqueta>{t("regalos.titular", { titular: estado.cuenta.titular })}</Etiqueta>
+        ) : null}
+        <CampoCopiable
+          valor={estado.cuenta.iban}
+          etiqueta={t("regalos.etiquetaCuenta")}
+          textoCopiar={t("regalos.copiar")}
+          textoCopiado={t("regalos.copiado")}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Boton
+        jerarquia="secundario"
+        onClick={revelar}
+        disabled={estado.fase === "pidiendo"}
+        className="mt-pila"
+      >
+        {estado.fase === "pidiendo" ? t("regalos.revelando") : t("regalos.revelar")}
+      </Boton>
+
+      {estado.fase === "fallo" ? (
+        <p role="alert" className="mt-pila text-pequeno text-tinta-suave">
+          {t("regalos.errorRevelar")}
+        </p>
+      ) : null}
+
+      {/*
+        Sin JavaScript no hay botón que valga, y meter el número en el
+        `<noscript>` sería devolverlo al HTML entregado — justo lo que este
+        componente existe para evitar. Así que se dice a quién escribir.
+      */}
+      <noscript>
+        <p className="mt-pila text-pequeno text-tinta-suave">{t("regalos.sinJavascript")}</p>
+      </noscript>
+    </>
+  );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -158,3 +158,10 @@ export const RUTA_PENDIENTES = "/panel/invitados/pendientes";
  * en CI o un mock de nuestro propio código, que no probaría que el correo sale.
  */
 export const URL_RESEND = process.env.RESEND_URL ?? "https://api.resend.com";
+
+/**
+ * De dónde saca la landing el número de cuenta, y por qué no viene ya puesto:
+ * un IBAN escrito en el HTML lo indexan los buscadores y lo recogen los
+ * rastreadores sin que nadie haya abierto la página. Ver BODA-28.
+ */
+export const RUTA_CUENTA_REGALOS = "/regalos/cuenta";

--- a/tests/e2e/buscadores.spec.ts
+++ b/tests/e2e/buscadores.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "@playwright/test";
+import postgres from "postgres";
+
+import { RUTA_ACCESO, RUTA_PANEL, RUTA_RSVP } from "../../src/config/constants";
+
+/**
+ * BODA-92 · Buscadores: lo público sí, lo privado no
+ *
+ * LO QUE DE VERDAD PROTEGE ES LA CABECERA, y por eso se prueba aparte. Un
+ * `robots.txt` es una petición que cada rastreador decide si respeta; los que
+ * van a por datos personales no la respetan. `X-Robots-Tag` es una
+ * instrucción, y detrás de ella están el middleware y RLS.
+ *
+ * El sitemap se prueba por lo que NO lleva. Que contenga la portada es fácil;
+ * lo que arruinaría una boda es que enumerara los enlaces de invitación, que
+ * llevan un token dentro y son de una familia cada uno.
+ */
+
+const cadena = process.env.DATABASE_URL;
+
+test.describe("Lo privado no se indexa", () => {
+  /*
+    Las rutas que no pueden acabar en un buscador. Se listan por lo que son y
+    no por un patrón: `/cocina` no comparte prefijo con ninguna, y una
+    expresión que las cubriera todas escondería justo eso.
+  */
+  const PRIVADAS = [RUTA_PANEL, `${RUTA_PANEL}/invitados`, RUTA_ACCESO, "/cocina"];
+
+  for (const ruta of PRIVADAS) {
+    test(`${ruta} responde con noindex en la cabecera`, async ({ request }) => {
+      const respuesta = await request.get(ruta, { maxRedirects: 0 });
+      expect(respuesta.headers()["x-robots-tag"] ?? "").toContain("noindex");
+    });
+  }
+
+  test("un enlace de invitación tampoco, exista o no", async ({ request }) => {
+    // Con token inventado: si sólo se protegieran los válidos, bastaría con
+    // probar cadenas para saber cuáles lo son.
+    const respuesta = await request.get(`${RUTA_RSVP}/token-que-no-existe-000000`);
+    expect(respuesta.headers()["x-robots-tag"] ?? "").toContain("noindex");
+  });
+
+  test("el robots.txt lo pide además, por si acaso", async ({ request }) => {
+    const texto = await (await request.get("/robots.txt")).text();
+
+    expect(texto).toContain(`Disallow: ${RUTA_PANEL}/`);
+    expect(texto).toContain(`Disallow: ${RUTA_RSVP}/`);
+    expect(texto).toContain("Disallow: /cocina");
+  });
+});
+
+test.describe("El sitemap", () => {
+  test.skip(!cadena, "Hace falta DATABASE_URL: las páginas salen de la base.");
+
+  test("lleva la portada y no lleva ni un enlace de invitación", async ({ request }) => {
+    const xml = await (await request.get("/sitemap.xml")).text();
+
+    expect(xml).toContain("<urlset");
+
+    /*
+      LO QUE NO PUEDE ESTAR. Un sitemap con enlaces de invitación los publica:
+      son URLs con un token dentro, y cada una abre los datos de una familia.
+      Se comprueba por el prefijo de la ruta, no por un token concreto, porque
+      lo que no puede aparecer es la sección entera.
+    */
+    expect(xml, "el sitemap no puede enumerar invitaciones").not.toContain(`${RUTA_RSVP}/`);
+    expect(xml).not.toContain(RUTA_PANEL);
+    expect(xml).not.toContain(RUTA_ACCESO);
+  });
+
+  /**
+   * CASO DE ERROR · Una sección apagada no se ofrece a los buscadores.
+   *
+   * `reserva_la_fecha` es una página propia y su ruta devuelve 404 cuando la
+   * sección está apagada. Un sitemap escrito a mano la citaría igual y mandaría
+   * a los buscadores contra una página que no existe.
+   */
+  test("una página apagada no aparece", async ({ request }) => {
+    const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
+    const [previo] = await sql<{ visible: boolean }[]>`
+      select visible from public.secciones_landing where seccion = 'reserva_la_fecha'
+    `;
+
+    try {
+      await sql`
+        update public.secciones_landing set visible = false where seccion = 'reserva_la_fecha'
+      `;
+      const xml = await (await request.get("/sitemap.xml")).text();
+      expect(xml).not.toContain("/reserva-la-fecha");
+    } finally {
+      await sql`
+        update public.secciones_landing
+           set visible = ${previo?.visible ?? true}
+         where seccion = 'reserva_la_fecha'
+      `;
+      await sql.end();
+    }
+  });
+});
+
+test.describe("Los datos estructurados del evento", () => {
+  test.skip(!cadena, "Hace falta DATABASE_URL: la fecha sale de la base.");
+
+  test("dicen la fecha que hay en la base, no una escrita a mano", async ({
+    page,
+    request,
+  }) => {
+    const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
+    const [boda] = await sql<{ fecha_hora_ceremonia: Date }[]>`
+      select fecha_hora_ceremonia from public.configuracion_boda
+    `;
+    await sql.end();
+
+    await page.goto("/");
+    const bruto = await page.locator('script[type="application/ld+json"]').textContent();
+    const datos = JSON.parse(bruto!) as { "@type": string; startDate: string };
+
+    expect(datos["@type"]).toBe("Event");
+    expect(new Date(datos.startDate).getTime()).toBe(boda.fecha_hora_ceremonia.getTime());
+
+    // Y no se cuela nada privado: los datos estructurados son lo más fácil de
+    // recolectar de toda la página.
+    expect(bruto).not.toContain(RUTA_RSVP);
+    const html = await (await request.get("/")).text();
+    expect(html).toContain("application/ld+json");
+  });
+});

--- a/tests/e2e/correo-confirmacion.spec.ts
+++ b/tests/e2e/correo-confirmacion.spec.ts
@@ -22,6 +22,21 @@ import { RUTA_RSVP } from "../../src/config/constants";
 const cadena = process.env.DATABASE_URL;
 const PUERTO_BUZON = 54999;
 
+/**
+ * CADA CONTEXTO, CON SU PROPIO ORIGEN.
+ *
+ * El cortafuegos del RSVP cuenta intentos fallidos por origen, y toda la suite
+ * sale de `127.0.0.1`: los tests que abren enlaces inválidos a propósito
+ * —«un enlace que no vale», la rotación de tokens— gastan ese cupo, y cuando le
+ * toca el turno a este fichero la IP puede estar cerrada. Entonces el enlace no
+ * se abre y el test falla por algo que no tiene nada que ver con el correo.
+ *
+ * Pasó. Con una cabecera propia, este fichero tiene su cupo entero y no se lo
+ * gasta nadie. No se relaja el límite: se deja de compartir el cubo.
+ */
+let siguienteOrigen = 0;
+const origen = () => ({ "x-forwarded-for": `198.51.100.${(siguienteOrigen += 1) + 100}` });
+
 interface CorreoCapturado {
   from: string;
   to: string[];
@@ -117,7 +132,11 @@ test.describe("El acuse de recibo", () => {
     const correo = `invitada-${Date.now()}@ejemplo.test`;
     const token = await crearGrupo(`feliz-${Date.now()}`, correo);
 
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origen(),
+    });
     const pagina = await contexto.newPage();
     await pagina.goto(`${RUTA_RSVP}/${token}`);
     await pagina.locator('input[value="confirmado"]').first().check();
@@ -155,7 +174,11 @@ test.describe("El acuse de recibo", () => {
   test("con el proveedor caído, la confirmación se guarda igual", async ({ browser }) => {
     const token = await crearGrupo(`caido-${Date.now()}`, `caido-${Date.now()}@ejemplo.test`);
 
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origen(),
+    });
     const pagina = await contexto.newPage();
     await pagina.goto(`${RUTA_RSVP}/${token}`);
     await pagina.locator('input[value="confirmado"]').first().check();
@@ -182,7 +205,11 @@ test.describe("El acuse de recibo", () => {
 
     const token = await crearGrupo(`sin-correo-${Date.now()}`, null);
 
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origen(),
+    });
     const pagina = await contexto.newPage();
     await pagina.goto(`${RUTA_RSVP}/${token}`);
     await pagina.locator('input[value="confirmado"]').first().check();

--- a/tests/e2e/regalos-dresscode.spec.ts
+++ b/tests/e2e/regalos-dresscode.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import postgres from "postgres";
 
 import copy from "../../content/copy.es.json";
+import { RUTA_CUENTA_REGALOS } from "../../src/config/constants";
 import { conSeccionApagada, fijarSeccionVisible } from "./utiles/secciones";
 
 /**
@@ -56,10 +57,18 @@ test("los regalos enseñan la cuenta que hay en la base, no una escrita a mano",
   await expect(regalos).toContainText(copy.regalos.etiqueta);
   await expect(regalos).toContainText(copy.regalos.descripcion);
 
-  // La cuenta va en un campo de sólo lectura: así se selecciona entera de una
-  // pasada, con JavaScript o sin él.
-  const campo = regalos.getByLabel(copy.regalos.etiquetaCuenta);
-  await expect(campo).toHaveValue(iban);
+  /*
+    LA CUENTA YA NO SE PINTA DE ENTRADA, y este test cambió con BODA-28.
+
+    Antes se comprobaba que el campo traía el IBAN puesto. Ahora lo que tiene
+    que haber es un botón: el número no puede viajar en el HTML entregado
+    —lo indexan los buscadores y lo recogen los rastreadores sin que nadie
+    abra la página— y se pide al pulsar. Que al pulsar aparezca el que hay en
+    la base lo comprueba `regalos.spec.ts`; aquí basta con que el número NO
+    esté antes, que es lo que este fichero vigila.
+  */
+  await expect(regalos.getByRole("button", { name: copy.regalos.revelar })).toBeVisible();
+  expect(await page.content()).not.toContain(iban);
 
   await expect(regalos).toContainText(copy.regalos.buzon);
 });
@@ -101,9 +110,17 @@ test("con la sección apagada, el IBAN no está ni en el HTML ni en el menú", a
 }) => {
   const iban = await ibanDelEntorno();
 
-  // Encendida, está.
-  const encendida = await request.get("/");
-  expect(await encendida.text()).toContain(iban);
+  /*
+    ENCENDIDA, EL NÚMERO SALE POR LA RUTA — no por el HTML.
+
+    Desde BODA-28 el IBAN no viaja en la página, así que comprobarlo ahí ya no
+    diría nada: saldría «no está» con la sección encendida y con la sección
+    apagada, y el test pasaría sin haber probado nada. Lo que hay que ver es
+    que la puerta por la que sale de verdad se abre y se cierra con ella.
+  */
+  const conCuenta = await request.get(RUTA_CUENTA_REGALOS);
+  expect(conCuenta.status()).toBe(200);
+  expect(await conCuenta.text()).toContain(iban);
 
   await conSeccionApagada("regalos", async () => {
     const apagada = await request.get("/");
@@ -111,6 +128,12 @@ test("con la sección apagada, el IBAN no está ni en el HTML ni en el menú", a
 
     expect(html, "el IBAN sigue publicado con la sección apagada").not.toContain(iban);
     expect(html).not.toContain(copy.regalos.titulo);
+
+    // Y la ruta se cierra con la sección: es la misma condición, comprobada
+    // por la base y no por la pantalla.
+    const sinCuenta = await request.get(RUTA_CUENTA_REGALOS);
+    expect(sinCuenta.status(), "apagar la sección tiene que cerrar la ruta").toBe(404);
+    expect(await sinCuenta.text()).not.toContain(iban);
 
     // Y el menú tampoco ofrece un enlace a una sección que ya no está.
     await page.goto("/");

--- a/tests/e2e/regalos.spec.ts
+++ b/tests/e2e/regalos.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "@playwright/test";
+import postgres from "postgres";
+
+import copy from "../../content/copy.es.json";
+import { RUTA_CUENTA_REGALOS } from "../../src/config/constants";
+
+/**
+ * BODA-28 · El número de cuenta sólo se revela al pulsar
+ *
+ * EL CASO DE ERROR ES EL QUE JUSTIFICA EL TICKET, y es el que se comprueba
+ * primero: que el IBAN **no esté en el HTML entregado**. Un número de cuenta
+ * escrito en la página lo indexan los buscadores y lo recogen los rastreadores
+ * sin que nadie la haya abierto. Con el número detrás de un botón, lo ve quien
+ * mira la web y nada más.
+ *
+ * Se comprueba sobre el HTML crudo —`page.request.get("/")`— y no sobre lo que
+ * se ve. Mirar la pantalla no valdría: un `display:none` esconde el número de
+ * los ojos y lo deja intacto para cualquier rastreador.
+ */
+
+const cadena = process.env.DATABASE_URL;
+
+/** Un IBAN de pruebas con la forma que exige la restricción de la tabla. */
+const IBAN = "ES9121000418450200051332";
+const TITULAR = "(DES) Paloma y David";
+
+async function conBase<T>(trabajo: (sql: postgres.Sql) => Promise<T>): Promise<T> {
+  const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
+  try {
+    return await trabajo(sql);
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * LO QUE HABÍA ANTES, PARA DEVOLVERLO.
+ *
+ * El seed trae un IBAN y la sección encendida, así que el menú de la landing
+ * lleva «Regalos». Dejar esto a `null` al terminar tira esa entrada del menú y
+ * rompe el test de navegación, que corre después — pasó. Es estado global: se
+ * guarda al entrar y se restaura al salir, como con el plazo del RSVP.
+ */
+let anterior: { iban: string | null; titular: string | null } = { iban: null, titular: null };
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("La sección de regalos", () => {
+  test.skip(!cadena, "Hace falta DATABASE_URL.");
+
+  test.beforeAll(async () => {
+    const [previo] = await conBase(
+      (sql) => sql<{ iban_regalos: string | null; titular_cuenta: string | null }[]>`
+        select iban_regalos, titular_cuenta from public.configuracion_privada
+      `,
+    );
+    anterior = { iban: previo?.iban_regalos ?? null, titular: previo?.titular_cuenta ?? null };
+
+    await conBase(async (sql) => {
+      await sql`
+        insert into public.configuracion_privada (iban_regalos, titular_cuenta)
+        values (${IBAN}, ${TITULAR})
+        on conflict (fila_unica) do update
+          set iban_regalos = excluded.iban_regalos,
+              titular_cuenta = excluded.titular_cuenta
+      `;
+      await sql`update public.secciones_landing set visible = true where seccion = 'regalos'`;
+    });
+  });
+
+  test.afterAll(async () => {
+    // Como estaba, no vacío: el seed trae un IBAN y hay tests que cuentan con él.
+    await conBase(
+      (sql) => sql`
+        update public.configuracion_privada
+           set iban_regalos = ${anterior.iban}, titular_cuenta = ${anterior.titular}
+      `,
+    );
+  });
+
+  /**
+   * CASO DE ERROR · EL NÚMERO NO VIAJA EN EL HTML.
+   */
+  test("el IBAN no está en el HTML entregado antes de pulsar", async ({ page }) => {
+    const respuesta = await page.request.get("/");
+    const html = await respuesta.text();
+
+    // La sección sí está: es lo que hace que la comprobación signifique algo.
+    expect(html).toContain(copy.regalos.titulo);
+    expect(html).toContain(copy.regalos.revelar);
+
+    // Y el número no, ni entero ni troceado por el formato.
+    expect(html, "el IBAN no puede viajar en el HTML de la landing").not.toContain(IBAN);
+    expect(html).not.toContain(TITULAR);
+  });
+
+  test("al pulsar aparece el número, y se puede copiar", async ({ page, context }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await page.goto("/");
+
+    const seccion = page.locator("#regalos");
+    await seccion.getByRole("button", { name: copy.regalos.revelar }).click();
+
+    // Ahora sí: el número, su titular, y el botón de copiar.
+    const campo = seccion.getByLabel(copy.regalos.etiquetaCuenta);
+    await expect(campo).toHaveValue(IBAN);
+    await expect(seccion.getByText(TITULAR)).toBeVisible();
+
+    await seccion.getByRole("button", { name: copy.regalos.copiar }).click();
+    await expect(seccion.getByRole("button", { name: copy.regalos.copiado })).toBeVisible();
+
+    const copiado = await page.evaluate(() => navigator.clipboard.readText());
+    expect(copiado, "copiar tiene que dejar el IBAN en el portapapeles").toBe(IBAN);
+  });
+
+  /**
+   * CASO DE ERROR · Sin cuenta configurada no hay sección ni ruta que valga.
+   */
+  test("sin IBAN, ni sección ni número", async ({ page }) => {
+    await conBase((sql) => sql`update public.configuracion_privada set iban_regalos = null`);
+
+    const html = await (await page.request.get("/")).text();
+    expect(html).not.toContain(copy.regalos.revelar);
+
+    // Y la ruta tampoco lo suelta: la base devuelve cero filas y esto es un 404.
+    const cuenta = await page.request.get(RUTA_CUENTA_REGALOS);
+    expect(cuenta.status()).toBe(404);
+
+    // Se devuelve para los tests siguientes del fichero.
+    await conBase((sql) => sql`update public.configuracion_privada set iban_regalos = ${IBAN}`);
+  });
+});

--- a/tests/e2e/regalos.spec.ts
+++ b/tests/e2e/regalos.spec.ts
@@ -48,6 +48,19 @@ test.describe.configure({ mode: "serial" });
 test.describe("La sección de regalos", () => {
   test.skip(!cadena, "Hace falta DATABASE_URL.");
 
+  test.beforeEach(async () => {
+    // Cada test se coloca su propio escenario. Con `beforeAll` bastaba
+    // mientras corría un solo navegador; con dos proyectos, el `afterAll` de
+    // uno y el `beforeAll` del otro se pisan y el fallo no dice por qué.
+    await conBase(async (sql) => {
+      await sql`
+        update public.configuracion_privada
+           set iban_regalos = ${IBAN}, titular_cuenta = ${TITULAR}
+      `;
+      await sql`update public.secciones_landing set visible = true where seccion = 'regalos'`;
+    });
+  });
+
   test.beforeAll(async () => {
     const [previo] = await conBase(
       (sql) => sql<{ iban_regalos: string | null; titular_cuenta: string | null }[]>`
@@ -94,8 +107,25 @@ test.describe("La sección de regalos", () => {
     expect(html).not.toContain(TITULAR);
   });
 
-  test("al pulsar aparece el número, y se puede copiar", async ({ page, context }) => {
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  test("al pulsar aparece el número, y se puede copiar", async ({
+    page,
+    context,
+    browserName,
+  }) => {
+    /*
+      EL PORTAPAPELES SÓLO SE LEE EN CHROMIUM.
+
+      `clipboard-write` es un permiso que WebKit no conoce, y pedirlo allí no
+      es que no haga nada: lanza. Lo cazó el CI, porque en local sólo había
+      corrido el proyecto de escritorio.
+      
+      Lo que sí se comprueba en los dos es lo que ve quien usa la web: que el
+      botón confirma que ha copiado. La lectura del portapapeles es un extra
+      que sólo un navegador deja hacer, no el criterio del ticket.
+    */
+    const leePortapapeles = browserName === "chromium";
+    if (leePortapapeles) await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
     await page.goto("/");
 
     const seccion = page.locator("#regalos");
@@ -109,8 +139,10 @@ test.describe("La sección de regalos", () => {
     await seccion.getByRole("button", { name: copy.regalos.copiar }).click();
     await expect(seccion.getByRole("button", { name: copy.regalos.copiado })).toBeVisible();
 
-    const copiado = await page.evaluate(() => navigator.clipboard.readText());
-    expect(copiado, "copiar tiene que dejar el IBAN en el portapapeles").toBe(IBAN);
+    if (leePortapapeles) {
+      const copiado = await page.evaluate(() => navigator.clipboard.readText());
+      expect(copiado, "copiar tiene que dejar el IBAN en el portapapeles").toBe(IBAN);
+    }
   });
 
   /**

--- a/tests/e2e/rsvp.spec.ts
+++ b/tests/e2e/rsvp.spec.ts
@@ -26,6 +26,25 @@ const cadena = process.env.DATABASE_URL;
 
 test.describe.configure({ mode: "serial" });
 
+/**
+ * CADA CONTEXTO, CON SU PROPIO ORIGEN.
+ *
+ * `obtener_invitacion()` pasa por `exigir_cupo_rsvp()`, que cuenta intentos
+ * por origen — y TODA la suite sale de `127.0.0.1`. Los tests que abren
+ * enlaces inválidos a propósito gastan ese cupo, y para cuando arranca el
+ * proyecto móvil —que corre después del de escritorio— la IP está cerrada: la
+ * lectura lanza y la página muestra «Estamos preparando la web».
+ *
+ * Pasó en CI y sólo en `movil`, que es justo el que no puedo ejecutar aquí.
+ * No se relaja el límite —es una protección de verdad—: se deja de compartir
+ * el cubo. Los tests del cortafuegos siguen usando sus IP fijas, que es su
+ * razón de ser.
+ */
+let contador = 0;
+const origenPropio = () => ({
+  "x-forwarded-for": `198.51.100.${((contador += 1) % 200) + 20}`,
+});
+
 async function conBase<T>(trabajo: (sql: postgres.Sql) => Promise<T>): Promise<T> {
   const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
   try {
@@ -207,7 +226,11 @@ test.describe("El recorrido del invitado", () => {
     );
 
     const token = await crearGrupo("e2e-cookie", ["(DES) Gorka"]);
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origenPropio(),
+    });
     const pagina = await contexto.newPage();
 
     await pagina.goto(`${RUTA_RSVP}/${token}`);
@@ -228,7 +251,11 @@ test.describe("El recorrido del invitado", () => {
 
   test("lo escrito sobrevive al botón de atrás", async ({ browser }) => {
     const token = await crearGrupo("e2e-atras", ["(DES) Cris"]);
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origenPropio(),
+    });
     const pagina = await contexto.newPage();
 
     await pagina.goto(`${RUTA_RSVP}/${token}`);
@@ -255,7 +282,11 @@ test.describe("El recorrido del invitado", () => {
    */
   test("no deja avanzar si falta alguien, y dice quién", async ({ browser }) => {
     const token = await crearGrupo("e2e-falta", ["(DES) Dani", "(DES) Eva"]);
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origenPropio(),
+    });
     const pagina = await contexto.newPage();
 
     await pagina.goto(`${RUTA_RSVP}/${token}`);
@@ -272,7 +303,11 @@ test.describe("El recorrido del invitado", () => {
 
   test("si no viene nadie, no se pregunta por el menú", async ({ browser }) => {
     const token = await crearGrupo("e2e-nadie", ["(DES) Fran"]);
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origenPropio(),
+    });
     const pagina = await contexto.newPage();
 
     await pagina.goto(`${RUTA_RSVP}/${token}`);
@@ -468,7 +503,11 @@ test.describe("Cambiar una respuesta ya dada", () => {
   }) => {
     const token = await crearGrupo(`editar-${Date.now()}`, ["(DES) Editable"]);
 
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origenPropio(),
+    });
     const pagina = await contexto.newPage();
 
     // Primero, que sí.
@@ -525,7 +564,11 @@ test.describe("Cambiar una respuesta ya dada", () => {
   }) => {
     const token = await crearGrupo(`plazo-${Date.now()}`, ["(DES) Tarde"]);
 
-    const contexto = await browser.newContext({ javaScriptEnabled: false, locale: "es-ES" });
+    const contexto = await browser.newContext({
+      javaScriptEnabled: false,
+      locale: "es-ES",
+      extraHTTPHeaders: origenPropio(),
+    });
     const pagina = await contexto.newPage();
 
     await pagina.goto(`${RUTA_RSVP}/${token}`);

--- a/tests/unidad/copia-seguridad.test.ts
+++ b/tests/unidad/copia-seguridad.test.ts
@@ -1,0 +1,149 @@
+import { execFile } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import postgres from "postgres";
+import { afterAll, describe, expect, it } from "vitest";
+
+/**
+ * BODA-94 · Una copia que no se ha restaurado nunca no es una copia
+ *
+ * Es la diferencia entre este test y el que sería fácil escribir. Comprobar
+ * que `pg_dump` genera un fichero prueba que el comando existe; lo que hace
+ * falta saber es si ese fichero **devuelve la base**, y eso sólo se sabe
+ * restaurándolo.
+ *
+ * Y NO BASTA CON QUE VUELVAN LAS FILAS. Un volcado de sólo datos restauraría
+ * los invitados en una base sin políticas RLS: la lista estaría ahí, y también
+ * a la vista de cualquiera. Por eso el test cuenta las políticas después de
+ * restaurar — es la comprobación que distingue una copia útil de una que deja
+ * los datos desnudos.
+ */
+
+const ejecutar = promisify(execFile);
+const RAIZ = join(__dirname, "..", "..");
+const cadena = process.env.DATABASE_URL;
+
+const BASE_RESTAURADA = "boda_restaurada_prueba";
+const DIRECTORIO = join(RAIZ, "copias-de-prueba");
+
+/** La misma conexión pero contra otra base, para restaurar sin tocar la real. */
+function otraBase(nombre: string): string {
+  const url = new URL(cadena!);
+  url.pathname = `/${nombre}`;
+  return url.toString();
+}
+
+async function enPostgres<T>(trabajo: (sql: postgres.Sql) => Promise<T>): Promise<T> {
+  const sql = postgres(otraBase("postgres"), { max: 1, prepare: false, onnotice: () => {} });
+  try {
+    return await trabajo(sql);
+  } finally {
+    await sql.end();
+  }
+}
+
+afterAll(async () => {
+  rmSync(DIRECTORIO, { recursive: true, force: true });
+  if (cadena) {
+    await enPostgres((sql) => sql.unsafe(`drop database if exists ${BASE_RESTAURADA}`));
+  }
+});
+
+describe.skipIf(!cadena)("La copia de seguridad", () => {
+  it("se vuelca y se restaura, con sus filas y sus políticas RLS", async () => {
+    // 1. La copia.
+    const { stdout } = await ejecutar("./scripts/copia-de-seguridad.sh", [], {
+      cwd: RAIZ,
+      env: { ...process.env, DIRECTORIO_COPIAS: DIRECTORIO },
+    });
+    const fichero = stdout.trim();
+    expect(existsSync(fichero), "el volcado tiene que existir").toBe(true);
+
+    // 2. Una base vacía donde restaurarla. Vacía de verdad: restaurar sobre
+    //    la original no probaría nada, porque los datos ya están.
+    await enPostgres(async (sql) => {
+      await sql.unsafe(`drop database if exists ${BASE_RESTAURADA}`);
+      await sql.unsafe(`create database ${BASE_RESTAURADA}`);
+    });
+
+    const destino = otraBase(BASE_RESTAURADA);
+
+    /*
+        `extensions` y `auth` no vienen en el volcado —es de `public`— pero el
+        esquema los da por hecho. Se crean antes, que es exactamente lo que
+        habría que hacer restaurando en un Supabase nuevo.
+      */
+    const preparar = postgres(destino, { max: 1, prepare: false, onnotice: () => {} });
+    await preparar`create schema if not exists extensions`;
+    await preparar`create extension if not exists pgcrypto with schema extensions`;
+    await preparar`create schema if not exists auth`;
+    await preparar.unsafe(
+      `create table if not exists auth.users (id uuid primary key, email text)`,
+    );
+    await preparar.unsafe(
+      `create or replace function auth.uid() returns uuid language sql stable as
+         $$ select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid $$`,
+    );
+    for (const rol of ["anon", "authenticated", "service_role"]) {
+      await preparar.unsafe(
+        `do $$ begin if not exists (select 1 from pg_roles where rolname = '${rol}')
+             then create role ${rol} nologin; end if; end $$`,
+      );
+    }
+    await preparar.end();
+
+    // 3. La restauración. `pg_restore` avisa de lo que no puede aplicar y
+    //    sigue: se acepta su código de salida y se juzga por el resultado.
+    await ejecutar(
+      "bash",
+      [
+        "-c",
+        `PATH="$(ls -d /usr/lib/postgresql/*/bin | sort -V | tail -1):$PATH" ` +
+          `pg_restore --no-owner --no-privileges --dbname="${destino}" "${fichero}" 2>/dev/null || true`,
+      ],
+      { cwd: RAIZ },
+    );
+
+    // 4. Lo que importa: ¿está la boda dentro?
+    const restaurada = postgres(destino, { max: 1, prepare: false, onnotice: () => {} });
+    try {
+      const [invitados] = await restaurada<{ cuantos: number }[]>`
+          select count(*)::int as cuantos from public.invitados
+        `;
+      expect(invitados.cuantos, "los invitados tienen que volver").toBeGreaterThan(0);
+
+      /*
+          Y LAS PROTECCIONES. Sin esto, la copia devolvería la lista de
+          invitados a una base donde cualquiera la lee — que es peor que no
+          tener copia, porque nadie se enteraría.
+        */
+      const [politicas] = await restaurada<{ cuantas: number }[]>`
+          select count(*)::int as cuantas from pg_policies where schemaname = 'public'
+        `;
+      expect(politicas.cuantas, "las políticas RLS tienen que volver").toBeGreaterThan(10);
+
+      const [protegidas] = await restaurada<{ cuantas: number }[]>`
+          select count(*)::int as cuantas
+            from pg_class as c
+            join pg_namespace as n on n.oid = c.relnamespace
+           where n.nspname = 'public' and c.relkind = 'r' and c.relrowsecurity
+        `;
+      expect(protegidas.cuantas, "RLS tiene que seguir activado").toBeGreaterThan(10);
+    } finally {
+      await restaurada.end();
+    }
+  }, 120_000);
+
+  it("sin DATABASE_URL no genera un fichero vacío: falla", async () => {
+    // Una copia que falla en silencio es no tener copia. Lo que no puede
+    // pasar es que salga en verde dejando un fichero que no sirve.
+    await expect(
+      ejecutar("./scripts/copia-de-seguridad.sh", [], {
+        cwd: RAIZ,
+        env: { ...process.env, DATABASE_URL: "", DIRECTORIO_COPIAS: DIRECTORIO },
+      }),
+    ).rejects.toThrow();
+  }, 30_000);
+});

--- a/tests/unidad/mantener-viva.test.ts
+++ b/tests/unidad/mantener-viva.test.ts
@@ -1,0 +1,69 @@
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * BODA-95 · El toque a la base tiene que fallar cuando la base no está
+ *
+ * Lo importante de este flujo no es que funcione: es que **se entere alguien
+ * cuando no funciona**. Si el proyecto ya está pausado y el script sale con
+ * cero, el flujo aparece en verde y nadie mira — que es lo mismo que no tener
+ * flujo, sólo que con la falsa tranquilidad de creer que se vigila.
+ *
+ * Por eso el caso de error se prueba SIEMPRE, sin base de datos: apuntando a
+ * un puerto cerrado. El camino feliz necesita una base de verdad y se salta
+ * donde no la hay.
+ */
+
+const ejecutar = promisify(execFile);
+const GUION = join(__dirname, "..", "..", "scripts", "mantener-viva-la-base.mjs");
+
+interface Resultado {
+  codigo: number;
+  salida: string;
+}
+
+async function correr(entorno: Record<string, string>): Promise<Resultado> {
+  try {
+    const { stdout, stderr } = await ejecutar("node", [GUION], {
+      env: { ...process.env, ...entorno },
+      timeout: 30_000,
+    });
+    return { codigo: 0, salida: `${stdout}${stderr}` };
+  } catch (error) {
+    const fallo = error as { code?: number; stdout?: string; stderr?: string };
+    return { codigo: fallo.code ?? 1, salida: `${fallo.stdout ?? ""}${fallo.stderr ?? ""}` };
+  }
+}
+
+describe("El toque que mantiene viva la base", () => {
+  it("con la base inalcanzable, falla y dice que puede estar pausada", async () => {
+    // Un puerto cerrado: la conexión falla de verdad, no simulada.
+    const resultado = await correr({
+      DATABASE_URL: "postgres://nadie:nada@127.0.0.1:1/vacio",
+    });
+
+    expect(resultado.codigo, "un fallo en verde es no tener vigilancia").not.toBe(0);
+    expect(resultado.salida).toContain("pausado");
+  }, 40_000);
+
+  it("sin DATABASE_URL tampoco pasa en verde", async () => {
+    const resultado = await correr({ DATABASE_URL: "" });
+
+    expect(resultado.codigo).not.toBe(0);
+    expect(resultado.salida).toContain("DATABASE_URL");
+  }, 40_000);
+
+  it.skipIf(!process.env.DATABASE_URL)(
+    "contra la base real, dice que está despierta",
+    async () => {
+      const resultado = await correr({ DATABASE_URL: process.env.DATABASE_URL! });
+
+      expect(resultado.codigo, resultado.salida).toBe(0);
+      expect(resultado.salida).toContain("despierta");
+    },
+    40_000,
+  );
+});


### PR DESCRIPTION
## Qué cambia

Cuatro cosas independientes, un commit cada una.

Closes #28
Closes #63
Closes #66
Closes #65

> **Cuatro tickets en una PR, y lo digo en voz alta.** #28 arregla algo que ya está en `main` y os bloquea para meter el IBAN; los otros tres son pequeños, de producción, y no se tocan entre sí. Van en **commits separados y coherentes**, que es lo que la convención de una-rama-por-ticket protege de verdad. Si preferís cuatro PR, lo parto sin problema.

## Cómo probarlo en el preview

**El número de cuenta (#28)**
1. Con un IBAN en el panel, abrir la landing: hay un botón, no un número. Ver el código fuente: **el IBAN no está**.
2. Pulsar: aparece con su titular y el botón de copiar, que confirma.
3. Apagar la sección: desaparece y `/regalos/cuenta` responde 404.

**Buscadores (#63)**
4. `/robots.txt` niega `/panel/`, `/rsvp/`, `/acceso/` y `/cocina`.
5. `/sitemap.xml` lleva la portada y la reserva de fecha, y **ni un enlace de invitación**.
6. En la portada hay un `application/ld+json` con la fecha de la boda.

**Los dos flujos (#66, #65)** — necesitan configuración vuestra, ver más abajo.
7. Actions → «Mantener viva la base» → Run workflow.
8. Actions → «Copia de seguridad» → Run workflow.

## Lo que necesito de vosotros para que los dos flujos funcionen

Están escritos y probados, pero sin esto fallan **avisando** (que es mejor que pasar en verde sin hacer nada):

| Dónde                | Nombre         | Qué es                                           |
| -------------------- | -------------- | ------------------------------------------------ |
| Settings → Secrets   | `DATABASE_URL` | La conexión a la base de producción               |
| Settings → Variables | `REPO_COPIAS`  | `usuario/repo-privado`, el destino de las copias  |
| Settings → Secrets   | `TOKEN_COPIAS` | Un token con permiso de escritura en ese repo     |

**El repositorio de copias tiene que ser privado**: un volcado lleva los nombres, teléfonos y alergias de doscientas personas.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: rutas en `src/config/constants.ts`, rótulos en `content/copy.es.json`, fecha y lugar de `configuracion_boda`, destino de las copias en variables
- [x] Test incluido: camino feliz **y** caso de error en los cuatro tickets
- [ ] CI verde entero — en local pasan 191 unitarios y 135 E2E de escritorio
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: el campo conserva su rótulo, el fallo lleva `role="alert"`, y hay `<noscript>` que dice a quién escribir
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview — no puedo: `vercel.app` está bloqueado por la política de salida de este contenedor

### Por qué el IBAN no puede ir en el HTML

Un número de cuenta escrito en la página lo indexan los buscadores y lo recogen los rastreadores sin que nadie la haya abierto. Detrás de un botón no es un secreto —quien conozca la ruta puede pedirla— pero deja fuera todo lo que no es una persona mirando la web. Y hay una razón de fondo: la sección dice «vuestra presencia ya es el regalo», y un número a la vista contradice esa frase por mucho que la frase esté encima.

### Tres tests que, escritos de la forma fácil, no habrían probado nada

**El del IBAN apagado.** Su primera mitad comprobaba que encendida el número **sí** estaba en el HTML. Ahora no está ni encendida ni apagada, así que esa comprobación saldría «no está» siempre y **pasaría sin probar nada**. Mira la ruta, que es por donde el número sale de verdad.

**El del toque a la base.** Lo importante no es que funcione: es que **se entere alguien cuando no funciona**. Si el proyecto ya está pausado y el script saliera con cero, el flujo aparecería en verde y nadie miraría. Ese caso se prueba siempre y sin base, apuntando a un puerto cerrado.

**El de la copia de seguridad.** Comprobar que `pg_dump` genera un fichero prueba que el comando existe. El test **restaura** en una base vacía y mira qué hay — y no sólo las filas: cuenta las **políticas RLS** y las tablas con RLS activado. Un volcado de sólo datos devolvería la lista de invitados a una base donde la lee cualquiera, que es peor que no tener copia porque nadie se enteraría.

### Lo que encontró el CI y yo no podía ver

`clipboard-write` es un permiso de Chromium: en WebKit **lanza** y tumba el test. Se me escapó porque **WebKit no está instalado en este contenedor** y el proyecto `movil` no se puede ejecutar aquí. Ahora los dos navegadores comprueban lo que ve quien usa la web. Conviene tenerlo presente: la mitad móvil de la suite sólo la ve el CI, y es la que más importa aquí.

### Detalles que no son evidentes

**El sitemap es dinámico porque el test lo obligó**: generado en el build, apagar una sección la dejaba anunciada hasta el siguiente despliegue, mandando a los buscadores contra una ruta que ya da 404.

**El toque a la base no es `select 1`**: eso lo contesta PostgreSQL sin tocar nada nuestro, y diría que la base responde aunque el esquema estuviera vacío. Lee `configuracion_boda`. Va cada tres días y no cada seis porque el límite es siete y GitHub retrasa —y a veces se salta— los flujos programados.

**Las copias se guardan treinta días** y no sólo la última: un borrado se detecta tarde, y una copia que sobrescribe la de ayer copia también el borrado.

## Base de datos

- [x] No la toca
- [ ] Trae migración **y** su SQL de rollback en `supabase/migrations/rollback/`

## Documentación

- [ ] No hace falta
- [x] `docs/ENTORNO.md` actualizado con las variables de los dos flujos y cómo restaurar