### PR TITLE
feat(historia): cada hito lleva su foto, y la sección tiene test

### DIFF
--- a/docs/PLAN-MAESTRO.md
+++ b/docs/PLAN-MAESTRO.md
@@ -335,7 +335,7 @@ Secciones del enumerado `seccion_landing`:
 | ---------------------- | ----------------------------------------------------------- | ------- |
 | `portada`              | Nombres, fecha y lugar a pantalla completa                  | BODA-22 |
 | `cuenta_atras`         | Lo que falta, calculado desde la fecha de la BBDD           | BODA-23 |
-| `historia`             | Hitos de la pareja, con reveal al entrar en pantalla        | BODA-24 |
+| `historia`             | Hitos de la pareja, con foto opcional y reveal al entrar    | BODA-24 |
 | `galeria`              | Rejilla de fotos con lightbox                               | BODA-25 |
 | `programa`             | El día hora a hora                                          | BODA-22 |
 | `ubicaciones`          | Ceremonia y banquete, con mapa                              | BODA-26 |
@@ -349,6 +349,8 @@ Secciones del enumerado `seccion_landing`:
 | `reserva_la_fecha`     | **No es una sección: es una página aparte** (ver más abajo) | BODA-30 |
 
 **Por qué la landing no se cachea.** Nació con `revalidate = 3600` y se quitó tras un fallo en producción: si la base no responde justo en el despliegue —caída, pausada por inactividad del plan gratuito, o una variable de entorno que aún no está—, lo que se hornea y se sirve **durante una hora entera** es la pantalla de «estamos preparando la web», aunque la base vuelva a los diez segundos. Ahora se consulta en cada visita: ocho consultas indexadas sobre tablas de pocas filas, lanzadas a la vez, medidas en 27 ms de mediana en local. A cambio, un cambio en el panel se ve al instante y un fallo nunca se queda pegado. Ver BODA-09.
+
+**Una foto enlazada desde otra tabla se comprueba dos veces.** Los hitos de `historia` —y lo mismo valdrá para alojamientos o proveedores— apuntan a `medios` por `medio_id`. RLS protege `medios` cuando se pregunta _por_ `medios`, pero una consulta a `hitos_historia` con un `join` se lleva lo que encuentre, así que el `publicado` de la foto se exige **en la propia condición del join**. Sin eso, enlazar una imagen recién subida y dejarla para revisar la publicaría por la puerta de atrás. El `join` es `LEFT` a propósito: la historia se escribe meses antes de tener las fotos, y un hito sin imagen tiene que salir igual.
 
 **Principios de animación:** el movimiento sirve a la narrativa, no la interrumpe. Todas las duraciones y curvas son tokens. Con `prefers-reduced-motion` los reveals se convierten en fades cortos o desaparecen. Ninguna animación puede provocar layout shift (CLS objetivo < 0.1).
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { Fragment, type ReactNode } from "react";
 
 import { EnPreparacion } from "@/components/marketing/en-preparacion";
@@ -19,7 +20,7 @@ import {
   Titulo1,
   Titulo3,
 } from "@/components/ui/tipografia";
-import { ID_CONTENIDO, IDIOMA, ZONA_HORARIA } from "@/config/constants";
+import { BUCKET_MEDIOS, ID_CONTENIDO, IDIOMA, ZONA_HORARIA } from "@/config/constants";
 import { anclaDe, esAncla, vaEnElMenu, type Seccion } from "@/config/secciones";
 import {
   obtenerAlojamientos,
@@ -36,6 +37,7 @@ import {
   type ConfiguracionBoda,
   type RutaLlegada,
   type ConsejoVestimenta,
+  type HitoHistoria,
   type Medio,
 } from "@/lib/bbdd/landing";
 import { t } from "@/lib/copy";
@@ -173,7 +175,7 @@ export default async function PaginaInicio() {
       <Portada configuracion={configuracion} foto={fotosPortada[0] ?? null} urlBase={urlBase} />
     ),
     cuenta_atras: <CuentaAtrasSeccion configuracion={configuracion} />,
-    historia: historia.length > 0 ? <Historia hitos={historia} /> : undefined,
+    historia: historia.length > 0 ? <Historia hitos={historia} urlBase={urlBase} /> : undefined,
     preboda:
       preboda.length > 0 ? (
         <ListaDeHoras
@@ -624,16 +626,20 @@ function CuentaAtrasSeccion({ configuracion }: { configuracion: ConfiguracionBod
   );
 }
 
-function Historia({
-  hitos,
-}: {
-  hitos: {
-    id: string;
-    titulo: string;
-    fechaTexto: string | null;
-    descripcion: string | null;
-  }[];
-}) {
+/**
+ * BODA-24 · NUESTRA HISTORIA
+ *
+ * LA FOTO ES OPCIONAL EN CADA HITO, y no por comodidad: la historia se escribe
+ * meses antes de tener las fotos escaneadas. Un hito sin imagen deja su hueco
+ * en el color de fondo —igual que `HuecoFoto` en la portada— en vez de un icono
+ * de imagen rota, y la fila sigue leyéndose.
+ *
+ * EL HUECO SE RESERVA CON `aspect-hito` Y NO CON EL TAMAÑO DE LA FOTO. Las tres
+ * van en fila y vienen de sitios distintos —un carrete, un móvil, una captura—,
+ * así que respetar la proporción de cada una convertiría la fila en una
+ * escalera. Reservado el hueco, la imagen no empuja el texto al cargar.
+ */
+function Historia({ hitos, urlBase }: { hitos: HitoHistoria[]; urlBase: string | undefined }) {
   return (
     <Bloque
       seccion="historia"
@@ -644,6 +650,23 @@ function Historia({
       <ol className="grid gap-bloque sm:grid-cols-3">
         {hitos.map((hito) => (
           <li key={hito.id} className="animacion-subir-al-ver">
+            {hito.foto && urlBase ? (
+              <div className="relative mb-elemento aspect-hito overflow-hidden rounded-imagen bg-superficie-hundida">
+                <Image
+                  src={`${urlBase}/storage/v1/object/public/${BUCKET_MEDIOS}/${hito.foto.ruta}`}
+                  alt={hito.foto.textoAlternativo}
+                  fill
+                  // Tres columnas en escritorio, una en móvil. Sin esto el
+                  // navegador se descarga la versión de pantalla completa para
+                  // pintarla a un tercio de ancho.
+                  sizes="(min-width: 40rem) 33vw, 100vw"
+                  className="object-cover"
+                  placeholder={hito.foto.marcadorBorroso ? "blur" : "empty"}
+                  blurDataURL={hito.foto.marcadorBorroso ?? undefined}
+                />
+              </div>
+            ) : null}
+
             {hito.fechaTexto ? <Etiqueta>{hito.fechaTexto}</Etiqueta> : null}
             <Titulo3 className="mt-pila">{hito.titulo}</Titulo3>
             {hito.descripcion ? <Cuerpo className="mt-linea">{hito.descripcion}</Cuerpo> : null}

--- a/src/lib/bbdd/landing.ts
+++ b/src/lib/bbdd/landing.ts
@@ -72,6 +72,27 @@ export interface HitoHistoria {
   titulo: string;
   fechaTexto: string | null;
   descripcion: string | null;
+  /**
+   * La foto de ese momento, o `null`. Es opcional a propósito: la historia se
+   * escribe antes de tener las fotos escaneadas, y un hito sin imagen tiene que
+   * poder publicarse igual.
+   */
+  foto: FotoDeHito | null;
+}
+
+/**
+ * Lo que hace falta de un medio para pintar la foto de un hito.
+ *
+ * NO ES `Medio` ENTERO. Un hito nunca lleva vídeo —es un recuerdo, no un
+ * fondo—, así que arrastrar `tipo` y `posterRuta` obligaría a comprobar en la
+ * plantilla algo que la consulta ya descarta.
+ */
+export interface FotoDeHito {
+  ruta: string;
+  textoAlternativo: string;
+  ancho: number | null;
+  alto: number | null;
+  marcadorBorroso: string | null;
 }
 
 export interface Cancion {
@@ -250,21 +271,67 @@ export async function obtenerPreguntasFrecuentes(): Promise<PreguntaFrecuente[]>
   return filas.map((f) => ({ id: f.id, pregunta: f.pregunta, respuesta: f.respuesta }));
 }
 
+/**
+ * BODA-24 · Los hitos de «nuestra historia», con su foto.
+ *
+ * `LEFT JOIN` Y NO `JOIN`, que es la diferencia entre una sección que funciona
+ * y una que desaparece a medias: la historia se escribe meses antes de tener
+ * las fotos escaneadas, así que un hito sin `medio_id` es lo normal al
+ * principio y tiene que salir igual.
+ *
+ * SE EXIGE ADEMÁS QUE LA FOTO ESTÉ PUBLICADA. Un hito publicado puede apuntar a
+ * una foto que todavía es borrador —se sube la imagen, se enlaza y se deja para
+ * revisar—, y sin esta condición esa foto saldría en la web por la puerta de
+ * atrás: RLS protege `medios` cuando se pregunta por `medios`, pero aquí se
+ * está preguntando por `hitos_historia`, y el `join` se lleva lo que encuentre.
+ * En ese caso sale el hito con su texto y sin imagen, que es lo correcto.
+ *
+ * `where publicado` está de más —la política `hitos_historia_lectura_publica`
+ * ya lo impone para `anon`— y se escribe igual, por lo mismo que en
+ * `obtenerMedios`: quien lee esta consulta tiene que ver la intención sin ir a
+ * buscar la política.
+ */
 export async function obtenerHistoria(): Promise<HitoHistoria[]> {
   const filas = await leerComoAnonimo(
     (tx) => tx<
-      { id: string; titulo: string; fecha_texto: string | null; descripcion: string | null }[]
+      {
+        id: string;
+        titulo: string;
+        fecha_texto: string | null;
+        descripcion: string | null;
+        ruta_almacenamiento: string | null;
+        texto_alternativo: Record<string, string> | null;
+        ancho: number | null;
+        alto: number | null;
+        marcador_borroso: string | null;
+      }[]
     >`
-      select id, titulo, fecha_texto, descripcion
-      from public.hitos_historia
-      order by orden
+      select h.id, h.titulo, h.fecha_texto, h.descripcion,
+             m.ruta_almacenamiento, m.texto_alternativo,
+             m.ancho, m.alto, m.marcador_borroso
+      from public.hitos_historia as h
+      left join public.medios as m
+        on m.id = h.medio_id and m.publicado and m.tipo = 'imagen'
+      where h.publicado
+      order by h.orden
     `,
   );
+
   return filas.map((f) => ({
     id: f.id,
     titulo: f.titulo,
     fechaTexto: f.fecha_texto,
     descripcion: f.descripcion,
+    foto: f.ruta_almacenamiento
+      ? {
+          ruta: f.ruta_almacenamiento,
+          textoAlternativo:
+            f.texto_alternativo?.es ?? Object.values(f.texto_alternativo ?? {})[0] ?? "",
+          ancho: f.ancho,
+          alto: f.alto,
+          marcadorBorroso: f.marcador_borroso,
+        }
+      : null,
   }));
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -203,6 +203,7 @@
   --radius-modal: var(--radio-modal);
   --radius-etiqueta: var(--radio-etiqueta);
   --aspect-mapa: var(--proporcion-mapa);
+  --aspect-hito: var(--proporcion-hito);
   --shadow-sutil: var(--sombra-sutil);
   --shadow-tarjeta: var(--sombra-tarjeta);
   --shadow-elevada: var(--sombra-elevada);

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -208,6 +208,11 @@
    * ancha deja la finca en el centro y el pueblo fuera, que es justo la
    * referencia que hace falta para situarse. */
   --proporcion-mapa: var(--ratio-paisaje);
+
+  /* La foto de un hito de «nuestra historia». Cuadrada porque las tres van en
+   * fila y son fotos de origen distinto —un carrete, un móvil, una captura—:
+   * dejar cada una con su proporción convierte la fila en una escalera. */
+  --proporcion-hito: var(--ratio-cuadrado);
   --sombra-sutil: var(--shadow-1);
   --sombra-tarjeta: var(--shadow-2);
   --sombra-elevada: var(--shadow-3);

--- a/tests/e2e/historia.spec.ts
+++ b/tests/e2e/historia.spec.ts
@@ -1,0 +1,187 @@
+import { expect, test } from "@playwright/test";
+import postgres from "postgres";
+
+/**
+ * BODA-24 · Nuestra historia
+ *
+ * La sección ya se pintaba y ya leía de `hitos_historia`, pero no tenía test
+ * propio —así que por la regla 4 no estaba entregada— y a cada hito le faltaba
+ * su foto.
+ *
+ * LOS DATOS SE METEN POR SQL Y NO POR EL PANEL. Lo que se prueba aquí es que la
+ * LANDING obedece a la tabla: qué sale, en qué orden y qué se calla. Pasar por
+ * el panel mezclaría dos cosas y, el día que fallara, no diría cuál de las dos
+ * se ha roto.
+ *
+ * TODO LO QUE SE INSERTA SE BORRA EN UN `afterAll`, que corre también cuando el
+ * test falla. Sin eso, una prueba rota deja tres hitos de mentira publicados en
+ * la web de la boda.
+ */
+
+const CADENA = process.env.DATABASE_URL;
+
+/** Lo que lleva todo lo nuestro, para reconocerlo y para poder borrarlo. */
+const MARCA = "(DES) E2E historia";
+
+/**
+ * EL SELLO ES DE ESTA EJECUCIÓN, Y ESO NO ES COSMÉTICA.
+ *
+ * El trabajo de CI corre la suite en `escritorio` y en `movil` a la vez, y los
+ * dos apuntan a la MISMA base. Con una limpieza por `like '(DES) E2E
+ * historia%'`, el que acabase primero borraría los hitos del otro a media
+ * prueba — y el fallo saldría como «la sección no contiene el hito», que no se
+ * parece en nada a lo que habría pasado.
+ *
+ * Cada proyecto corre en su propio proceso, así que cada uno evalúa este módulo
+ * y se queda con su sello. Se siembra con él y se borra por él.
+ */
+const SELLO = Date.now();
+
+async function conBase<T>(trabajo: (sql: postgres.Sql) => Promise<T>): Promise<T> {
+  const sql = postgres(CADENA!, { max: 1, prepare: false, onnotice: () => {} });
+  try {
+    return await trabajo(sql);
+  } finally {
+    await sql.end();
+  }
+}
+
+interface Sembrado {
+  /** Hito publicado con foto publicada: tiene que salir entero. */
+  conFoto: string;
+  /** Hito publicado cuya foto sigue en borrador: sale él, no la foto. */
+  fotoEnBorrador: string;
+  /** Hito en borrador: no sale de ninguna manera. */
+  enBorrador: string;
+  /** El texto alternativo de la foto publicada. */
+  alternativoVisible: string;
+  /** El de la que no debería verse. */
+  alternativoOculto: string;
+}
+
+/**
+ * Deja en la base los tres casos que importan y devuelve cómo reconocerlos.
+ *
+ * LAS FOTOS SON FILAS SIN FICHERO DETRÁS, y da igual: lo que se comprueba es
+ * qué llega al HTML, y el HTML lleva la URL y el texto alternativo se haya
+ * subido el fichero o no. Subir uno de verdad probaría Storage, que es lo que
+ * prueba `panel-medios.spec.ts`, no esta sección.
+ */
+async function sembrar(): Promise<Sembrado> {
+  const sello = SELLO;
+
+  const datos: Sembrado = {
+    conFoto: `${MARCA} con foto ${sello}`,
+    fotoEnBorrador: `${MARCA} foto en borrador ${sello}`,
+    enBorrador: `${MARCA} en borrador ${sello}`,
+    alternativoVisible: `${MARCA} alternativo visible ${sello}`,
+    alternativoOculto: `${MARCA} alternativo oculto ${sello}`,
+  };
+
+  await conBase(async (sql) => {
+    const [visible] = await sql<{ id: string }[]>`
+      insert into public.medios
+        (ruta_almacenamiento, texto_alternativo, seccion, tipo, publicado)
+      values
+        (${`historia/e2e-visible-${sello}.jpg`},
+         ${sql.json({ es: datos.alternativoVisible })},
+         'historia', 'imagen', true)
+      returning id
+    `;
+
+    const [oculta] = await sql<{ id: string }[]>`
+      insert into public.medios
+        (ruta_almacenamiento, texto_alternativo, seccion, tipo, publicado)
+      values
+        (${`historia/e2e-oculta-${sello}.jpg`},
+         ${sql.json({ es: datos.alternativoOculto })},
+         'historia', 'imagen', false)
+      returning id
+    `;
+
+    await sql`
+      insert into public.hitos_historia (titulo, medio_id, orden, publicado)
+      values
+        (${datos.conFoto},        ${visible.id}, 900, true),
+        (${datos.fotoEnBorrador}, ${oculta.id},  901, true),
+        (${datos.enBorrador},     null,          902, false)
+    `;
+  });
+
+  return datos;
+}
+
+/** Borra SÓLO lo de esta ejecución. Ver el comentario de `SELLO`. */
+async function limpiar(): Promise<void> {
+  const mio = `${MARCA}%${SELLO}`;
+  await conBase(async (sql) => {
+    // Los hitos primero: `medio_id` es una clave ajena.
+    await sql`delete from public.hitos_historia where titulo like ${mio}`;
+    await sql`delete from public.medios where texto_alternativo->>'es' like ${mio}`;
+  });
+}
+
+test.describe("Nuestra historia", () => {
+  test.skip(
+    !CADENA,
+    "Necesita la base de datos: solo corre en el trabajo de CI que la levanta.",
+  );
+
+  test.afterAll(limpiar);
+
+  /**
+   * EL CAMINO FELIZ Y EL DE ERROR VAN JUNTOS A PROPÓSITO. Los dos preguntan por
+   * el MISMO HTML, y separarlos costaría sembrar y limpiar dos veces para
+   * mirar dos veces la misma página.
+   */
+  test("los hitos publicados salen con su foto, y los borradores no salen", async ({
+    page,
+    request,
+  }) => {
+    const datos = await sembrar();
+
+    await page.goto("/");
+
+    const seccion = page.locator("#historia");
+    await expect(seccion).toBeVisible();
+
+    // FELIZ: el hito publicado, con su título y su foto enlazada.
+    await expect(seccion.getByText(datos.conFoto)).toBeVisible();
+    await expect(
+      seccion.locator(`img[alt="${datos.alternativoVisible}"]`),
+      "la foto del hito tiene que llegar con su texto alternativo",
+    ).toHaveCount(1);
+
+    /*
+      ERROR 1: UN HITO EN BORRADOR NO EXISTE PARA LA WEB.
+
+      Se mira el HTML ENTREGADO y no lo que se ve en pantalla. Un elemento
+      escondido con CSS sigue estando en la fuente, así que `not.toBeVisible()`
+      pasaría con el borrador dentro del documento — que es exactamente la fuga
+      que hay que descartar.
+    */
+    const html = await (await request.get("/")).text();
+    expect(
+      html.includes(datos.enBorrador),
+      "un hito en borrador no puede estar en el HTML",
+    ).toBe(false);
+
+    /*
+      ERROR 2, EL SUTIL: EL HITO ESTÁ PUBLICADO PERO SU FOTO NO.
+
+      Pasa constantemente —se sube la imagen, se enlaza al hito y se deja para
+      revisar— y es el caso que el `left join` tiene que cazar por su cuenta:
+      RLS protege `medios` cuando se pregunta por `medios`, pero aquí se
+      pregunta por `hitos_historia` y el `join` se lleva lo que encuentre. Lo
+      correcto es que salga el hito con su texto y sin imagen.
+    */
+    expect(
+      html.includes(datos.fotoEnBorrador),
+      "el hito sí sale: el que está sin publicar es su foto, no él",
+    ).toBe(true);
+    expect(
+      html.includes(datos.alternativoOculto),
+      "una foto sin publicar no puede colarse por el hito que la enlaza",
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #24

Sale de la #132, donde viajaba junto al gestor de medios. **No depende de él**: `hitos_historia.medio_id` y la tabla `medios` existen desde la migración original, y el test siembra sus filas por SQL. Se separa porque la #132 está bloqueada por una avería del proyecto —#126— y esto está terminado.

## Qué faltaba

La sección ya se pintaba y ya leía de `hitos_historia`, pero no tenía test propio —así que por la regla 4 no estaba entregada— y a cada hito le faltaba su foto.

## La decisión que hay que revisar

**La foto se exige publicada en la propia condición del `join`.** RLS protege `medios` cuando se pregunta *por* `medios`, pero aquí se pregunta por `hitos_historia` y el `join` se lleva lo que encuentre. Sin esa condición, enlazar una imagen recién subida y dejarla para revisar la publicaría por la puerta de atrás. Con ella sale el hito con su texto y sin imagen, que es lo correcto.

`LEFT` y no `JOIN` a secas: la historia se escribe meses antes de tener las fotos escaneadas, así que un hito sin `medio_id` es lo normal al principio y tiene que salir igual.

El hueco lo reserva `aspect-hito` —token nuevo, cuadrado— y no el tamaño de cada foto: las tres van en fila y vienen de sitios distintos (un carrete, un móvil, una captura), así que respetar la proporción de cada una convierte la fila en una escalera. Reservado el hueco, la imagen no empuja el texto al cargar.

## Test

`historia.spec.ts` cubre los tres casos con datos sembrados por SQL:

- el hito publicado con foto publicada sale entero, con su texto alternativo;
- el hito en borrador **no está ni en el HTML** —se mira la fuente, no la pantalla, porque algo escondido con CSS sigue estando—;
- el hito publicado cuya **foto** sigue en borrador sale él pero no ella, que es lo que comprueba la condición del `join`.

El sembrado lleva un sello por ejecución: `escritorio` y `movil` corren a la vez contra la **misma** base, y una limpieza por prefijo hacía que el que acabara primero borrase los datos del otro a media prueba.

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_