### PR TITLE
feat(playlist): añadir canción desde la portada, con la invitación del navegador

### DIFF
--- a/content/copy.es.json
+++ b/content/copy.es.json
@@ -104,9 +104,18 @@
     "titulo": "Playlist colaborativa",
     "descripcion": "Dejadnos la canción que os apetece bailar y la añadimos a la lista que sonará esa noche.",
     "campoCancion": "Canción y artista",
+    "campoAyuda": "Por ejemplo: «Tú me dejaste de querer — C. Tangana»",
     "anadir": "Añadir",
+    "anadiendo": "Apuntando…",
     "anadida": "Apuntada. Gracias.",
-    "vacia": "Todavía no hay canciones. Estrenad la lista."
+    "vacia": "Todavía no hay canciones. Estrenad la lista.",
+    "sinInvitacion": "Para apuntar una canción, entrad desde vuestro enlace de invitación.",
+    "errorVacio": "Escribid la canción antes de darle a añadir.",
+    "errorTexto": "Escribid la canción y el artista, sin pasaros de largo.",
+    "errorEnlace": "Vuestro enlace de invitación ya no vale. Escribidnos y os mandamos otro.",
+    "errorTope": "Ya habéis apuntado diez canciones. Con eso hay fiesta de sobra.",
+    "errorIntentos": "Demasiados intentos seguidos. Probad dentro de un rato.",
+    "errorAveria": "No hemos podido apuntarla. Probad dentro de un rato."
   },
   "regalos": {
     "etiqueta": "Vuestra presencia ya es el regalo",

--- a/docs/PLAN-MAESTRO.md
+++ b/docs/PLAN-MAESTRO.md
@@ -262,7 +262,7 @@ Sobre `grupos_invitacion`, `invitados` y `confirmaciones`, `anon` **no tiene nad
 
 - **`obtener_invitacion(token)`** → el grupo del token y su gente. Enumera sus columnas a mano: sin eso, un invitado recibiría el teléfono y las notas privadas de sus coinvitados, y cualquier columna futura se publicaría sola. **Cero filas significa «este enlace no vale»**, y no lanza excepción: al abortar se perdería el registro del intento y el cortafuegos dejaría de contar.
 - **`registrar_confirmacion(token, respuestas)`** → registra la respuesta del grupo, todo o nada. Escribe además menú y alergias en `invitados`, que es donde viven.
-- **`sugerir_cancion(token, texto)`** → añade a la playlist, con tope de diez por grupo.
+- **`sugerir_cancion(token, texto)`** → añade a la playlist, con tope de diez por grupo. La escriben los dos sitios donde se pide una canción: el último paso del RSVP y el campo de la sección `playlist` en la portada.
 - **`datos_para_regalos()`** → el IBAN y su titular, o cero filas. Es la única puerta por la que sale un dato de `configuracion_privada`, y sólo se abre con la sección `regalos` visible.
 - **`crear_grupo_invitacion(...)`** y **`rotar_token_invitacion(grupo)`** → del panel, devuelven el token en claro una sola vez.
 - **`importar_invitados(filas)`** → da de alta en bloque la gente de un CSV, en **una** transacción: o entran todas o no entra ninguna. Reutiliza el grupo cuando ya existe uno con ese nombre, porque un CSV trae una fila por persona y una invitación son varias. No emite enlaces: importar da de alta gente, no reparte invitaciones.
@@ -296,7 +296,7 @@ Secciones del enumerado `seccion_landing`:
 | `regalos`              | Número de cuenta en campo copiable. Nace apagada            | BODA-37 |
 | `dresscode`            | Qué ponerse, un bloque por consejo                          | BODA-38 |
 | `preguntas_frecuentes` | Acordeón nativo: etiqueta, niños, aparcamiento…             | BODA-27 |
-| `playlist`             | Canciones que sugieren los invitados                        | BODA-29 |
+| `playlist`             | Canciones que sugieren los invitados, con campo para añadir | BODA-29 |
 | `rsvp`                 | Llamada a confirmar asistencia                              | BODA-28 |
 | `reserva_la_fecha`     | **No es una sección: es una página aparte** (ver más abajo) | BODA-30 |
 
@@ -311,6 +311,8 @@ Página independiente, ligera y compartible: fecha grande, foto, «añadir al ca
 ### RSVP (`/rsvp/[token]`)
 
 El grupo se identifica por su enlace único — sin contraseñas. Formulario multipaso: asistencia por persona → menú y alergias → transporte/alojamiento → canción y mensaje. Confirmación por email (Resend) y posibilidad de editar hasta la fecha límite.
+
+**Abrir la invitación deja huella en el navegador.** El middleware guarda el token de `/rsvp/[token]` en una cookie `httpOnly` de un año, y de ahí lo saca la portada para el campo de la playlist: `sugerir_cancion()` exige token —la lista que sonará esa noche es de los invitados, no de internet entera— y en la portada no hay ninguno en la URL. Quien nunca ha abierto su invitación no ve el campo, ve la línea que explica que hace falta el enlace; enseñar un campo que sólo puede responder «vuestro enlace no vale» se lee como que la web está rota. El token **no** viaja en el HTML de la portada ni en un campo oculto: eso lo pondría en el código fuente de una página pública y en el historial del móvil, y ese token abre los datos de una familia entera. La cookie no se valida al escribirla —sería una consulta a la base en cada navegación de toda la web— porque la base la vuelve a comprobar cuando de verdad importa, al escribir, y un token inventado allí no abre nada.
 
 ---
 

--- a/src/app/acciones-playlist.ts
+++ b/src/app/acciones-playlist.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { sugerirCancion, type MotivoCancion } from "@/lib/bbdd/playlist";
+import { t } from "@/lib/copy";
+import { invitacionRecordada } from "@/lib/invitacion-recordada";
+
+import { type EstadoPlaylist } from "./estado-playlist";
+
+/**
+ * BODA-27 · APUNTAR UNA CANCIÓN DESDE LA PORTADA
+ *
+ * El token no viaja en el formulario: se saca de la cookie que dejó el enlace
+ * de invitación. Mandarlo en un campo oculto sería ponerlo en el HTML de una
+ * página pública y en el historial del navegador, y ese token abre los datos
+ * de una familia entera.
+ *
+ * SE VALIDA EN LA BASE, NO AQUÍ. `sugerir_cancion()` comprueba el token, la
+ * longitud y el tope de diez por grupo; esta acción sólo traduce lo que
+ * responde. Lo único que se mira antes de llamar es que haya algo escrito, y
+ * eso porque un campo vacío no merece un viaje a la base.
+ */
+export async function anadirCancion(
+  previo: EstadoPlaylist,
+  datos: FormData,
+): Promise<EstadoPlaylist> {
+  const sello = previo.sello + 1;
+  const texto = String(datos.get("cancion") ?? "").trim();
+
+  if (!texto) {
+    return { fase: "fallo", aviso: t("playlist.errorVacio"), texto: "", sello };
+  }
+
+  const token = await invitacionRecordada();
+  if (!token) {
+    return { fase: "fallo", aviso: t("playlist.sinInvitacion"), texto, sello };
+  }
+
+  const resultado = await sugerirCancion(token, texto);
+
+  if (!resultado.ok) {
+    return { fase: "fallo", aviso: AVISOS[resultado.motivo](), texto, sello };
+  }
+
+  /*
+    La portada es `force-dynamic`, así que se vuelve a pintar sola en la
+    respuesta de esta acción y la canción recién apuntada aparece en la lista
+    sin recargar. `revalidatePath` está igualmente porque sin él la lista se
+    serviría de la caché del router al volver a la portada desde otra página:
+    la canción estaría en la base y no en la pantalla, que es la forma más
+    segura de que alguien la apunte dos veces.
+  */
+  revalidatePath("/");
+
+  return { fase: "apuntada", aviso: null, texto: "", sello };
+}
+
+/**
+ * Cada motivo, su frase. Funciones y no cadenas: `t()` lee el copy al
+ * llamarla, y un objeto de cadenas se evaluaría al cargar el módulo.
+ */
+const AVISOS: Record<MotivoCancion, () => string> = {
+  texto: () => t("playlist.errorTexto"),
+  enlace: () => t("playlist.errorEnlace"),
+  tope: () => t("playlist.errorTope"),
+  intentos: () => t("playlist.errorIntentos"),
+  averia: () => t("playlist.errorAveria"),
+};

--- a/src/app/estado-playlist.ts
+++ b/src/app/estado-playlist.ts
@@ -1,0 +1,41 @@
+/**
+ * EL ESTADO DEL CAMPO DE LA PLAYLIST, EN SU PROPIO FICHERO
+ *
+ * No está aquí por orden: está aquí porque **no puede estar en el otro**. Un
+ * módulo `"use server"` sólo puede exportar funciones asíncronas — un `type` o
+ * una constante compilan, pasan el lint y revientan al ejecutarse con un
+ * «algo no ha ido bien» que no dice nada. Ya pasó una vez, en la importación
+ * de invitados, y hay un test unitario que lo vigila desde entonces.
+ */
+
+/** Lo que la pantalla necesita saber después de intentar apuntar una canción. */
+export interface EstadoPlaylist {
+  /** `null` mientras nadie ha escrito nada todavía. */
+  fase: "inicial" | "apuntada" | "fallo";
+  /** Ya traducido a castellano: la pantalla no conoce los códigos de la base. */
+  aviso: string | null;
+  /**
+   * Lo que se escribió, para devolverlo al campo cuando algo falla. Sin esto,
+   * un tope alcanzado borra de la pantalla la canción que costó recordar.
+   */
+  texto: string;
+  /**
+   * Cuántas veces se ha enviado. Es lo que usa el campo como `key`, y por eso
+   * sube en cada intento y no sólo en los buenos.
+   *
+   * REACT NO VACÍA UN CAMPO NO CONTROLADO al repintar: apuntada la canción, el
+   * texto seguía escrito y el botón invitaba a mandarla otra vez. Cambiar la
+   * `key` monta un campo nuevo, que nace con el `defaultValue` de este estado
+   * —vacío si fue bien, lo escrito si falló—. Con un contador que sólo subiera
+   * al acertar, dos canciones seguidas compartirían `key` y la segunda no se
+   * limpiaría.
+   */
+  sello: number;
+}
+
+export const ESTADO_INICIAL: EstadoPlaylist = {
+  fase: "inicial",
+  aviso: null,
+  texto: "",
+  sello: 0,
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { CuentaAtras } from "@/components/marketing/cuenta-atras";
 import { BotonEnlace } from "@/components/ui/boton";
 import { DatosEstructurados } from "@/components/datos-estructurados";
 import { CuentaRegalos } from "@/components/ui/cuenta-regalos";
+import { FormularioPlaylist } from "@/components/ui/formulario-playlist";
 import {
   Cita,
   Conector,
@@ -38,6 +39,7 @@ import {
   type Medio,
 } from "@/lib/bbdd/landing";
 import { t } from "@/lib/copy";
+import { invitacionRecordada } from "@/lib/invitacion-recordada";
 
 /**
  * LANDING
@@ -104,6 +106,18 @@ function fechaEnPuntos(fecha: Date): string {
 }
 
 export default async function PaginaInicio() {
+  /*
+    Si el navegador recuerda una invitación, la playlist enseña el campo para
+    apuntar una canción. Se lee aquí y no dentro de la sección para que la
+    portada tenga un solo sitio donde se decide qué se pinta.
+
+    NO SE COMPRUEBA CONTRA LA BASE. Sería una consulta más en cada visita a la
+    portada para adelantar un «no» que la base va a dar igualmente al escribir,
+    y por el camino gastaría cupo del cortafuegos del RSVP a quien no ha pedido
+    nada.
+  */
+  const hayInvitacion = (await invitacionRecordada()) !== null;
+
   let datos;
   try {
     datos = await cargarLanding();
@@ -186,7 +200,7 @@ export default async function PaginaInicio() {
       rutas.length > 0 ? <Transporte rutas={rutas} configuracion={configuracion} /> : undefined,
     preguntas_frecuentes:
       preguntas.length > 0 ? <Preguntas preguntas={preguntas} /> : undefined,
-    playlist: <Playlist canciones={canciones} />,
+    playlist: <Playlist canciones={canciones} puedeApuntar={hayInvitacion} />,
     // Sin cuenta no hay sección: ver el comentario de `Regalos`.
     regalos: cuentaRegalos ? <Regalos /> : undefined,
     dresscode: consejos.length > 0 ? <DressCode consejos={consejos} /> : undefined,
@@ -706,7 +720,26 @@ function Preguntas({
   );
 }
 
-function Playlist({ canciones }: { canciones: { id: string; texto: string }[] }) {
+/**
+ * LA PLAYLIST
+ *
+ * La lista se ve siempre; el campo para apuntar, sólo si el navegador recuerda
+ * una invitación. `sugerir_cancion()` exige token —la lista que sonará esa
+ * noche es de los invitados, no de internet— y enseñar un campo que va a
+ * responder «vuestro enlace no vale» a quien nunca tuvo uno es peor que no
+ * enseñarlo: se lee como que la web está rota.
+ *
+ * En su lugar va una línea que dice qué hace falta. Quien tiene invitación la
+ * ha abierto alguna vez, así que para los ciento veinte que importan el campo
+ * está ahí.
+ */
+function Playlist({
+  canciones,
+  puedeApuntar,
+}: {
+  canciones: { id: string; texto: string }[];
+  puedeApuntar: boolean;
+}) {
   return (
     <Bloque
       seccion="playlist"
@@ -716,6 +749,14 @@ function Playlist({ canciones }: { canciones: { id: string; texto: string }[] })
       realzada
       centrada
     >
+      {puedeApuntar ? (
+        <FormularioPlaylist />
+      ) : (
+        <Cuerpo className="mx-auto mt-elemento max-w-texto text-center text-pequeno text-tinta-suave">
+          {t("playlist.sinInvitacion")}
+        </Cuerpo>
+      )}
+
       {canciones.length > 0 ? (
         <ul className="mt-elemento flex flex-wrap justify-center gap-interno-compacto">
           {canciones.map((cancion) => (

--- a/src/components/ui/formulario-playlist.tsx
+++ b/src/components/ui/formulario-playlist.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { anadirCancion } from "@/app/acciones-playlist";
+import { ESTADO_INICIAL } from "@/app/estado-playlist";
+import { Boton } from "@/components/ui/boton";
+import { CampoTexto } from "@/components/ui/campo";
+import { LIMITE_TEXTO_CANCION } from "@/config/constants";
+import { t } from "@/lib/copy";
+
+/**
+ * BODA-27 · EL CAMPO PARA APUNTAR UNA CANCIÓN
+ *
+ * FUNCIONA SIN JAVASCRIPT, y no es un adorno: es un `<form>` con una acción de
+ * servidor, así que sin JavaScript el navegador manda el formulario de toda la
+ * vida y la canción se apunta igual. Quien abre esto es un invitado desde el
+ * móvil, en el pueblo, con cobertura de dos rayas — el escenario donde el
+ * JavaScript tarda o no llega. Con JavaScript encima no recarga la página y
+ * confirma en el sitio.
+ *
+ * EL TOKEN NO ESTÁ AQUÍ. Ni en un campo oculto ni en ninguna parte del HTML:
+ * la acción lo saca de la cookie que dejó el enlace de invitación. Un token en
+ * la portada sería un token en el código fuente de una página pública.
+ *
+ * EL AVISO ES UN `role="alert"`, que es lo que hace que un lector de pantalla
+ * lo anuncie sin que haya que ir a buscarlo. Vale igual para el «apuntada» que
+ * para el error: quien no ve la pantalla necesita saber las dos cosas.
+ */
+export function FormularioPlaylist() {
+  const [estado, enviar, enviando] = useActionState(anadirCancion, ESTADO_INICIAL);
+
+  return (
+    <form action={enviar} className="mx-auto mt-elemento grid max-w-texto gap-interno">
+      <CampoTexto
+        /*
+          La `key` cambia en cada envío para que el campo se monte de nuevo y
+          coja el `defaultValue` de este estado: vacío si la canción entró, lo
+          escrito si no. Sin esto, apuntada la canción el texto se quedaba
+          puesto y el botón invitaba a mandarla otra vez.
+        */
+        key={estado.sello}
+        etiqueta={t("playlist.campoCancion")}
+        ayuda={t("playlist.campoAyuda")}
+        error={estado.fase === "fallo" ? (estado.aviso ?? undefined) : undefined}
+        name="cancion"
+        type="text"
+        defaultValue={estado.texto}
+        required
+        maxLength={LIMITE_TEXTO_CANCION}
+        autoComplete="off"
+        enterKeyHint="done"
+      />
+
+      <div className="flex flex-wrap items-center justify-center gap-interno">
+        <Boton type="submit" jerarquia="secundario" disabled={enviando}>
+          {enviando ? t("playlist.anadiendo") : t("playlist.anadir")}
+        </Boton>
+
+        {estado.fase === "apuntada" ? (
+          <p role="status" className="text-pequeno text-tinta-suave">
+            {t("playlist.anadida")}
+          </p>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -86,6 +86,31 @@ export const MINUTOS_BORRADOR_RSVP = 180;
 export const PASOS_RSVP = ["asistencia", "detalles", "mensaje"] as const;
 export type PasoRsvp = (typeof PASOS_RSVP)[number];
 
+/**
+ * Cuánto recuerda el navegador de qué invitación es.
+ *
+ * Se guarda al abrir el enlace de invitación y sirve para que la playlist de
+ * la portada sepa quién escribe: apuntar una canción exige token, porque la
+ * lista es de los invitados y no de internet entera.
+ *
+ * UN AÑO, Y NO UNA SESIÓN. La invitación se manda meses antes de la boda y la
+ * canción se apunta cuando a uno le viene a la cabeza —en el coche, oyendo la
+ * radio—, que no es el mismo día en que confirmó. Una cookie de sesión
+ * obligaría a volver a WhatsApp a buscar el enlace justo en ese momento, y lo
+ * que pasa entonces es que no se apunta la canción.
+ */
+export const DIAS_RECUERDO_INVITACION = 365;
+
+/**
+ * Lo más largo que puede ser una canción apuntada en la playlist.
+ *
+ * ES EL MISMO NÚMERO QUE LA RESTRICCIÓN DE LA TABLA, a propósito: el navegador
+ * corta antes de mandar y la base vuelve a comprobarlo. Si aquí fuera mayor, el
+ * campo dejaría escribir un texto que la base rechaza después, y el invitado se
+ * llevaría un error por algo que la pantalla le había dejado hacer.
+ */
+export const LIMITE_TEXTO_CANCION = 160;
+
 /** Rutas del panel privado. Se escriben en varios sitios: viven aquí. */
 export const RUTA_ACCESO = "/acceso";
 export const RUTA_CONFIRMAR_ACCESO = "/acceso/confirmar";

--- a/src/lib/bbdd/playlist.ts
+++ b/src/lib/bbdd/playlist.ts
@@ -1,0 +1,71 @@
+import "server-only";
+
+import { huellaDePeticion } from "@/lib/huella-peticion";
+
+import { llamarComoAnonimo } from "./cliente";
+
+/**
+ * APUNTAR UNA CANCIÓN EN LA PLAYLIST
+ *
+ * La única escritura pública de la web además del RSVP, y pasa por
+ * `sugerir_cancion()`, que es `security definer` y decide sola qué acepta:
+ * exige un token de invitación válido, limita la longitud del texto y no deja
+ * pasar de diez canciones por grupo. Aquí no se vuelve a comprobar nada de
+ * eso — repetir una regla es tener dos sitios donde puede cambiar sólo uno.
+ *
+ * DOS SITIOS LLAMAN A ESTO Y POR ESO VIVE APARTE. La portada, cuando alguien
+ * escribe en el campo de la playlist, y el RSVP, que manda la canción del
+ * formulario de confirmación. Los códigos de error de la base los traduce este
+ * fichero una vez para los dos.
+ *
+ * NO LANZA NUNCA. Devuelve por qué no ha podido, y quien llama decide qué
+ * hacer: la portada lo enseña, el RSVP lo apunta en el registro y sigue —
+ * perder una confirmación de asistencia porque la canción número once no cabía
+ * sería un intercambio pésimo.
+ */
+
+/** Códigos con los que la base cuenta qué ha pasado al sugerir una canción. */
+export const MOTIVOS_CANCION = {
+  /** CAN01 · el texto está vacío, es de una letra o pasa de 160. */
+  textoInvalido: "CAN01",
+  /** CAN02 · el token no corresponde a ninguna invitación. */
+  enlaceInvalido: "CAN02",
+  /** CAN03 · ese grupo ya ha apuntado diez. */
+  topeDelGrupo: "CAN03",
+  /** RSV02 · demasiados intentos desde el mismo sitio; lo pone el cortafuegos. */
+  demasiadosIntentos: "RSV02",
+} as const;
+
+export type MotivoCancion = "texto" | "enlace" | "tope" | "intentos" | "averia";
+
+export type ResultadoCancion = { ok: true } | { ok: false; motivo: MotivoCancion };
+
+export async function sugerirCancion(token: string, texto: string): Promise<ResultadoCancion> {
+  try {
+    await llamarComoAnonimo(
+      (tx) => tx`select public.sugerir_cancion(${token}, ${texto})`,
+      await huellaDePeticion(),
+    );
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, motivo: motivoDe(error) };
+  }
+}
+
+/**
+ * Se mira el mensaje porque es donde `raise exception 'CAN01'` deja el código,
+ * igual que en el RSVP.
+ *
+ * LO DESCONOCIDO ES UNA AVERÍA, NO CULPA DE QUIEN ESCRIBE. Decirle «vuestro
+ * enlace no vale» a alguien cuya única falta es que la base no responde es la
+ * peor traducción posible: se queda convencido de que su invitación está rota.
+ */
+function motivoDe(error: unknown): MotivoCancion {
+  const texto = error instanceof Error ? error.message : String(error);
+
+  if (texto.includes(MOTIVOS_CANCION.textoInvalido)) return "texto";
+  if (texto.includes(MOTIVOS_CANCION.enlaceInvalido)) return "enlace";
+  if (texto.includes(MOTIVOS_CANCION.topeDelGrupo)) return "tope";
+  if (texto.includes(MOTIVOS_CANCION.demasiadosIntentos)) return "intentos";
+  return "averia";
+}

--- a/src/lib/bbdd/rsvp.ts
+++ b/src/lib/bbdd/rsvp.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { huellaDePeticion } from "@/lib/huella-peticion";
 
 import { ErrorDeLectura, leerComoAnonimo, llamarComoAnonimo } from "./cliente";
+import { sugerirCancion } from "./playlist";
 
 /**
  * EL RSVP PÚBLICO
@@ -206,13 +207,9 @@ export async function registrarConfirmacion(
  * de verdad importa: se registra el motivo y se sigue.
  */
 async function anotarCancion(token: string, texto: string): Promise<void> {
-  try {
-    await llamarComoAnonimo(
-      (tx) => tx`select public.sugerir_cancion(${token}, ${texto})`,
-      await huellaDePeticion(),
-    );
-  } catch (error) {
-    console.error("La confirmación se guardó, pero la canción no:", error);
+  const resultado = await sugerirCancion(token, texto);
+  if (!resultado.ok) {
+    console.error("La confirmación se guardó, pero la canción no:", resultado.motivo);
   }
 }
 

--- a/src/lib/invitacion-recordada.ts
+++ b/src/lib/invitacion-recordada.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+import { COOKIE_INVITACION } from "@/lib/invitacion";
+
+/**
+ * La invitación que el navegador recuerda, para las páginas y las acciones.
+ *
+ * Es la pareja de `invitacion.ts`: allí se escribe la cookie desde el
+ * middleware, aquí se lee desde el servidor. Están en dos ficheros porque el
+ * middleware no puede ni ver `next/headers`.
+ *
+ * NUNCA LANZA. Sin cookie, con la cookie vacía o con la cookie a medias, la
+ * respuesta es `null` y quien llama enseña la explicación. Que la portada
+ * entera se caiga por una cookie mal formada sería el peor cambio posible por
+ * una sección que es un extra.
+ */
+export async function invitacionRecordada(): Promise<string | null> {
+  const valor = (await cookies()).get(COOKIE_INVITACION)?.value?.trim();
+  return valor || null;
+}

--- a/src/lib/invitacion.ts
+++ b/src/lib/invitacion.ts
@@ -1,0 +1,97 @@
+import type { NextRequest, NextResponse } from "next/server";
+
+import { DIAS_RECUERDO_INVITACION, RUTA_RSVP } from "@/config/constants";
+
+/**
+ * BODA-27 · EL NAVEGADOR SE ACUERDA DE QUÉ INVITACIÓN ES
+ *
+ * La playlist de la portada deja apuntar canciones, y `sugerir_cancion()` en
+ * la base exige un token de invitación válido. Eso está bien puesto: la lista
+ * que sonará esa noche es de los ciento veinte invitados, no de quien pase por
+ * la web. Pero en la portada no hay token en la URL — el token vive en
+ * `/rsvp/<token>`, que es otra página.
+ *
+ * ASÍ QUE SE GUARDA AL ABRIR LA INVITACIÓN. Quien entra por su enlace deja una
+ * cookie con él, y a partir de ahí la portada sabe quién escribe. Quien llega a
+ * la web sin haber abierto nunca su invitación no ve el campo: ve una línea que
+ * explica que hace falta el enlace. Nada de un formulario que sólo sirve para
+ * dar un error.
+ *
+ * NO SE COMPRUEBA AQUÍ QUE EL TOKEN VALGA, y no es un descuido. Comprobarlo
+ * significaría una consulta a la base en cada navegación de toda la web,
+ * incluida la portada, para un dato que la base vuelve a comprobar cuando de
+ * verdad importa: al escribir. Un token inventado guardado en esta cookie no
+ * abre nada — `sugerir_cancion()` lo rechaza y además apunta el intento fallido
+ * en el mismo cortafuegos que protege el RSVP.
+ *
+ * ESTE FICHERO LO IMPORTA EL MIDDLEWARE, así que no puede tocar
+ * `next/headers` ni `server-only`: allí no existen. Leer la cookie desde una
+ * página es lo que hace `invitacion-recordada.ts`, que es su pareja.
+ */
+
+/**
+ * `boda:` delante, como el borrador del RSVP: en un navegador con veinte
+ * pestañas abiertas, un nombre de cookie sin prefijo es un nombre que alguien
+ * más va a usar.
+ */
+export const COOKIE_INVITACION = "boda:invitacion";
+
+/**
+ * El token de un `/rsvp/<token>`, o `null` si la ruta es otra.
+ *
+ * Se exige que sea EXACTAMENTE un segmento debajo del RSVP. `/rsvp` a secas no
+ * lleva token, y cualquier cosa más profunda tampoco es una invitación: dar por
+ * bueno el primer trozo convertiría una ruta futura en un token falso que se
+ * guardaría encima del bueno.
+ */
+export function tokenDeInvitacionEnRuta(ruta: string): string | null {
+  if (!ruta.startsWith(`${RUTA_RSVP}/`)) return null;
+
+  const resto = ruta.slice(RUTA_RSVP.length + 1);
+  if (!resto || resto.includes("/")) return null;
+
+  // La ruta viene codificada; el token que espera la base es el de verdad.
+  try {
+    return decodeURIComponent(resto);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Anota la invitación en la respuesta si la petición era la de un enlace.
+ *
+ * Devuelve la misma respuesta para poder encadenarla en el `return` del
+ * middleware, que es donde se sabe cuál es la definitiva.
+ */
+export function recordarInvitacion(
+  peticion: NextRequest,
+  respuesta: NextResponse,
+): NextResponse {
+  const token = tokenDeInvitacionEnRuta(peticion.nextUrl.pathname);
+  if (!token) return respuesta;
+
+  respuesta.cookies.set(COOKIE_INVITACION, token, {
+    // El navegador no necesita leerlo: sólo se usa en el servidor.
+    httpOnly: true,
+    sameSite: "lax",
+    /*
+      `Secure` según el protocolo real y no según `NODE_ENV`, por la misma
+      razón que el borrador del RSVP: una compilación de producción servida por
+      `http` —los tests E2E— marcaba la cookie como segura y Safari la tiraba
+      sin decir nada.
+
+      Se mira primero la cabecera que pone el proxy: detrás de Vercel, la
+      petición que llega al middleware ya no conserva el `https` con el que
+      entró.
+    */
+    secure: (peticion.headers.get("x-forwarded-proto") ?? peticion.nextUrl.protocol).startsWith(
+      "https",
+    ),
+    // Toda la web, no sólo el RSVP: quien la va a leer es la portada.
+    path: "/",
+    maxAge: DIAS_RECUERDO_INVITACION * 24 * 60 * 60,
+  });
+
+  return respuesta;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 import { PARAMETRO_VOLVER, RUTA_ACCESO, RUTA_PANEL } from "@/config/constants";
+import { recordarInvitacion } from "@/lib/invitacion";
 
 /**
  * BODA-41 · LA PUERTA, ANTES DE PINTAR NADA
@@ -25,6 +26,11 @@ import { PARAMETRO_VOLVER, RUTA_ACCESO, RUTA_PANEL } from "@/config/constants";
  * `perfiles`. Repetirlo aquí costaría una consulta más en cada navegación y,
  * peor, abriría un bucle: quien tuviera sesión y el perfil desactivado iría de
  * la puerta al panel y del panel a la puerta sin parar.
+ *
+ * Y DE PASO ANOTA LA INVITACIÓN. Quien abre su enlace `/rsvp/<token>` deja
+ * aquí una cookie con él, y así la playlist de la portada sabe quién escribe.
+ * Se hace en el middleware porque es el único sitio que ve esa navegación y
+ * puede escribir cookies: una página no puede.
  */
 
 /** Rutas que exigen sesión. El resto de la web es pública. */
@@ -44,7 +50,9 @@ export async function middleware(peticion: NextRequest) {
   // Cerrado y no abierto: una variable que falta no puede acabar en una puerta
   // franca.
   if (!url || !clave) {
-    return esDelPanel(peticion.nextUrl.pathname) ? aLaPuerta(peticion) : respuesta;
+    return esDelPanel(peticion.nextUrl.pathname)
+      ? aLaPuerta(peticion)
+      : recordarInvitacion(peticion, respuesta);
   }
 
   const supabase = createServerClient(url, clave, {
@@ -75,7 +83,10 @@ export async function middleware(peticion: NextRequest) {
 
   if (esDelPanel(peticion.nextUrl.pathname)) sinGuardarEnCache(respuesta);
 
-  return respuesta;
+  // Al final y no antes: `setAll` puede haber sustituido la respuesta entera
+  // por otra al renovar la sesión, y la cookie tiene que ir en la que se
+  // devuelve. Anotarla en la primera era perderla justo al renovar.
+  return recordarInvitacion(peticion, respuesta);
 }
 
 /**

--- a/tests/e2e/playlist.spec.ts
+++ b/tests/e2e/playlist.spec.ts
@@ -1,0 +1,241 @@
+import { expect, test, type Browser, type BrowserContext } from "@playwright/test";
+import postgres from "postgres";
+
+import copy from "../../content/copy.es.json";
+import { RUTA_RSVP } from "../../src/config/constants";
+
+/**
+ * BODA-27 · Apuntar una canción desde la portada
+ *
+ * LO QUE DE VERDAD SE PRUEBA AQUÍ ES QUIÉN PUEDE ESCRIBIR. La playlist es la
+ * única escritura pública de la web además del RSVP, y la regla es que hace
+ * falta una invitación: la lista que sonará esa noche es de los ciento veinte
+ * invitados, no de quien pase por la web. Así que el primer test es el de
+ * quien llega sin invitación, y comprueba que **no hay campo**, no que el
+ * campo dé error.
+ *
+ * Y SE COMPRUEBA CONTRA LA BASE, no contra la pantalla. Una sección que dice
+ * «apuntada» y no escribe nada pasaría cualquier test que sólo mire el HTML —
+ * y el fallo se vería el día de la boda, cuando el DJ pida la lista.
+ *
+ * SIN JAVASCRIPT EL CAMINO FELIZ. Es una acción de servidor dentro de un
+ * `<form>`, así que tiene que funcionar igual con el JavaScript apagado: quien
+ * abre esto lo hace desde el móvil, en el pueblo donde es la boda.
+ */
+
+const cadena = process.env.DATABASE_URL;
+
+/**
+ * Cada contexto con su propio origen: `sugerir_cancion()` pasa por
+ * `exigir_cupo_rsvp()`, que cuenta intentos por IP, y toda la suite sale de
+ * `127.0.0.1`. Sin esto, los tests que prueban enlaces inválidos cierran el
+ * cupo a los demás. Es el mismo remedio que en `rsvp.spec.ts`.
+ */
+let contador = 0;
+const origenPropio = () => ({
+  // Bloque propio: `198.51.100.x` ya se lo reparten `rsvp` y el del acuse de
+  // recibo, y el cortafuegos cuenta por IP. Compartirlo funcionaría hasta el
+  // día en que uno de los tres gaste diez intentos.
+  "x-forwarded-for": `203.0.113.${((contador += 1) % 100) + 100}`,
+});
+
+async function conBase<T>(trabajo: (sql: postgres.Sql) => Promise<T>): Promise<T> {
+  const sql = postgres(cadena!, { max: 1, prepare: false, onnotice: () => {} });
+  try {
+    return await trabajo(sql);
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Un grupo nuevo por test: así ninguno depende del orden ni del seed.
+ *
+ * SE BORRA EL DE LA VEZ ANTERIOR ANTES DE CREARLO. El token es fijo —tiene que
+ * serlo para poder abrir la misma invitación— y `huella_token` es única, así
+ * que la segunda ejecución de la suite chocaba contra la primera. Un test que
+ * sólo pasa con la base recién hecha es un test que no se puede repetir, y en
+ * local la base se reutiliza.
+ *
+ * Las canciones se borran ANTES que el grupo y a propósito: la clave ajena es
+ * `on delete set null` —una sugerencia no se pierde porque su grupo
+ * desaparezca— así que borrar el grupo primero las dejaría huérfanas y
+ * visibles en la playlist de verdad, ejecución tras ejecución.
+ */
+async function crearGrupo(sufijo: string): Promise<{ token: string; grupoId: string }> {
+  const token = `desarrollo-playlist-${sufijo}-000000`;
+  const grupoId = await conBase(async (sql) => {
+    await sql`
+      delete from public.canciones_sugeridas
+       where grupo_id in (
+         select id from public.grupos_invitacion
+          where huella_token = public.huella_token(${token})
+       )
+    `;
+    await sql`
+      delete from public.grupos_invitacion where huella_token = public.huella_token(${token})
+    `;
+    const [grupo] = await sql<{ id: string }[]>`
+      insert into public.grupos_invitacion
+        (nombre, lado, invitado_a, maximo_acompanantes, huella_token)
+      values (
+        ${`(DES) Playlist ${sufijo}`}, 'ambos',
+        array['ceremonia','banquete','fiesta']::public.evento_boda[], 0,
+        public.huella_token(${token})
+      )
+      returning id
+    `;
+    return grupo.id;
+  });
+  return { token, grupoId };
+}
+
+/**
+ * Abre la invitación para que el navegador se quede con ella, que es lo que
+ * habilita el campo de la portada. No se inyecta la cookie a mano a propósito:
+ * lo que hay que probar es que **abrir el enlace** basta.
+ */
+async function conInvitacionAbierta(
+  browser: Browser,
+  token: string,
+  javaScriptEnabled = true,
+): Promise<BrowserContext> {
+  const contexto = await browser.newContext({
+    javaScriptEnabled,
+    locale: "es-ES",
+    extraHTTPHeaders: origenPropio(),
+  });
+  const pagina = await contexto.newPage();
+  await pagina.goto(`${RUTA_RSVP}/${token}`);
+  await pagina.close();
+  return contexto;
+}
+
+test.describe("La playlist colaborativa", () => {
+  test.skip(!cadena, "Hace falta DATABASE_URL: se comprueba lo que quedó escrito.");
+
+  /**
+   * CASO DE ERROR · Sin invitación no hay campo, y el token no se filtra.
+   */
+  test("quien llega sin invitación ve la explicación, no un campo roto", async ({
+    browser,
+  }) => {
+    const contexto = await browser.newContext({
+      locale: "es-ES",
+      extraHTTPHeaders: origenPropio(),
+    });
+    const pagina = await contexto.newPage();
+
+    const html = await (await pagina.request.get("/")).text();
+
+    // La sección está —si no, la comprobación no significaría nada—…
+    expect(html).toContain(copy.playlist.titulo);
+    // …y lo que hay es la explicación, no el campo.
+    expect(html).toContain(copy.playlist.sinInvitacion);
+    expect(html).not.toContain(copy.playlist.campoCancion);
+
+    await pagina.goto("/");
+    await expect(
+      pagina.locator("#playlist").getByRole("button", { name: copy.playlist.anadir }),
+    ).toHaveCount(0);
+
+    await contexto.close();
+  });
+
+  /**
+   * CAMINO FELIZ · Con la invitación abierta, y sin JavaScript.
+   */
+  test("con la invitación abierta se apunta una canción, sin JavaScript", async ({
+    browser,
+  }) => {
+    const { token, grupoId } = await crearGrupo("feliz");
+    const contexto = await conInvitacionAbierta(browser, token, false);
+    const pagina = await contexto.newPage();
+
+    // Fijo y no con la hora dentro: `crearGrupo` limpia las canciones de este
+    // grupo al empezar, así que repetir la suite no va dejando sugerencias
+    // sueltas en la playlist que sí se enseña.
+    const cancion = "(DES) Que nos sigan las luces — Sidonie";
+
+    await pagina.goto("/");
+    const seccion = pagina.locator("#playlist");
+    await seccion.getByLabel(copy.playlist.campoCancion).fill(cancion);
+    await seccion.getByRole("button", { name: copy.playlist.anadir }).click();
+
+    // Lo que ve quien la ha apuntado: su canción, ya en la lista.
+    await expect(pagina.locator("#playlist").getByText(cancion)).toBeVisible();
+
+    // Y lo que importa de verdad: que esté escrita, y atribuida a su grupo.
+    const [fila] = await conBase(
+      (sql) => sql<{ grupo_id: string }[]>`
+        select grupo_id from public.canciones_sugeridas where texto = ${cancion}
+      `,
+    );
+    expect(fila?.grupo_id, "la canción tiene que quedar guardada con su grupo").toBe(grupoId);
+
+    await contexto.close();
+  });
+
+  /**
+   * EL TOKEN NO PUEDE ESTAR EN LA PORTADA.
+   *
+   * Es la contrapartida de haberlo guardado en una cookie: si además viajara
+   * en un campo oculto, estaría en el código fuente de una página pública y en
+   * el historial del móvil. Ese token abre los datos de una familia entera.
+   */
+  test("el enlace de invitación no viaja en el HTML de la portada", async ({ browser }) => {
+    const { token } = await crearGrupo("token");
+    const contexto = await conInvitacionAbierta(browser, token);
+    const pagina = await contexto.newPage();
+
+    const html = await (await pagina.request.get("/")).text();
+
+    // El campo sí está: el navegador recuerda la invitación.
+    expect(html).toContain(copy.playlist.campoCancion);
+    // El token no, ni entero ni en un `value`.
+    expect(html, "el token no puede aparecer en la portada").not.toContain(token);
+
+    // Y la cookie que lo lleva no la puede leer el JavaScript de la página.
+    const galleta = (await contexto.cookies()).find((c) => c.name === "boda:invitacion");
+    expect(galleta?.httpOnly, "la cookie de la invitación tiene que ser httpOnly").toBe(true);
+
+    await contexto.close();
+  });
+
+  /**
+   * CASO DE ERROR · El tope de diez por grupo se cuenta en la base y se cuenta
+   * aquí. Se llenan las diez por SQL —lo que se prueba es la número once, no
+   * escribir diez veces en un formulario.
+   */
+  test("pasado el tope del grupo se explica, y no se escribe nada más", async ({ browser }) => {
+    const { token, grupoId } = await crearGrupo("tope");
+    await conBase(async (sql) => {
+      for (let i = 0; i < 10; i += 1) {
+        await sql`
+          insert into public.canciones_sugeridas (texto, grupo_id)
+          values (${`(DES) Relleno ${i} ${grupoId.slice(0, 8)}`}, ${grupoId})
+        `;
+      }
+    });
+
+    const contexto = await conInvitacionAbierta(browser, token);
+    const pagina = await contexto.newPage();
+
+    await pagina.goto("/");
+    const seccion = pagina.locator("#playlist");
+    await seccion.getByLabel(copy.playlist.campoCancion).fill("(DES) La once no cabe");
+    await seccion.getByRole("button", { name: copy.playlist.anadir }).click();
+
+    await expect(seccion.getByText(copy.playlist.errorTope)).toBeVisible();
+
+    const [cuenta] = await conBase(
+      (sql) => sql<{ total: number }[]>`
+        select count(*)::int as total
+          from public.canciones_sugeridas where grupo_id = ${grupoId}
+      `,
+    );
+    expect(cuenta.total, "el tope es del lado de la base, no sólo del mensaje").toBe(10);
+
+    await contexto.close();
+  });
+});

--- a/tests/unidad/invitacion.test.ts
+++ b/tests/unidad/invitacion.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { RUTA_RSVP } from "../../src/config/constants";
+import { tokenDeInvitacionEnRuta } from "../../src/lib/invitacion";
+
+/**
+ * DE QUÉ RUTAS SE APUNTA LA INVITACIÓN
+ *
+ * De esta función depende que la cookie del navegador guarde un token de
+ * verdad y no cualquier cosa. Equivocarse tiene dos formas, y las dos son
+ * malas:
+ *
+ *  - **Guardar de más.** Si mañana existiera `/rsvp/<token>/gracias` y se
+ *    cogiera el primer trozo, iría bien; pero si se cogiera la ruta entera se
+ *    guardaría un token inválido ENCIMA del bueno, y la playlist dejaría de
+ *    funcionarle a quien ya la tenía.
+ *  - **Guardar de menos.** Sin token no hay campo en la portada, y el invitado
+ *    ve la explicación de que le falta su enlace cuando acaba de abrirlo.
+ *
+ * Es una función pura y el middleware no se puede probar de otra manera
+ * razonable, así que se prueba aquí, que además cuesta milisegundos.
+ */
+describe("El token de invitación en la ruta", () => {
+  it("lo saca de un enlace de invitación", () => {
+    expect(tokenDeInvitacionEnRuta(`${RUTA_RSVP}/abc-123`)).toBe("abc-123");
+  });
+
+  it("lo devuelve descodificado, como lo espera la base", () => {
+    // Un token con un carácter que el navegador escapa por el camino: si se
+    // guardara tal cual, la huella no coincidiría con ninguna invitación.
+    expect(tokenDeInvitacionEnRuta(`${RUTA_RSVP}/uno%2Bdos`)).toBe("uno+dos");
+  });
+
+  it("no se inventa nada fuera del RSVP", () => {
+    expect(tokenDeInvitacionEnRuta("/")).toBeNull();
+    expect(tokenDeInvitacionEnRuta("/panel/invitados")).toBeNull();
+    expect(tokenDeInvitacionEnRuta("/rsvpalgo/abc")).toBeNull();
+  });
+
+  it("la raíz del RSVP no lleva token", () => {
+    expect(tokenDeInvitacionEnRuta(RUTA_RSVP)).toBeNull();
+    expect(tokenDeInvitacionEnRuta(`${RUTA_RSVP}/`)).toBeNull();
+  });
+
+  /**
+   * LO MÁS PROFUNDO NO ES UNA INVITACIÓN.
+   *
+   * Hoy no existe ninguna ruta así. Se fija ahora porque el día que exista,
+   * quien la añada no va a acordarse de esta cookie.
+   */
+  it("una ruta más profunda no cuenta", () => {
+    expect(tokenDeInvitacionEnRuta(`${RUTA_RSVP}/abc-123/gracias`)).toBeNull();
+  });
+
+  it("una ruta mal codificada no rompe nada", () => {
+    // `decodeURIComponent` lanza con un `%` suelto. Un middleware que lanza
+    // tumba TODAS las páginas de la web, no sólo ésta.
+    expect(tokenDeInvitacionEnRuta(`${RUTA_RSVP}/100%`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Qué cambia

El último texto que faltaba de tu entrega: el campo para apuntar una canción en la sección de playlist de la portada.

## Lo que no era obvio: de dónde sale el permiso

El campo estaba en tu HTML y los copys estaban en `copy.es.json` desde el principio. Lo que no estaba era **quién puede escribir**.

`sugerir_cancion()` exige token de invitación, y está bien que lo exija: la lista que sonará esa noche es de los ciento veinte invitados, no de quien pase por la web. Pero en la portada no hay token en la URL — vive en `/rsvp/<token>`, que es otra página.

Así que **el middleware lo anota al abrir la invitación**, en una cookie `httpOnly`, y la portada lo lee de ahí.

- **Un año, no una sesión.** La canción se apunta cuando a uno le viene a la cabeza —en el coche, oyendo la radio—, que no es el día en que confirmó. Una cookie de sesión obligaría a volver a WhatsApp a buscar el enlace justo en ese momento, y lo que pasa entonces es que no se apunta la canción.
- **Sin invitación no hay campo**, hay una línea que explica que hace falta el enlace. Un campo que sólo puede responder «vuestro enlace no vale» no se lee como una regla, se lee como que la web está rota.
- **El token no viaja en el HTML** de la portada ni en un campo oculto. Eso lo pondría en el código fuente de una página pública y en el historial del móvil, y ese token abre los datos de una familia entera. Hay un test que lo comprueba, y otro que exige que la cookie sea `httpOnly`.
- **La cookie no se valida al escribirla.** Sería una consulta a la base en cada navegación de toda la web para adelantar un «no» que la base da igualmente al escribir — y gastaría cupo del cortafuegos a quien no ha pedido nada. Un token inventado ahí no abre nada: `sugerir_cancion()` lo rechaza y apunta el intento fallido.

## De paso

El RSVP tenía su propia copia de la llamada a `sugerir_cancion()`. Ahora los códigos de error de la base viven en un solo sitio —`src/lib/bbdd/playlist.ts`— para los dos que la usan.

## Cómo probarlo en el preview

1. Abre la portada en una ventana nueva y baja a **Playlist**: no hay campo, hay una línea que dice que hace falta el enlace de invitación.
2. Abre tu enlace `/rsvp/<token>` y vuelve a la portada. Ahora sí está el campo.
3. Escribe «Que nos sigan las luces — Sidonie» y dale a **Añadir**: aparece en la lista al momento.
4. Repite hasta once veces: la número once dice que ya hay diez y no se escribe.

## Definition of Done

- [x] Funciona contra la BBDD real, sin mocks ni datos de ejemplo incrustados
- [x] Cero hardcode: los textos salen de `copy.es.json`, el tope de longitud de `constants.ts`, y las reglas de la propia función de la base
- [x] Test E2E incluido: camino feliz **sin JavaScript** y tres casos de error (sin invitación, token en el HTML, tope del grupo)
- [ ] CI verde entero — en local: 197 unitarios y 133 E2E de escritorio
- [x] Responsive en móvil, tablet y escritorio
- [x] Accesible: `<label>` de verdad, error con `role="alert"`, confirmación con `role="status"`, y funciona sólo con teclado
- [x] Pasado por las skills de diseño
- [ ] Revisado en el deploy preview — no puedo: `vercel.app` está bloqueado por la política de salida de este contenedor

### Sobre los E2E en local

Cuatro tests fallan **en este contenedor y también en `main` sin tocar nada**: los tres de recuperar contraseña y el del acuse de recibo. Dependen de salidas de red que aquí están cerradas. En CI están verdes.

## Base de datos

- [x] No la toca — `sugerir_cancion()` ya existía y ya tenía el tope de diez

## Documentación

- [x] `docs/PLAN-MAESTRO.md` actualizado en esta misma PR


---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_