### PR TITLE
fix(landing): la nota del autobús sale de la base, no de un literal

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,7 @@ import {
   obtenerMedios,
   obtenerSecciones,
   type ConfiguracionBoda,
+  type RutaLlegada,
   type ConsejoVestimenta,
   type Medio,
 } from "@/lib/bbdd/landing";
@@ -163,6 +164,17 @@ export default async function PaginaInicio() {
           seccion="programa"
           etiqueta={formatoFecha.format(configuracion.fechaCeremonia)}
           titulo={t("programa.titulo")}
+          /*
+            LA NOTA DEL AUTOBÚS SALE DE `rutas_llegada`, NO DE UN LITERAL.
+
+            La entrega la traía escrita —«a las 12:00 y de vuelta a las 02:00 y
+            04:30»— pero esas horas ya están en la base, en la ruta del
+            autobús. Copiarlas aquí sería tenerlas en dos sitios que se pueden
+            contradecir, y el día que cambie el horario cambiaría uno y no el
+            otro: media boda esperando en la Plaza de Santo Domingo a una hora
+            que ya no es.
+          */
+          entradilla={notaDelAutobus(rutas)}
           hitos={programa}
         />
       ) : undefined,
@@ -224,6 +236,19 @@ export default async function PaginaInicio() {
       />
     </>
   );
+}
+
+/**
+ * El detalle de la ruta en autobús, para anunciarlo encima del programa.
+ *
+ * Se busca por el modo y no por una posición fija: las rutas las ordena quien
+ * organiza desde el panel, y «la segunda de la lista» dejaría de ser el autobús
+ * en cuanto alguien mueva una. Si no hay ruta en autobús no se anuncia nada,
+ * que es lo correcto: no todas las bodas ponen.
+ */
+function notaDelAutobus(rutas: RutaLlegada[]): string | null {
+  const autobus = rutas.find((ruta) => /autob[uú]s|bus/i.test(ruta.modo));
+  return autobus?.detalle ?? null;
 }
 
 /** Todo lo que la landing necesita, pedido de una vez. */


### PR DESCRIPTION
## Qué cambia

Quinto de los seis textos de la entrega que faltaban: encima del programa se anuncia el autobús.

## Por qué no lo he copiado y pegado

Tu HTML lo trae escrito: *«Habrá autobús desde el centro de León a las 12:00 y de vuelta a las 02:00 y 04:30»*. Copiarlo era lo rápido.

**Pero esas horas ya están en la base**, en la ruta del autobús de `rutas_llegada` — y ahora también en el hito «Autobús desde León» del programa. Escribirlas una tercera vez sería tenerlas en tres sitios que se pueden contradecir, y el día que cambie el horario cambiarían dos y no el tercero: **media boda esperando en la Plaza de Santo Domingo a una hora que ya no es**. Eso no es un fallo de maquetación, es gente plantada.

Así que la nota se compone leyendo el detalle de la ruta. Una hora, un sitio.

La ruta se busca **por su modo y no por su posición**: el orden lo decide quien organiza desde el panel, y «la segunda de la lista» dejaría de ser el autobús en cuanto alguien mueva una. Sin ruta en autobús no se anuncia nada, que es lo correcto — no todas las bodas ponen.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: el texto sale de `rutas_llegada`
- [x] Sin test nuevo: lo cubren los tests de sección existentes
- [ ] CI verde entero — en local pasan 191 unitarios y 135 E2E de escritorio
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview — no puedo: `vercel.app` está bloqueado por la política de salida de este contenedor

## Lo que queda de la entrega

Un texto: poder **añadir canción desde la landing**. En tu HTML hay un campo «Añadir» ahí; hoy solo se listan. Eso ya no es transcribir: es una escritura pública nueva, con su función en la base y su cupo, como la del RSVP.

Y una pregunta abierta: la sección **«paisaje»** — tu frase fija (*«Todo empezó entre Barcelona y Sevilla y continúa en León»*) o la línea de tiempo de hitos que hay ahora.

## Base de datos

- [x] No la toca

## Documentación

- [x] No hace falta

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_