### PR TITLE
test(e2e): apuntar el destino de la redirección en el rastro

### DIFF
--- a/tests/e2e/panel-gastos.spec.ts
+++ b/tests/e2e/panel-gastos.spec.ts
@@ -3,6 +3,7 @@ import postgres from "postgres";
 
 import copy from "../../content/copy.es.json";
 import { RUTA_ACCESO, RUTA_GASTOS, RUTA_PANEL } from "../../src/config/constants";
+import { laPista, seguirLaPista } from "./utiles/rastro";
 
 /**
  * BODA-61 · Partidas de gasto
@@ -76,7 +77,8 @@ async function esperarEstado(pagina: Page, esperado: string) {
       .innerText()
       .catch(() => "(no se pudo leer la pantalla)");
     throw new Error(
-      `${(fallo as Error).message}\n\nLa pantalla decía:\n${enPantalla.slice(0, 600)}`,
+      `${(fallo as Error).message}\n\nLo que hizo la pestaña:\n${laPista(pagina)}` +
+        `\n\nLa pantalla decía:\n${enPantalla.slice(0, 600)}`,
     );
   }
 }
@@ -204,6 +206,7 @@ test.describe("Los gastos del presupuesto", () => {
     const categoria = await crearCategoria("Feliz");
     const concepto = `${MARCA} Ramo de novia`;
 
+    seguirLaPista(page);
     await entrar(page);
     await page.goto(RUTA_GASTOS);
 

--- a/tests/e2e/panel-pagos.spec.ts
+++ b/tests/e2e/panel-pagos.spec.ts
@@ -3,6 +3,7 @@ import postgres from "postgres";
 
 import copy from "../../content/copy.es.json";
 import { RUTA_ACCESO, RUTA_PAGOS, RUTA_PANEL } from "../../src/config/constants";
+import { laPista, seguirLaPista } from "./utiles/rastro";
 
 /**
  * BODA-62 · Pagos y calendario de vencimientos
@@ -74,7 +75,8 @@ async function esperarEstado(pagina: Page, esperado: string) {
       .innerText()
       .catch(() => "(no se pudo leer la pantalla)");
     throw new Error(
-      `${(fallo as Error).message}\n\nLa pantalla decía:\n${enPantalla.slice(0, 600)}`,
+      `${(fallo as Error).message}\n\nLo que hizo la pestaña:\n${laPista(pagina)}` +
+        `\n\nLa pantalla decía:\n${enPantalla.slice(0, 600)}`,
     );
   }
 }
@@ -187,6 +189,7 @@ test.describe("Los pagos y sus vencimientos", () => {
     // De partida: los dos pendientes, mil euros por pagar.
     expect(await pendienteDe(montaje.categoriaId), "de partida quedan los 1.000").toBe(1000);
 
+    seguirLaPista(page);
     await entrar(page);
     await page.goto(RUTA_PAGOS);
 

--- a/tests/e2e/panel-proveedores.spec.ts
+++ b/tests/e2e/panel-proveedores.spec.ts
@@ -3,6 +3,7 @@ import postgres from "postgres";
 
 import copy from "../../content/copy.es.json";
 import { RUTA_ACCESO, RUTA_PANEL, RUTA_PROVEEDORES } from "../../src/config/constants";
+import { laPista, seguirLaPista } from "./utiles/rastro";
 
 /**
  * BODA-70 · Proveedores y sus categorías
@@ -92,47 +93,6 @@ async function primeraCategoria(pagina: Page): Promise<string> {
     .locator("option")
     .first();
   return (await opcion.textContent())?.trim() ?? "";
-}
-
-/**
- * LO QUE LE HA PASADO A ESTA PESTAÑA, PASO A PASO.
- *
- * Cuando una espera de URL se agota, la pregunta siguiente no es «qué se ve» —
- * eso ya se adjunta— sino **si llegó a haber viaje**. Una acción de servidor que
- * escribe y redirige deja un rastro muy concreto: un `POST` con su código y una
- * navegación a la URL nueva. Distinguir «el POST no salió», «salió y respondió
- * 500» y «respondió bien pero el navegador no se movió» son tres averías
- * distintas con tres arreglos distintos, y desde el registro de CI no se
- * distinguen sin esto.
- *
- * Se apunta en un `WeakMap` y no en una variable suelta porque cada test tiene
- * su propia `page` y corren en paralelo fuera de CI.
- */
-const rastro = new WeakMap<Page, string[]>();
-
-function seguirLaPista(pagina: Page): void {
-  const pasos: string[] = [];
-  rastro.set(pagina, pasos);
-
-  pagina.on("framenavigated", (marco) => {
-    if (marco === pagina.mainFrame()) pasos.push(`navega a ${marco.url()}`);
-  });
-  pagina.on("response", (respuesta) => {
-    if (respuesta.request().method() === "POST") {
-      pasos.push(`POST ${respuesta.status()} → ${respuesta.url()}`);
-    }
-  });
-  pagina.on("pageerror", (fallo) => pasos.push(`error de página: ${fallo.message}`));
-  pagina.on("console", (mensaje) => {
-    if (mensaje.type() === "error") pasos.push(`consola: ${mensaje.text()}`);
-  });
-}
-
-/** El rastro en texto, para pegarlo en el mensaje de un fallo. */
-function laPista(pagina: Page): string {
-  const pasos = rastro.get(pagina);
-  if (!pasos?.length) return "(no se apuntó ningún paso)";
-  return pasos.slice(-25).join("\n");
 }
 
 /**

--- a/tests/e2e/utiles/rastro.ts
+++ b/tests/e2e/utiles/rastro.ts
@@ -1,0 +1,97 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * EL RASTRO DE UNA PESTAÑA: QUÉ SALIÓ, QUÉ VOLVIÓ Y A DÓNDE DECÍA IR
+ *
+ * Vivía copiado dentro de `panel-proveedores.spec.ts`. Se saca aquí porque el
+ * fallo que persigue —#126— aparece en cuatro specs distintos, y una copia por
+ * spec es cuatro sitios donde arreglar lo mismo.
+ *
+ *
+ * LO QUE APORTA RESPECTO A LA VERSIÓN QUE HABÍA: EL DESTINO DE LA REDIRECCIÓN
+ *
+ * La versión original apuntaba método, código y URL de la petición. Con eso,
+ * un fallo de #126 se lee así:
+ *
+ *     POST 303 → http://localhost:3000/panel/proveedores
+ *
+ * …y se queda a medias, porque **`respuesta.url()` es a dónde se ENVIÓ el
+ * POST, no a dónde decía la respuesta que fuera**. El dato que hace falta para
+ * cerrar #126 es el otro: el `Location` de ese `303`. Distingue dos averías que
+ * hoy se ven idénticas —
+ *
+ *   · apunta a la URL con `?estado=` y el navegador no la sigue
+ *     → el problema está en el router de cliente;
+ *   · apunta a la misma URL sin query
+ *     → el problema está en el servidor.
+ *
+ * Se estuvo dando por hecho que ese dato sólo salía abriendo la traza de
+ * Playwright del artefacto de CI, que desde el contenedor de trabajo no se
+ * puede descargar. No es cierto: la respuesta pasa por aquí y sus cabeceras
+ * están a mano. El diagnóstico cabe en el registro del propio CI.
+ *
+ * Se apuntan las dos cabeceras que puede usar Next para redirigir: `location`
+ * —camino sin JavaScript— y `x-action-redirect` —camino de acción de servidor,
+ * donde la redirección viaja aparte del `Location`—. Medido: por el camino
+ * nativo llega `location`; por el de cliente, no.
+ *
+ *
+ * SE APUNTA EL POST AL SALIR Y AL VOLVER. Escuchando sólo la respuesta, una
+ * petición que se queda a medias no deja ni una línea, y ese silencio se
+ * confunde con «no se envió nada» — que es justo la distinción que hace falta.
+ *
+ * OJO AL LEERLO: un `ERR_ABORTED` sobre el POST **no es el fallo**. Aparece
+ * igual en ejecuciones que pasan; es cómo el navegador reporta la petición
+ * original una vez seguida la redirección. Lo mismo con los `_rsc` abortados,
+ * que son prefetch cancelados de rutina. Comprobado reproduciéndolo.
+ *
+ * Se guarda en un `WeakMap` y no en una variable suelta porque cada test tiene
+ * su propia `page` y fuera de CI corren en paralelo.
+ */
+const rastro = new WeakMap<Page, string[]>();
+
+export function seguirLaPista(pagina: Page): void {
+  const pasos: string[] = [];
+  rastro.set(pagina, pasos);
+
+  pagina.on("framenavigated", (marco) => {
+    if (marco === pagina.mainFrame()) pasos.push(`navega a ${marco.url()}`);
+  });
+
+  pagina.on("request", (peticion) => {
+    if (peticion.method() !== "POST") return;
+    // `next-action` sólo viaja por el camino de cliente. Su ausencia dice que
+    // el formulario se envió de forma nativa, sin que React lo interceptase.
+    const accion = peticion.headers()["next-action"];
+    pasos.push(`POST sale → ${peticion.url()} ${accion ? "(cliente)" : "(nativo)"}`);
+  });
+
+  pagina.on("response", (respuesta) => {
+    if (respuesta.request().method() !== "POST") return;
+
+    const cabeceras = respuesta.headers();
+    const destino = cabeceras["location"] ?? cabeceras["x-action-redirect"];
+    pasos.push(
+      `POST vuelve ${respuesta.status()} · destino=${destino ?? "(ninguno en cabeceras)"}`,
+    );
+  });
+
+  pagina.on("requestfailed", (peticion) => {
+    pasos.push(
+      `${peticion.method()} cortada (${peticion.failure()?.errorText ?? "sin motivo"}) → ${peticion.url()}`,
+    );
+  });
+
+  pagina.on("pageerror", (fallo) => pasos.push(`error de página: ${fallo.message}`));
+
+  pagina.on("console", (mensaje) => {
+    if (mensaje.type() === "error") pasos.push(`consola: ${mensaje.text()}`);
+  });
+}
+
+/** El rastro en texto, para pegarlo en el mensaje de un fallo. */
+export function laPista(pagina: Page): string {
+  const pasos = rastro.get(pagina);
+  if (!pasos?.length) return "(no se apuntó nada: ¿falta `seguirLaPista`?)";
+  return pasos.slice(-30).join("\n");
+}

--- a/tests/e2e/utiles/rastro.ts
+++ b/tests/e2e/utiles/rastro.ts
@@ -32,18 +32,39 @@ import type { Page } from "@playwright/test";
  *
  * Se apuntan las dos cabeceras que puede usar Next para redirigir: `location`
  * —camino sin JavaScript— y `x-action-redirect` —camino de acción de servidor,
- * donde la redirección viaja aparte del `Location`—. Medido: por el camino
- * nativo llega `location`; por el de cliente, no.
+ * donde la redirección viaja aparte del `Location`—. Medido contra la propia
+ * aplicación compilada en producción: por el camino de cliente llega
+ * `x-action-redirect: /ruta?estado=algo;push` y `location` viene vacío.
+ *
+ *
+ * Y LO QUE PIDE EL ENRUTADOR DESPUÉS, que es la otra mitad de la respuesta.
+ * Sabiendo el destino, quedan cuatro lecturas y cada una señala a un sitio
+ * distinto:
+ *
+ *   · sin destino               → el servidor no llegó a redirigir;
+ *   · destino y ni una petición → el enrutador lo recibió y no hizo nada;
+ *   · destino y petición rota   → se cayó yendo a por la página nueva;
+ *   · destino, petición correcta y ninguna navegación
+ *                               → tenía la página nueva y no la aplicó.
+ *
+ * Sin esto, las cuatro se ven igual: «POST 303 y ahí se acaba».
  *
  *
  * SE APUNTA EL POST AL SALIR Y AL VOLVER. Escuchando sólo la respuesta, una
  * petición que se queda a medias no deja ni una línea, y ese silencio se
  * confunde con «no se envió nada» — que es justo la distinción que hace falta.
  *
- * OJO AL LEERLO: un `ERR_ABORTED` sobre el POST **no es el fallo**. Aparece
- * igual en ejecuciones que pasan; es cómo el navegador reporta la petición
- * original una vez seguida la redirección. Lo mismo con los `_rsc` abortados,
- * que son prefetch cancelados de rutina. Comprobado reproduciéndolo.
+ * OJO AL LEERLO: un `ERR_ABORTED` sobre el POST **no es el fallo**. Sale igual
+ * en ejecuciones que pasan —medido: reproduciendo la misma pantalla contra la
+ * aplicación compilada, el POST aparece cortado y la navegación se hace
+ * después—; es cómo el navegador reporta la petición original cuando el
+ * enrutador se lleva la respuesta por su cuenta. Lo mismo con los `_rsc`
+ * abortados, que son prefetch cancelados de rutina.
+ *
+ * SÓLO SE APUNTAN LAS PETICIONES ROTAS QUE VIENEN DESPUÉS DE LA ACCIÓN. Antes
+ * hay decenas de prefetch cancelados —una pantalla con dieciséis secciones dejó
+ * once seguidos— y con el rastro recortado a las últimas líneas, ese ruido
+ * empuja fuera justo lo que hay que leer. Las del POST se apuntan siempre.
  *
  * Se guarda en un `WeakMap` y no en una variable suelta porque cada test tiene
  * su propia `page` y fuera de CI corren en paralelo.
@@ -53,6 +74,11 @@ const rastro = new WeakMap<Page, string[]>();
 export function seguirLaPista(pagina: Page): void {
   const pasos: string[] = [];
   rastro.set(pagina, pasos);
+
+  // Antes de la primera acción, los `_rsc` son prefetch de rutina y son
+  // decenas; después, son el enrutador yendo a por la página nueva. Sólo
+  // interesan los segundos.
+  let huboPost = false;
 
   pagina.on("framenavigated", (marco) => {
     if (marco === pagina.mainFrame()) pasos.push(`navega a ${marco.url()}`);
@@ -67,16 +93,27 @@ export function seguirLaPista(pagina: Page): void {
   });
 
   pagina.on("response", (respuesta) => {
-    if (respuesta.request().method() !== "POST") return;
+    const peticion = respuesta.request();
 
-    const cabeceras = respuesta.headers();
-    const destino = cabeceras["location"] ?? cabeceras["x-action-redirect"];
-    pasos.push(
-      `POST vuelve ${respuesta.status()} · destino=${destino ?? "(ninguno en cabeceras)"}`,
-    );
+    if (peticion.method() === "POST") {
+      huboPost = true;
+      const cabeceras = respuesta.headers();
+      const destino = cabeceras["location"] ?? cabeceras["x-action-redirect"];
+      pasos.push(
+        `POST vuelve ${respuesta.status()} · destino=${destino ?? "(ninguno en cabeceras)"}`,
+      );
+      return;
+    }
+
+    // Lo que el enrutador pide DESPUÉS de la acción: ahí se ve si llegó a
+    // intentar la navegación. Ver el porqué en la cabecera del fichero.
+    if (huboPost && peticion.url().includes("_rsc=")) {
+      pasos.push(`el enrutador pide ${respuesta.status()} ← ${peticion.url()}`);
+    }
   });
 
   pagina.on("requestfailed", (peticion) => {
+    if (!huboPost && peticion.method() !== "POST") return;
     pasos.push(
       `${peticion.method()} cortada (${peticion.failure()?.errorText ?? "sin motivo"}) → ${peticion.url()}`,
     );


### PR DESCRIPTION
## Qué pasa

#126 se lleva persiguiendo varias sesiones y el rastro que había se queda a medias. Cuando falla, el registro de CI dice:

```
POST 303 → http://localhost:3000/panel/proveedores
```

Y eso no contesta la pregunta, porque **`respuesta.url()` es a dónde se ENVIÓ el POST, no a dónde decía la respuesta que fuera**. El dato que falta es el `Location` de ese `303`.

Se venía dando por hecho que ese dato sólo salía abriendo la traza de Playwright del artefacto de CI, que desde el contenedor de trabajo no se puede descargar. **No es cierto**: la respuesta pasa por el propio test, y `response.headers()` está a mano en el mismo sitio donde ya se apuntaba el estado. El diagnóstico cabe en el registro del CI, sin artefacto.

## Qué cambia

Por cada `POST` se apunta ahora:

- si llevaba la cabecera `next-action` — camino de cliente — o no — envío nativo del formulario;
- el `location` / `x-action-redirect` de la respuesta, como `destino=…`.

Con eso las dos averías que hoy se ven idénticas quedan separadas:

| Lo que se lea | Dónde está el fallo |
| --- | --- |
| `destino` apunta a la URL con `?estado=` y el navegador no acaba ahí | el router de cliente |
| `destino` apunta a la misma URL sin query | el servidor |
| `destino=(ninguno en cabeceras)` con `303` | la redirección viaja en el cuerpo del flujo RSC |

De paso, el rastro sale de `panel-proveedores.spec.ts` a `tests/e2e/utiles/rastro.ts` — #126 asoma en cuatro specs distintos y una copia por spec son cuatro sitios donde arreglar lo mismo — y se cablea también en `panel-pagos` y `panel-gastos`, donde el fallo aparece de forma intermitente.

## Lo que NO cambia

Ni una línea de `src/`. Esto es instrumentación: no arregla #126, lo hace legible. El arreglo va en su PR cuando el CI diga a dónde apuntaba el `303`.

## Notas de lectura del rastro

Queda escrito en el propio fichero, porque ya me ha despistado dos veces:

- un `ERR_ABORTED` sobre el POST **no es el fallo** — aparece igual en ejecuciones que pasan; es cómo el navegador reporta la petición original una vez seguida la redirección. Comprobado reproduciéndolo;
- los `_rsc` abortados son prefetch cancelados de rutina.

## Comprobado

`npm run verificar` en verde: typecheck, lint, stylelint, formato y 211 unitarios.

Refs #126

---
_Generated by [Claude Code](https://claude.ai/code/session_013PR38Uf6SfbgKhPy7SXQ17)_